### PR TITLE
updates conda recipe version info

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,13 +1,13 @@
 package:
   name: pymca
-  version: master
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '')[1:] }}
 
 source:
-  git_url: https://github.com/vasole/pymca.git
-  git_tag: master
+  git_url: ../
+  git_tag: master # change to branch or tag name, as needed
 
 build:
-  number: 0
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 requirements:
   build:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: ../
-  git_tag: master # change to branch or tag name, as needed
+  git_tag: #master # change to branch or tag name, as needed
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
@@ -14,8 +14,6 @@ requirements:
     - python
     - cython
     - numpy
-    - pyqt
-    #- fisx
   run:
     - python
     - numpy

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,12 +15,14 @@ requirements:
     - cython
     - numpy
     - pyqt
+    - fisx
   run:
     - python
     - numpy
     - pyqt
     - matplotlib
     - h5py
+    - fisx
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - cython
     - numpy
     - pyqt
-    - fisx
+    #- fisx
   run:
     - python
     - numpy

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+
+if sys.version.startswith('2.6') or sys.version.startswith('3.1'):
+    import unittest2 as unittest
+else:
+    import unittest
+
+suite = unittest.TestLoader().discover('PyMca5', pattern='*Test.py')
+unittest.TextTestRunner(verbosity=1).run(suite)


### PR DESCRIPTION
This is a simple change to the conda recipe, making use of templating to dynamically set the conda package version information based on git tags. If you set `git_tag: v5.0.0`, for example, you will get a conda package called `pymca-5.0.0-np19py27_0`. As of this commit, if `git_tag: master`, it would produce `pymca-5.0.0-np19py27_10`, indicating the 10th commit after the v5.0.0 tag.

I recommend leaving `git_tag: master` committed in the repo, and making temporary local modifications in the working directory when creating conda packages for any particular release.