### PR TITLE
Fixes some bugs

### DIFF
--- a/PyMca5/PyMcaIO/HDF5Stack1D.py
+++ b/PyMca5/PyMcaIO/HDF5Stack1D.py
@@ -153,11 +153,12 @@ class HDF5Stack1D(DataObject.DataObject):
                 #expect same entry names in the files
                 #Unfortunately this does not work for SOLEIL
                 for entry in entryNames:
-                    path = "/"+entry + ySelection
+                    path = "/"+entry + ySelection 
                     dirname = posixpath.dirname(path)
                     base = posixpath.basename(path)
                     try:
-                        if base in tmpHdf[dirname].keys():
+                        file_entry = tmpHdf[dirname]
+                        if base in file_entry.keys():
                             scanlist.append(entry)
                     except:
                         pass
@@ -166,21 +167,27 @@ class HDF5Stack1D(DataObject.DataObject):
                 #expect same structure in the files even if the
                 #names are different (SOLEIL ...)
                 if len(entryNames):
+
                     i = 0
                     for entry in entryNames:
                         path = "/"+entry + ySelection
                         dirname = posixpath.dirname(path)
                         base = posixpath.basename(path)
-                        if hasattr(tmpHdf[dirname], "keys"):
-                            i += 1
-                            if base in tmpHdf[dirname].keys():
-                                scanlist.append("1.%d" % i)
+                        try:
+                            file_entry = tmpHdf[dirname]
+                            if hasattr(file_entry, "keys"):
+                                i += 1
+                                if base in file_entry.keys():
+                                    scanlist.append("1.%d" % i)
+                        except KeyError:
+                            print("%s not in file, ignoring." % dirname)
+                        
                     if not len(scanlist):
                         path = "/" + ySelection
                         dirname = posixpath.dirname(path)
                         base = posixpath.basename(path)
                         try:
-                            if base in tmpHdf[dirname].keys():
+                            if base in file_entry.keys():
                                 JUST_KEYS = False
                                 scanlist.append("")
                         except:
@@ -190,6 +197,7 @@ class HDF5Stack1D(DataObject.DataObject):
                     JUST_KEYS = False
                     scanlist.append("")
         else:
+
             try:
                 number, order = [int(x) for x in scanlist[0].split(".")]
                 JUST_KEYS = True

--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -186,18 +186,22 @@ class McaAdvancedFitBatch(object):
                            ["EdfFileStack", "HDF5Stack1D"]:
                             self.__stack = True
             if self.__stack:
+                print "processing stack"
                 self.__processStack()
+                print "self.imgDir after stack",self.imgDir
                 if self._HDF5:
                     # The complete stack has been analyzed
                     break
             else:
+                print "processing onefile", self.imgDir
                 self.__processOneFile()
+
         if self.counter:
             if not self.roiFit:
                 if self.fitFiles:
                     self.listfile.write(']\n')
                     self.listfile.close()
-            if self.__ncols is not None and not self._nosave:
+            if (self.__ncols is not None) and (self._nosave is None):
                 if self.__ncols:self.saveImage()
         self.onEnd()
 
@@ -502,6 +506,7 @@ class McaAdvancedFitBatch(object):
         return outfile
 
     def __processOneMca(self,x,y,filename,key,info=None):
+        print "processing one mca"
         self._concentrationsAsAscii = ""
         if not self.roiFit:
             result = None
@@ -697,13 +702,13 @@ class McaAdvancedFitBatch(object):
 
             #IMAGES
             if self.fitImages:
-                self.imgDir = None
                 #this only works with EDF
                 if self.__ncols is not None:
                     if not self.counter:
-                        if not self._nosave:
-                            imgdir = self.os_path_join(self._outputdir,"IMAGES")
+                        if self._nosave is None:
                             
+                            imgdir = self.os_path_join(self._outputdir,"IMAGES")
+                            print "setting imdir in iff", imgdir
                             if not os.path.exists(imgdir):
                                 try:
                                     os.mkdir(imgdir)
