### PR TITLE
Use the SvgRenderer if available 

### DIFF
--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2016 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -1351,7 +1351,7 @@ class ScanWindow(PlotWindow.PlotWindow):
             # printer was not selected
             return
         #self._printer = None
-        if PlotWindow.PlotWidget.SVG and (qt.qVersion() > "5.0.0"):
+        if PlotWindow.PlotWidget.SVG:
             svg = True
             self._svgRenderer = self.getSvgRenderer()
         else:


### PR DESCRIPTION
Closes  #54 by using the SVG rendering rather than the pixmap. 

This reintroduces  a minor curve clipping bug, when the applied zoom uses a Y range that does not cover all the data range for the given X range.   