### PR TITLE
Use silx DataView widget

### DIFF
--- a/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetTable.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetTable.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -23,35 +23,24 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-"""The :class:`HDF5DatasetView` widget in this module aims to be used
-instead of :class:`HDF5DatasetTable` in :class:`QNexusWidget` for
-visualization of HDF5 datasets."""
-__author__ = "P. Knobel - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF Data Analysis"
+__contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import CloseEventNotifyingWidget
+from PyMca5.PyMcaGui import NumpyArrayTableWidget
 
-from silx.gui.data import DataViewerFrame
-
-
-class HDF5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
-    """QWidget displaying data as raw values in a table widget, or as a
-    curve, image or stack in a plot widget.
-
-    The plot features depend on *silx*'s availability.
-    """
+class HDF5DatasetTable(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
     def __init__(self, parent=None):
         CloseEventNotifyingWidget.CloseEventNotifyingWidget.__init__(self,
                                                                      parent)
         self.mainLayout = qt.QVBoxLayout(self)
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.mainLayout.setSpacing(0)
-        self.viewWidget = DataViewerFrame.DataViewerFrame(self)
-        self.mainLayout.addWidget(self.viewWidget)
+        self.arrayTableWidget =  NumpyArrayTableWidget.NumpyArrayTableWidget(self)
+        self.mainLayout.addWidget(self.arrayTableWidget)
 
     def setDataset(self, dataset):
-        self.viewWidget.setData(dataset)
-
-
+        self.arrayTableWidget.setArrayData(dataset)
 

--- a/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetView.py
@@ -29,18 +29,33 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import CloseEventNotifyingWidget
-from PyMca5.PyMcaGui import NumpyArrayTableWidget
 
-class HDF5DatasetTable(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
+
+try:
+    from silx.gui.widgets import DataViewerFrame
+except ImportError:
+    DataViewerFrame = None
+    from PyMca5.PyMcaGui import NumpyArrayTableWidget
+
+
+class HDF5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
     def __init__(self, parent=None):
         CloseEventNotifyingWidget.CloseEventNotifyingWidget.__init__(self,
                                                                      parent)
         self.mainLayout = qt.QVBoxLayout(self)
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.mainLayout.setSpacing(0)
-        self.arrayTableWidget =  NumpyArrayTableWidget.NumpyArrayTableWidget(self)
-        self.mainLayout.addWidget(self.arrayTableWidget)
+        if DataViewerFrame is None:
+            self.viewWidget = NumpyArrayTableWidget.NumpyArrayTableWidget(self)
+        else:
+            self.viewWidget = DataViewerFrame.DataViewerFrame(self)
+        self.mainLayout.addWidget(self.viewWidget)
 
     def setDataset(self, dataset):
-        self.arrayTableWidget.setArrayData(dataset)
+        if DataViewerFrame is None:
+            self.viewWidget.setArrayData(dataset)
+        else:
+            self.viewWidget.setData(dataset)
+
+
 

--- a/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetView.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -32,13 +32,18 @@ from PyMca5.PyMcaGui import CloseEventNotifyingWidget
 
 
 try:
-    from silx.gui.widgets import DataViewerFrame
+    from silx.gui.data import DataViewerFrame
 except ImportError:
     DataViewerFrame = None
     from PyMca5.PyMcaGui import NumpyArrayTableWidget
 
 
 class HDF5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
+    """QWidget displaying data as raw values in a table widget, or as a
+    curve, image or stack in a plot widget.
+
+    The plot features depend on *silx*'s availability.
+    """
     def __init__(self, parent=None):
         CloseEventNotifyingWidget.CloseEventNotifyingWidget.__init__(self,
                                                                      parent)

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -45,7 +45,14 @@ else:
 from . import HDF5Widget
 from . import HDF5Info
 from . import HDF5CounterTable
-from . import HDF5DatasetView
+try:
+    from . import HDF5DatasetView
+except ImportError:
+    from . import HDF5DatasetTable
+    HDF5DatasetView = None
+    print("fail")
+else:
+    print("success")
 from PyMca5.PyMcaIO import ConfigDict
 if "PyMcaDirs" in sys.modules:
     from PyMca5 import PyMcaDirs
@@ -414,7 +421,10 @@ class QNexusWidget(qt.QWidget):
             if isinstance(dataset, h5py.Dataset):
                 if len(dataset.shape):
                     #0 length datasets do not need a table
-                    widget.w = HDF5DatasetView.HDF5DatasetView(widget)
+                    if HDF5DatasetView is not None:
+                        widget.w = HDF5DatasetView.HDF5DatasetView(widget)
+                    else:
+                        widget.w = HDF5DatasetTable.HDF5DatasetTable(widget)
                     try:
                         widget.w.setDataset(dataset)
                     except:
@@ -480,7 +490,10 @@ class QNexusWidget(qt.QWidget):
         fileIndex = self.data.sourceName.index(filename)
         phynxFile  = self.data._sourceObjectList[fileIndex]
         dataset = phynxFile[name]
-        widget = HDF5DatasetView.HDF5DatasetView()
+        if HDF5DatasetView is not None:
+            widget = HDF5DatasetView.HDF5DatasetView()
+        else:
+            widget = HDF5DatasetTable.HDF5DatasetTable()
         title = os.path.basename(filename)
         title += " %s" % name
         widget.setWindowTitle(title)

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -45,7 +45,7 @@ else:
 from . import HDF5Widget
 from . import HDF5Info
 from . import HDF5CounterTable
-from . import HDF5DatasetTable
+from . import HDF5DatasetView
 from PyMca5.PyMcaIO import ConfigDict
 if "PyMcaDirs" in sys.modules:
     from PyMca5 import PyMcaDirs
@@ -414,12 +414,12 @@ class QNexusWidget(qt.QWidget):
             if isinstance(dataset, h5py.Dataset):
                 if len(dataset.shape):
                     #0 length datasets do not need a table
-                    widget.w = HDF5DatasetTable.HDF5DatasetTable(widget)
+                    widget.w = HDF5DatasetView.HDF5DatasetView(widget)
                     try:
                         widget.w.setDataset(dataset)
                     except:
                         print("Error filling table")
-                    widget.addTab(widget.w, 'TableView')
+                    widget.addTab(widget.w, 'DataView')
         widget.show()
         return widget
 
@@ -480,7 +480,7 @@ class QNexusWidget(qt.QWidget):
         fileIndex = self.data.sourceName.index(filename)
         phynxFile  = self.data._sourceObjectList[fileIndex]
         dataset = phynxFile[name]
-        widget = HDF5DatasetTable.HDF5DatasetTable()
+        widget = HDF5DatasetView.HDF5DatasetView()
         title = os.path.basename(filename)
         title += " %s" % name
         widget.setWindowTitle(title)

--- a/doc/source/PyMca5.PyMcaGui.io.hdf5.rst
+++ b/doc/source/PyMca5.PyMcaGui.io.hdf5.rst
@@ -9,10 +9,10 @@ hdf5 Package
     :undoc-members:
     :show-inheritance:
 
-:mod:`HDF5DatasetTable` Module
+:mod:`HDF5DatasetView` Module
 ------------------------------
 
-.. automodule:: PyMca5.PyMcaGui.io.hdf5.HDF5DatasetTable
+.. automodule:: PyMca5.PyMcaGui.io.hdf5.HDF5DatasetView
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
If silx is installed, use the `DataViewFrame` widget instead of `NumpyArrayTableWidget`, to show data when user clicks on "Show information" on a HDF5 dataset.

I leave the status as work in progress, because it is possible that the `DataView` module will be moved to another package than `silx.gui.widgets` before the coming release. 