@@ -715,6 +720,8 @@ class McaAdvancedFitBatch(object):
                                 print("%s does not seem to be a valid directory" %\
                                       imgdir)
                             self.imgDir = imgdir
+                            
+                            print "self.imgDir",self.imgDir
 
                         self.__peaks  = []
                         self.__images = {}
@@ -782,8 +789,9 @@ class McaAdvancedFitBatch(object):
                 if self.__ncols is not None:
                     self.imgDir=None
                     if not self.counter:
-                        if self._nosave is not None:
+                        if self._nosave is None:
                             imgdir = self.os_path_join(self._outputdir,"IMAGES")
+                            print "setting imgdir in else:",imgdir
                             if not os.path.exists(imgdir):
                                 try:
                                     os.mkdir(imgdir)
@@ -827,6 +835,7 @@ class McaAdvancedFitBatch(object):
         self.savedImages=[]
         if ffile is None:
             ffile = os.path.splitext(self._rootname)[0]
+            print "here", self.imgDir, ffile
             ffile = self.os_path_join(self.imgDir,ffile)
         if not self.roiFit:
             if (self.fileStep > 1) or (self.mcaStep > 1):

--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -186,14 +186,11 @@ class McaAdvancedFitBatch(object):
                            ["EdfFileStack", "HDF5Stack1D"]:
                             self.__stack = True
             if self.__stack:
-                print "processing stack"
                 self.__processStack()
-                print "self.imgDir after stack",self.imgDir
                 if self._HDF5:
                     # The complete stack has been analyzed
                     break
             else:
-                print "processing onefile", self.imgDir
                 self.__processOneFile()
 
         if self.counter:
@@ -506,7 +503,6 @@ class McaAdvancedFitBatch(object):
         return outfile
 
     def __processOneMca(self,x,y,filename,key,info=None):
-        print "processing one mca"
         self._concentrationsAsAscii = ""
         if not self.roiFit:
             result = None
@@ -708,7 +704,6 @@ class McaAdvancedFitBatch(object):
                         if self._nosave is None:
                             
                             imgdir = self.os_path_join(self._outputdir,"IMAGES")
-                            print "setting imdir in iff", imgdir
                             if not os.path.exists(imgdir):
                                 try:
                                     os.mkdir(imgdir)
@@ -721,7 +716,6 @@ class McaAdvancedFitBatch(object):
                                       imgdir)
                             self.imgDir = imgdir
                             
-                            print "self.imgDir",self.imgDir
 
                         self.__peaks  = []
                         self.__images = {}
@@ -791,7 +785,6 @@ class McaAdvancedFitBatch(object):
                     if not self.counter:
                         if self._nosave is None:
                             imgdir = self.os_path_join(self._outputdir,"IMAGES")
-                            print "setting imgdir in else:",imgdir
                             if not os.path.exists(imgdir):
                                 try:
                                     os.mkdir(imgdir)
@@ -835,7 +828,6 @@ class McaAdvancedFitBatch(object):
         self.savedImages=[]
         if ffile is None:
             ffile = os.path.splitext(self._rootname)[0]
-            print "here", self.imgDir, ffile
             ffile = self.os_path_join(self.imgDir,ffile)
         if not self.roiFit:
             if (self.fileStep > 1) or (self.mcaStep > 1):


### PR DESCRIPTION
Hi Armando,
This PR does two things:
1/ fixes a bug I introduced in the last PR.

2/ Since January, our beamlines output nexus files with multiple entries. These entries are very different, however the PyMca batch fit assumes all the entries will be the same and tries to batch over all of these entries, which fails.

I added a try-catch around this statement so it carries on. It's been tested by users and they are happy. Incidentally, now we know that the batch fit can do this, we might write something on our side to exploit it in the future.

Also, since the users who noticed this bug, also want to process their data on windows, they asked me to ask when the next windows release will be? Would it be possible to do a patch release for windows that fixes this bug?

Aaron

