### PR TITLE
Adds ability to fit to numpy arrays

### DIFF
--- a/PyMca5/PyMcaIO/NumpyStack.py
+++ b/PyMca5/PyMcaIO/NumpyStack.py
@@ -1,0 +1,71 @@
+#/*##########################################################################
+#
+# The PyMca X-Ray Fluorescence Toolkit
+#
+# Copyright (c) 2004-2014 European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+__author__ = "V.A. Sole - ESRF Data Analysis"
+__contact__ = "sole@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+
+import numpy
+import h5py
+try:
+    from PyMca5.PyMcaCore import DataObject
+    from PyMca5.PyMcaMisc import PhysicalMemory
+except ImportError:
+    print("HDF5Stack1D importing DataObject from local directory!")
+    import DataObject
+    import PhysicalMemory
+
+DEBUG = 0
+SOURCE_TYPE = "NumpyStack"
+
+class NumpyStack(DataObject.DataObject):
+    def __init__(self, y):
+        DataObject.DataObject.__init__(self)
+        # we need this to be 3D with shape (y,x,spectrum)
+        if y.ndim == 1:
+            y = y.reshape((1,1,-1))
+        elif y.ndim ==2:
+            y = np.expand_dims(y,0)
+        self.counter = 0
+        self.info['McaCalib'] = [0.0, 1.0, 0.0]
+        self.info["McaIndex"] = 2
+        self.info['Channel0'] = 0
+        self.info['Dim_1'] = y.shape[0]
+        self.info['Dim_2'] = y.shape[1]
+        self.info['Dim_3'] = y.shape[2]
+        self.info['SourceName'] = SOURCE_TYPE
+        self.info['SourceType'] = SOURCE_TYPE
+        self.data = y
+        self.incrProgressBar = 0 
+        self._HDF5Stack1D__dtype = numpy.ndarray
+        self.pleaseBreak =0
+
+
+
+

--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -41,6 +41,7 @@ from PyMca5.PyMcaIO import LuciaMap
 from PyMca5.PyMcaIO import AifiraMap
 from PyMca5.PyMcaIO import EDFStack
 from PyMca5.PyMcaIO import LispixMap
+from PyMca5.PyMcaIO import NumpyStack
 try:
     import h5py
     from PyMca5.PyMcaIO import HDF5Stack1D
@@ -104,9 +105,13 @@ class McaAdvancedFitBatch(object):
     def setFileList(self,filelist=None):
         self._rootname = ""
         if filelist is None:filelist = []
-        if type(filelist) == type(" "):filelist = [filelist]
-        self._filelist = filelist
-        self._rootname = self.getRootName(filelist)
+        if type(filelist[0]) is not numpy.ndarray:
+            if type(filelist) == type(" "):filelist = [filelist]
+            self._filelist = filelist
+            self._rootname = self.getRootName(filelist)
+        else:
+            self._filelist=filelist
+            self._rootname=''
 
     def getRootName(self,filelist=None):
         if filelist is None:filelist = self._filelist
@@ -165,6 +170,7 @@ class McaAdvancedFitBatch(object):
                         self.mcafit = ClassMcaTheory.McaTheory(self.__configList[i])
                         self.__currentConfig = i
             self.mcafit.enableOptimizedLinearFit()
+            
             inputfile   = self._filelist[i]
             self.__row += 1 #should be plus fileStep?
             self.onNewFile(inputfile, self._filelist)
@@ -175,7 +181,7 @@ class McaAdvancedFitBatch(object):
                 if hasattr(self.file, "info"):
                     if "SourceType" in self.file.info:
                         if self.file.info["SourceType"] in\
-                           ["EdfFileStack", "HDF5Stack1D"]:
+                           ["EdfFileStack", "HDF5Stack1D","NumpyStack"]:
                             self.__stack = True
             if self.__stack:
                 self.__processStack()
@@ -194,8 +200,17 @@ class McaAdvancedFitBatch(object):
         self.onEnd()
 
     def getFileHandle(self,inputfile):
+        
         try:
             self._HDF5 = False
+            if type(inputfile) == numpy.ndarray:
+                try:
+                    a = NumpyStack.NumpyStack(inputfile)
+                    return a
+                except Exception as e:
+#                     print e
+                    raise
+        
             if HDF5SUPPORT:
                 if h5py.is_hdf5(inputfile):
                     self._HDF5 = True
@@ -204,6 +219,7 @@ class McaAdvancedFitBatch(object):
                                                       self.selection)
                     except:
                         raise
+            
             ffile = self.__tryEdf(inputfile)
             if ffile is None:
                 ffile = self.__tryLucia(inputfile)


### PR DESCRIPTION
Hi Armando,

We have a use case which requires us to operate on a numpy array instead of a file. The data is already loaded in memory. We will use the methods in this pull request to integrate PyMca with our data parallel, big data processing pipeline Savu: https://github.com/DiamondLightSource/Savu. Creating this new data "type" seemed the best way to achieve this; I'd appreciate your thoughts!

Best wishes,
Aaron

