### PR TITLE
Fix minor selection bug in PrintPreview

### DIFF
--- a/PyMca5/PyMcaGui/plotting/Q4PyMcaPrintPreview.py
+++ b/PyMca5/PyMcaGui/plotting/Q4PyMcaPrintPreview.py
@@ -641,6 +641,7 @@ class GraphicsResizeRectItem(qt.QGraphicsRectItem):
         self.__point0 = self.pos()
         parent = self.parentItem()
         scene  = self.scene()
+        scene.clearSelection()
         rect = parent.rect()
         self._x = rect.x()
         self._y = rect.y()


### PR DESCRIPTION
When an item is selected with a left click, and then we try to resize another element without an intermediate click, the first item is dragged while the new one is resized.
This commit make sure the selection is cleared prior to resizing an item.