### PR TITLE
[Hdf5DatasetView] plugins support

### DIFF
--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -238,6 +238,13 @@ class Plugin1DBase(object):
             The legend of the active curve (or None) is returned.
         """
         curve = self._plotWindow.getActiveCurve(just_legend=just_legend)
+
+        # silx specific: when there is only one curve, get it, even if not active
+        # (PyMca's getActiveCurve already does this)
+        if curve is None and not self._legacy:
+            if len(self.getAllCurves(just_legend=True)) == 1:
+                curve = self._plotWindow.getCurve()
+
         if self._legacy or just_legend or curve is None:
             return curve
 

--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -111,7 +111,7 @@ shifting the curves.
                     replace = False
                 self.addCurve(x, y, legend=legend + " %.2f" % (i * increment),
                                     info=info, replace=replace, replot=replot)
-     
+
     MENU_TEXT="Simple Shift Example"
     def getPlugin1DInstance(plotWindow, **kw):
         ob = Shifting(plotWindow)
@@ -124,6 +124,35 @@ try:
     from numpy import argsort, nonzero, take
 except ImportError:
     print("WARNING: numpy not present")
+try:
+    from silx.gui.plot.Plot import Plot as silxPlot
+except ImportError:
+    silxPlot = None
+
+
+def merge_info_params(info, params):
+    """Return a copy of dictionary`info` updated with the content
+    of dictionary `params`.
+
+    If keys don't overlap, this will effectively concatenate info and
+    params.
+
+    :param dict info: Dictionary of custom curve metadata
+    :param dict params: Dictionary of standard curve metadata (*xlabel,
+        ylabel, linestyle...*)"""
+    # TODO. much more keys and values to fix (see McaWindow)
+    info_params = info.copy()
+    info_params.update(params)
+
+    # xlabel and ylabel default to None in *silx*,
+    # PyMca plugins expect a string
+    if info_params.get("xlabel", None) is None:
+        info_params["xlabel"] = "X"
+    if info_params.get("ylabel", None) is None:
+        info_params["ylabel"] = "Y"
+
+    return info_params
+
 
 class Plugin1DBase(object):
     def __init__(self, plotWindow, **kw):
@@ -133,18 +162,30 @@ class Plugin1DBase(object):
         Unless one knows what (s)he is doing, only a proxy should be used.
 
         I pass the actual instance to keep all doors open.
+
+        The plot window can be a legacy PyMca plot, in which case
+        :attr:`_legacy` is set to *True*, or a :class:`PluginsToolButton`
+        acting as proxy for a *silx* PlotWindow.
         """
         self._plotWindow = weakref.proxy(plotWindow)
 
-    #Window related functions
+        self._legacy = True
+        """The plot window can be a legacy PyMca plot, in which case
+        :attr:`_legacy` is set to *True*, or a :class:`PluginsToolButton`
+        acting as proxy for a *silx* PlotWindow (*legacy=False*).
+        """
+        if silxPlot is not None:
+            # FIXME: uncomment this when PluginsToolButton is in PyMca
+            # if isinstance(plotWindow, (silxPlot, PluginsToolButton)):
+            if hasattr(plotWindow, "plot"):  # PluginsToolButton.plot -> silx plot
+                self._legacy = False
+
+    # Window related functions
     def windowTitle(self):
         name = self._plotWindow.windowTitle()
-        try:
-            name = self._plotWindow.windowTitle()
-        except:
-            name = ""
         return name
 
+    # fixme: should we support **kw?
     def addCurve(self, x, y, legend=None, info=None,
                  replace=False, replot=True, **kw):
         """
@@ -162,10 +203,21 @@ class Plugin1DBase(object):
         :type replace: boolean default False
         :param replot: Flag to indicate plot is to be immediately updated
         :type replot: boolean default True
-        :param **kw: Additional keywords recognized by the plot window
+        :param **kw: Additional keywords recognized by the plot window.
+            Beware that the keywords recognized by *silx* and *PyMca*
+            plot windows may differ.
         """
-        return self._plotWindow.addCurve(x, y, legend=legend, info=info,
-                                    replace=replace, replot=replot, **kw)
+        if self._legacy:
+            return self._plotWindow.addCurve(x, y, legend=legend, info=info,
+                                             replace=replace, replot=replot, **kw)
+        else:
+            # fill = info.get("plot_fill", False) if info is not None else False
+            # fill = kw.get("fill", fill)
+            # linewidth = kw.get("linewidth", None)
+            return self._plotWindow.addCurve(x, y, legend=legend, info=info,
+                                             replace=replace, resetzoom=replot,
+                                             # fill=fill, linewidth=linewidth,  # Fixme: are these needed?
+                                             **kw)
 
     def getActiveCurve(self, just_legend=False):
         """
@@ -179,14 +231,20 @@ class Plugin1DBase(object):
 
         Default output has the form:
             xvalues, yvalues, legend, dict
-            where dict is a dictionnary containing curve info.
+            where dict is a dictionary containing curve info.
             For the time being, only the plot labels associated to the
             curve are warranted to be present under the keys xlabel, ylabel.
 
         If just_legend is True:
             The legend of the active curve (or None) is returned.
         """
-        return self._plotWindow.getActiveCurve(just_legend=just_legend)
+        curve = self._plotWindow.getActiveCurve(just_legend=just_legend)
+        if self._legacy or just_legend or curve is None:
+            return curve
+
+        # silx PlotWindow
+        x, y, legend, info, params = curve
+        return x, y, legend, merge_info_params(info, params)
 
     def getAllCurves(self, just_legend=False):
         """
@@ -208,7 +266,23 @@ class Plugin1DBase(object):
                 [legend0, legend1, ..., legendn]
             or just an empty list.
         """
-        return self._plotWindow.getAllCurves(just_legend=just_legend)
+        all_curves = []
+        for curve in self._plotWindow.getAllCurves(just_legend=just_legend):
+            if just_legend or self._legacy:
+                all_curves.append(curve)
+            else:
+                x, y, legend, info, params = curve
+                all_curves.append([x, y, legend, merge_info_params(info, params)])
+        return all_curves
+
+    def getCurve(self, legend):
+        curve = self._plotWindow.getCurve(legend)
+        if self._legacy or curve is None:
+            return curve
+
+        # silx PlotWindow
+        x, y, legend, info, params = curve
+        return x, y, legend, merge_info_params(info, params)
 
     def getMonotonicCurves(self):
         """
@@ -221,9 +295,8 @@ class Plugin1DBase(object):
                  [...],
                  [xvaluesn, yvaluesn, legendn, dictn]]
         """
-        allCurves = self.getAllCurves() * 1
-        for i in range(len(allCurves)):
-            curve = allCurves[i]
+        allCurves = []
+        for curve in self.getAllCurves():
             x, y, legend, info = curve[0:4]
             # Sort
             idx = argsort(x, kind='mergesort')
@@ -234,7 +307,7 @@ class Plugin1DBase(object):
             idx = nonzero((xproc[1:] > xproc[:-1]))[0]
             xproc = take(xproc, idx)
             yproc = take(yproc, idx)
-            allCurves[i][0:2] = xproc, yproc
+            allCurves.append([xproc, yproc, legend, info])
         return allCurves
 
     def getGraphXLimits(self):
@@ -301,8 +374,11 @@ class Plugin1DBase(object):
         :param replot: Flag to indicate plot is to be immediately updated
         :type replot: boolean default False
         """
-        return self._plotWindow.setGraphXLimits(xmin, xmax, replot=replot)
+        if self._legacy:
+            return self._plotWindow.setGraphXLimits(xmin, xmax, replot=replot)
+        return self._plotWindow.setGraphXLimits(xmin, xmax)
 
+    # TODO: support param axis='right'?
     def setGraphYLimits(self, ymin, ymax, replot=False):
         """
         Set the graph Y (left) limits.
@@ -314,7 +390,9 @@ class Plugin1DBase(object):
         :param replot: Flag to indicate plot is to be immediately updated
         :type replot: boolean default False
         """
-        return self._plotWindow.setGraphYLimits(ymin, ymax, replot=replot)
+        if self._legacy:
+            return self._plotWindow.setGraphYLimits(ymin, ymax, replot=replot)
+        return self._plotWindow.setGraphYLimits(ymin, ymax)
 
     def removeCurve(self, legend, replot=True):
         """
@@ -326,7 +404,9 @@ class Plugin1DBase(object):
         :param replot: Flag to indicate plot is to be immediately updated
         :type replot: boolean default True
         """
-        return self._plotWindow.removeCurve(legend, replot=replot)
+        if self._legacy:
+            self._plotWindow.removeCurve(legend, replot=replot)
+        return self._plotWindow.removeCurve(legend)
 
     def setActiveCurve(self, legend):
         """
@@ -350,16 +430,20 @@ class Plugin1DBase(object):
         :param title: The title to be associated to the X axis
         :type title: string
         """
-        return self._plotWindow.setGraphXTitle(title)
+        if self._legacy:
+            return self._plotWindow.setGraphXTitle(title)
+        return self._plotWindow.setGraphXLabel(title)
 
     def setGraphYTitle(self, title):
         """
         :param title: The title to be associated to the X axis
         :type title: string
         """
-        return self._plotWindow.setGraphYTitle(title)
+        if self._legacy:
+            return self._plotWindow.setGraphYTitle(title)
+        return self._plotWindow.setGraphYLabel(title)
 
-    #Methods to be implemented by the plugin
+    # Methods to be implemented by the plugin
     def getMethods(self, plottype=None):
         """
         :param plottype: string or None for the case the plugin only support
@@ -394,7 +478,10 @@ class Plugin1DBase(object):
         print("applyMethod not implemented")
         return
 
+
 MENU_TEXT = "Plugin1D Base"
+
+
 def getPlugin1DInstance(plotWindow, **kw):
     """
     This function will be called by the plot window instantiating and calling

--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -125,7 +125,7 @@ try:
 except ImportError:
     print("WARNING: numpy not present")
 try:
-    from silx.gui.plot.Plot import Plot as silxPlot
+    from silx.gui.plot.PlotWidget import PlotWidget as silxPlot
 except ImportError:
     silxPlot = None
 
@@ -174,9 +174,8 @@ class Plugin1DBase(object):
         :attr:`_legacy` is set to *True*, or a :class:`PluginsToolButton`
         acting as proxy for a *silx* PlotWindow (*legacy=False*).
         """
+
         if silxPlot is not None:
-            # FIXME: uncomment this when PluginsToolButton is in PyMca
-            # if isinstance(plotWindow, (silxPlot, PluginsToolButton)):
             if hasattr(plotWindow, "plot"):  # PluginsToolButton.plot -> silx plot
                 self._legacy = False
 

--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -81,7 +81,7 @@ class PluginsToolButton(qt.QToolButton, PluginLoader):
         self.setToolTip("Call/Load 1D Plugins")
 
         # fill attr pluginList and pluginInstanceDict with existing plugins
-        PluginLoader.__init__(self, parent)
+        PluginLoader.__init__(self, method='getPlugin1DInstance')
 
         # plugins expect a legacy API, not the silx Plot API
         self.plot = weakref.proxy(plot, self._ooPlotDestroyed)

--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -1,0 +1,230 @@
+#/*##########################################################################
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""This module defines a QToolButton opening a plugin menu when clicked:
+
+    - :class:`PluginsToolButton`
+
+This button takes a plot object as constructor parameter.
+The plot can be a legacy *PyMca* plot widget, or a *silx* plot widget.
+The minor API incompatibilities between the plugins and the *silx*
+plot widget are solved using a proxy class (:class:`PlotProxySilx`).
+
+This button inherits :class:`PluginLoader` to load the plugins.
+
+It also acts as a plot proxy to dynamically provide the plot methods needed
+by the plugins. This is done in its method :meth:`PluginsToolButton.__getattr__`
+which looks for needed methods in :attr:`PluginsToolButton.plot`.
+"""
+
+# TODO: we should probably support future plugins using the new silx plot API
+# (e.g. expecting 5 return values from getActiveCurve() ...)
+
+import logging
+import os
+import sys
+import traceback
+import weakref
+
+from silx.gui import qt
+
+from PyMca5.PyMcaGraph.PluginLoader import PluginLoader
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _toggleLogger():
+    """Toggle logger level for logging.DEBUG to logging.WARNING
+    and vice-versa."""
+    if _logger.getEffectiveLevel() == logging.DEBUG:
+        _logger.setLevel(logging.WARNING)
+    else:
+        _logger.setLevel(logging.DEBUG)
+
+
+class PluginsToolButton(qt.QToolButton, PluginLoader):
+    """Toolbutton providing a context menu loaded with PyMca plugins.
+    It behaves as a proxy for accessing the plot methods from the plugins.
+
+    :param plot: reference to related plot widget
+    :param parent: Parent QWidget widget
+    """
+
+    def __init__(self, plot, parent=None):
+
+        qt.QToolButton.__init__(self, parent)
+        self.setIcon(qt.QIcon(qt.QPixmap(IconDict["plugin"])))
+        self.setToolTip("Call/Load 1D Plugins")
+
+        # fill attr pluginList and pluginInstanceDict with existing plugins
+        PluginLoader.__init__(self, parent)
+
+        # plugins expect a legacy API, not the silx Plot API
+        self.plot = weakref.proxy(plot, self._ooPlotDestroyed)
+
+        self.clicked.connect(self._pluginClicked)
+
+    def _ooPlotDestroyed(self):
+        self.setEnabled(False)
+
+    def __getattr__(self, attr):
+        """Plot API for plugins: forward calls for unknown
+        methods to :attr:`plot`."""
+        try:
+            return getattr(self.plot, attr)
+        except AttributeError:
+            # blame plot class for missing attribute, not PluginsToolButton
+            raise AttributeError(
+                    self.plot.__class__.__name__ + " has no attribute " + attr)
+
+    def _pluginClicked(self):
+        actionNames = []
+        menu = qt.QMenu(self)
+        menu.addAction("Reload Plugins")
+        actionNames.append("Reload Plugins")
+        menu.addAction("Set User Plugin Directory")
+        actionNames.append("Set User Plugin Directory")
+
+        if _logger.getEffectiveLevel() == logging.DEBUG:
+            text = "Toggle DEBUG mode OFF"
+        else:
+            text = "Toggle DEBUG mode ON"
+
+        menu.addAction(text)
+        menu.addSeparator()
+        actionNames.append(text)
+        callableKeys = ["Dummy0", "Dummy1", "Dummy2"]
+        pluginInstances = self.pluginInstanceDict
+        for pluginName in self.pluginList:
+            if pluginName in ["PyMcaPlugins.Plugin1DBase", "Plugin1DBase"]:
+                continue
+            module = sys.modules[pluginName]
+            if hasattr(module, 'MENU_TEXT'):
+                text = module.MENU_TEXT
+            else:
+                text = os.path.basename(module.__file__)
+                if text.endswith('.pyc'):
+                    text = text[:-4]
+                elif text.endswith('.py'):
+                    text = text[:-3]
+
+            methods = pluginInstances[pluginName].getMethods(
+                    plottype=self.plot._plotType)
+            if not len(methods):
+                continue
+            elif len(methods) == 1:
+                pixmap = pluginInstances[pluginName].getMethodPixmap(methods[0])
+                tip = pluginInstances[pluginName].getMethodToolTip(methods[0])
+                if pixmap is not None:
+                    action = qt.QAction(qt.QIcon(qt.QPixmap(pixmap)), text, self)
+                else:
+                    action = qt.QAction(text, self)
+                if tip is not None:
+                    action.setToolTip(tip)
+                menu.addAction(action)
+            else:
+                menu.addAction(text)
+            actionNames.append(text)
+            callableKeys.append(pluginName)
+        menu.hovered.connect(self._actionHovered)
+        a = menu.exec_(qt.QCursor.pos())
+        if a is None:
+            return None
+
+        idx = actionNames.index(a.text())
+        if a.text() == "Reload Plugins":
+            n, message = self.getPlugins(exceptions=True)
+            if n < 1:
+                msg = qt.QMessageBox(self)
+                msg.setIcon(qt.QMessageBox.Information)
+                msg.setWindowTitle("No plugins")
+                msg.setInformativeText(" Problem loading plugins ")
+                msg.setDetailedText(message)
+                msg.exec_()
+            return
+        if a.text() == "Set User Plugin Directory":
+            dirName = qt.QFileDialog.getExistingDirectory(
+                    self,
+                    "Enter user plugins directory",
+                    os.getcwd())
+            if len(dirName):
+                pluginsDir = self.getPluginDirectoryList()
+                pluginsDirList = [pluginsDir[0], dirName]
+                self.pluginsToolButton.setPluginDirectoryList(pluginsDirList)
+            return
+        if "Toggle DEBUG mode" in a.text():
+            _toggleLogger()
+        key = callableKeys[idx]
+
+        methods = pluginInstances[key].getMethods(
+                plottype=self.plot._plotType)
+        if len(methods) == 1:
+            idx = 0
+        else:
+            actionNames = []
+            # allow the plugin designer to specify the order
+            #methods.sort()
+            menu = qt.QMenu(self)
+            for method in methods:
+                text = method
+                pixmap = pluginInstances[key].getMethodPixmap(method)
+                tip = pluginInstances[key].getMethodToolTip(method)
+                if pixmap is not None:
+                    action = qt.QAction(qt.QIcon(qt.QPixmap(pixmap)), text, self)
+                else:
+                    action = qt.QAction(text, self)
+                if tip is not None:
+                    action.setToolTip(tip)
+                menu.addAction(action)
+                actionNames.append((text, pixmap, tip, action))
+            #qt.QObject.connect(menu, qt.SIGNAL("hovered(QAction *)"), self._actionHovered)
+            menu.hovered.connect(self._actionHovered)
+            a = menu.exec_(qt.QCursor.pos())
+            if a is None:
+                return None
+            idx = -1
+            for action in actionNames:
+                if a.text() == action[0]:
+                    idx = actionNames.index(action)
+        try:
+            pluginInstances[key].applyMethod(methods[idx])
+        except:
+            msg = qt.QMessageBox(self)
+            msg.setIcon(qt.QMessageBox.Critical)
+            msg.setWindowTitle("Plugin error")
+            msg.setText("An error has occured while executing the plugin:")
+            msg.setInformativeText(str(sys.exc_info()[1]))
+            msg.setDetailedText(traceback.format_exc())
+            msg.exec_()
+
+    def _actionHovered(self, action):
+        # from PyMca5 PlotWindow
+        tip = action.toolTip()
+        if str(tip) != str(action.text()):
+            qt.QToolTip.showText(qt.QCursor.pos(), tip)
+        else:
+            qt.QToolTip.hideText()

--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -174,7 +174,7 @@ class PluginsToolButton(qt.QToolButton, PluginLoader):
             if len(dirName):
                 pluginsDir = self.getPluginDirectoryList()
                 pluginsDirList = [pluginsDir[0], dirName]
-                self.pluginsToolButton.setPluginDirectoryList(pluginsDirList)
+                self.setPluginDirectoryList(pluginsDirList)
             return
         if "Toggle DEBUG mode" in a.text():
             _toggleLogger()

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
@@ -25,21 +25,74 @@
 #############################################################################*/
 """The :class:`HDF5DatasetView` widget in this module aims to be used
 instead of :class:`HDF5DatasetTable` in :class:`QNexusWidget` for
-visualization of HDF5 datasets."""
+visualization of HDF5 datasets.
+
+It uses the silx :class:`DataViewerFrame` widget with views modified
+to handle plugins."""
 __author__ = "P. Knobel - ESRF Data Analysis"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+
+
+import os
+
+import PyMca5
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import CloseEventNotifyingWidget
 
+from PyMca5.PyMcaGui.PluginsToolButton import PluginsToolButton
+
 from silx.gui.data import DataViewerFrame
+from silx.gui.data import DataViews
+from silx.gui.plot import Plot1D
+
+
+PLUGINS_DIR = []
+if os.path.exists(os.path.join(os.path.dirname(PyMca5.__file__), "PyMcaPlugins")):
+    from PyMca5 import PyMcaPlugins
+    PLUGINS_DIR = os.path.dirname(PyMcaPlugins.__file__)
+else:
+    directory = os.path.dirname(__file__)
+    while True:
+        if os.path.exists(os.path.join(directory, "PyMcaPlugins")):
+            PLUGINS_DIR.append(os.path.join(directory, "PyMcaPlugins"))
+            break
+        directory = os.path.dirname(directory)
+        if len(directory) < 5:
+            break
+
+userPluginsDirectory = PyMca5.getDefaultUserPluginsDirectory()
+if userPluginsDirectory is not None:
+    PLUGINS_DIR.append(userPluginsDirectory)
+
+
+class Plot1DWithPlugins(Plot1D):
+    def __init__(self, parent=None):
+        Plot1D.__init__(self, parent)
+
+        self._toolbar = qt.QToolBar(self)
+        self.addToolBar(self._toolbar)
+        pluginsToolButton = PluginsToolButton(plot=self)
+
+        if PLUGINS_DIR:
+            pluginsToolButton.getPlugins(
+                    method="getPlugin1DInstance",
+                    directoryList=PLUGINS_DIR)
+        self._toolbar.addWidget(pluginsToolButton)
+
+
+class Plot1DViewWithPlugins(DataViews._Plot1dView):
+    def createWidget(self, parent):
+        return Plot1DViewWithPlugins(parent=parent)
 
 
 class DataViewerFrameWithPlugins(DataViewerFrame.DataViewerFrame):
     def __init__(self, parent=None):
         DataViewerFrame.DataViewerFrame.__init__(self, parent)
-        # self.removeView()
-        # self.addView()
+
+        # Replace Plot1D with a modified Plot1D with plugin support
+        self.removeView(DataViews._Plot1dView)
+        self.addView(Plot1DViewWithPlugins)
 
 
 class Hdf5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
@@ -42,7 +42,8 @@ from PyMca5.PyMcaGui import CloseEventNotifyingWidget
 
 from PyMca5.PyMcaGui.PluginsToolButton import PluginsToolButton
 
-from silx.gui.data import DataViewerFrame
+from silx.gui.data.DataViewer import DataViewer
+from silx.gui.data.DataViewerSelector import DataViewerSelector
 from silx.gui.data import DataViews
 from silx.gui.plot import Plot1D
 
@@ -50,7 +51,7 @@ from silx.gui.plot import Plot1D
 PLUGINS_DIR = []
 if os.path.exists(os.path.join(os.path.dirname(PyMca5.__file__), "PyMcaPlugins")):
     from PyMca5 import PyMcaPlugins
-    PLUGINS_DIR = os.path.dirname(PyMcaPlugins.__file__)
+    PLUGINS_DIR.append(os.path.dirname(PyMcaPlugins.__file__))
 else:
     directory = os.path.dirname(__file__)
     while True:
@@ -83,16 +84,98 @@ class Plot1DWithPlugins(Plot1D):
 
 class Plot1DViewWithPlugins(DataViews._Plot1dView):
     def createWidget(self, parent):
-        return Plot1DViewWithPlugins(parent=parent)
+        return Plot1DWithPlugins(parent=parent)
 
 
-class DataViewerFrameWithPlugins(DataViewerFrame.DataViewerFrame):
+class DataViewerFrameWithPlugins(qt.QWidget):
+    """
+    A silx  DataViewerFrame modified to replace
+    the silx DataViewer widget with our DataViewerWithPlugins.
+
+    See docstrings for attributes and methods on the original
+    :class:`silx.gui.data.DataViewerFrame`.
+    """
+    displayedViewChanged = qt.pyqtSignal(object)
+
+    dataChanged = qt.pyqtSignal()
+
     def __init__(self, parent=None):
-        DataViewerFrame.DataViewerFrame.__init__(self, parent)
+        super(DataViewerFrameWithPlugins, self).__init__(parent)
 
-        # Replace Plot1D with a modified Plot1D with plugin support
-        self.removeView(DataViews._Plot1dView)
-        self.addView(Plot1DViewWithPlugins)
+        class _DataViewer(DataViewer):
+            """Overwrite methods to avoid to create views while the instance
+            is not created. `initializeViews` have to be called manually."""
+
+            def _initializeViews(self):
+                pass
+
+            def initializeViews(self):
+                """Avoid to create views while the instance is not created."""
+                super(_DataViewer, self)._initializeViews()
+
+        self.__dataViewer = _DataViewer(self)
+
+        # initialize views when `self.__dataViewer` is set
+        self.__dataViewer.initializeViews()
+        # start of PyMca specific code
+        self.__dataViewer.removeView(
+            self.__dataViewer.getViewFromModeId(DataViews.PLOT1D_MODE))
+        self.__dataViewer.addView(Plot1DViewWithPlugins(self))
+        # end of PyMca specific code
+
+        self.__dataViewer.setFrameShape(qt.QFrame.StyledPanel)
+        self.__dataViewer.setFrameShadow(qt.QFrame.Sunken)
+        self.__dataViewerSelector = DataViewerSelector(self, self.__dataViewer)
+        self.__dataViewerSelector.setFlat(True)
+
+        layout = qt.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.__dataViewer, 1)
+        layout.addWidget(self.__dataViewerSelector)
+        self.setLayout(layout)
+
+        self.__dataViewer.dataChanged.connect(self.__dataChanged)
+        self.__dataViewer.displayedViewChanged.connect(self.__displayedViewChanged)
+
+    def __dataChanged(self):
+        self.dataChanged.emit()
+
+    def __displayedViewChanged(self, view):
+        self.displayedViewChanged.emit(view)
+
+    def availableViews(self):
+        return self.__dataViewer.availableViews()
+
+    def currentAvailableViews(self):
+        return self.__dataViewer.currentAvailableViews()
+
+    def createDefaultViews(self, parent=None):
+        return self.__dataViewer.createDefaultViews(parent)
+
+    def addView(self, view):
+        return self.__dataViewer.addView(view)
+
+    def removeView(self, view):
+        return self.__dataViewer.removeView(view)
+
+    def setData(self, data):
+        self.__dataViewer.setData(data)
+
+    def data(self):
+        return self.__dataViewer.data()
+
+    def setDisplayedView(self, view):
+        self.__dataViewer.setDisplayedView(view)
+
+    def displayedView(self):
+        return self.__dataViewer.displayedView()
+
+    def displayMode(self):
+        return self.__dataViewer.displayMode()
+
+    def setDisplayMode(self, modeId):
+        return self.__dataViewer.setDisplayMode(modeId)
 
 
 class Hdf5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
@@ -107,7 +190,20 @@ class Hdf5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
         self.mainLayout = qt.QVBoxLayout(self)
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.mainLayout.setSpacing(0)
+
+        # # This should be the proper way of changing a single view without
+        # # redefining the complete DataViewer
+        # self.viewWidget = DataViewerFrame(self)
+        # # for view in self.viewWidget.availableViews():
+        # #     if isinstance(view, DataViews._Plot1dView):
+        # #         self.viewWidget.removeView(view)
+        # # alternative:
+        # self.viewWidget.removeView(
+        #     self.viewWidget.getViewFromModeId(DataViews.PLOT1D_MODE))
+        # self.viewWidget.addView(Plot1DViewWithPlugins(self))
+
         self.viewWidget = DataViewerFrameWithPlugins(self)
+
         self.mainLayout.addWidget(self.viewWidget)
 
     def setDataset(self, dataset):

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
@@ -35,7 +35,14 @@ from PyMca5.PyMcaGui import CloseEventNotifyingWidget
 from silx.gui.data import DataViewerFrame
 
 
-class HDF5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
+class DataViewerFrameWithPlugins(DataViewerFrame.DataViewerFrame):
+    def __init__(self, parent=None):
+        DataViewerFrame.DataViewerFrame.__init__(self, parent)
+        # self.removeView()
+        # self.addView()
+
+
+class Hdf5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
     """QWidget displaying data as raw values in a table widget, or as a
     curve, image or stack in a plot widget.
 
@@ -47,7 +54,7 @@ class HDF5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
         self.mainLayout = qt.QVBoxLayout(self)
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.mainLayout.setSpacing(0)
-        self.viewWidget = DataViewerFrame.DataViewerFrame(self)
+        self.viewWidget = DataViewerFrameWithPlugins(self)
         self.mainLayout.addWidget(self.viewWidget)
 
     def setDataset(self, dataset):

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
@@ -70,6 +70,7 @@ if userPluginsDirectory is not None:
 class Plot1DWithPlugins(Plot1D):
     def __init__(self, parent=None):
         Plot1D.__init__(self, parent)
+        self._plotType = "SCAN"    # needed by legacy plugins
 
         self._toolbar = qt.QToolBar(self)
         self.addToolBar(self._toolbar)

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5DatasetView.py
@@ -122,7 +122,7 @@ class Hdf5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
 
         self.mainLayout.addWidget(self.viewWidget)
 
-    def setDataset(self, dataset):
+    def setData(self, dataset):
         self.viewWidget.setData(dataset)
 
 

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5NodeView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5NodeView.py
@@ -23,9 +23,9 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-"""The :class:`HDF5DatasetView` widget in this module aims to be used
-instead of :class:`HDF5DatasetTable` in :class:`QNexusWidget` for
-visualization of HDF5 datasets.
+"""The :class:`Hdf5NodeView` widget in this module aims to replace
+:class:`HDF5DatasetTable` in :class:`QNexusWidget` for visualization of HDF5
+datasets and groups, with support of NXdata groups as plot.
 
 It uses the silx :class:`DataViewerFrame` widget with views modified
 to handle plugins."""
@@ -98,9 +98,11 @@ class DataViewerFrameWithPlugins(DataViewerFrame):
         return views
 
 
-class Hdf5DatasetView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
+class Hdf5NodeView(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
     """QWidget displaying data as raw values in a table widget, or as a
-    curve, image or stack in a plot widget.
+    curve, image or stack in a plot widget. It can also display information
+    related to HDF5 groups (attributes, compression, ...) and interpret
+    a NXdata group to plot its data.
 
     The plot features depend on *silx*'s availability.
     """

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -46,10 +46,10 @@ from . import HDF5Widget
 from . import HDF5Info
 from . import HDF5CounterTable
 try:
-    from . import HDF5DatasetView
+    from . import Hdf5DatasetView
 except ImportError:
     from . import HDF5DatasetTable
-    HDF5DatasetView = None
+    Hdf5DatasetView = None
 from PyMca5.PyMcaIO import ConfigDict
 if "PyMcaDirs" in sys.modules:
     from PyMca5 import PyMcaDirs
@@ -418,8 +418,8 @@ class QNexusWidget(qt.QWidget):
             if isinstance(dataset, h5py.Dataset):
                 if len(dataset.shape):
                     #0 length datasets do not need a table
-                    if HDF5DatasetView is not None:
-                        widget.w = HDF5DatasetView.HDF5DatasetView(widget)
+                    if Hdf5DatasetView is not None:
+                        widget.w = Hdf5DatasetView.Hdf5DatasetView(widget)
                     else:
                         widget.w = HDF5DatasetTable.HDF5DatasetTable(widget)
                     try:
@@ -487,8 +487,8 @@ class QNexusWidget(qt.QWidget):
         fileIndex = self.data.sourceName.index(filename)
         phynxFile  = self.data._sourceObjectList[fileIndex]
         dataset = phynxFile[name]
-        if HDF5DatasetView is not None:
-            widget = HDF5DatasetView.HDF5DatasetView()
+        if Hdf5DatasetView is not None:
+            widget = Hdf5DatasetView.Hdf5DatasetView()
         else:
             widget = HDF5DatasetTable.HDF5DatasetTable()
         title = os.path.basename(filename)

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -413,7 +413,7 @@ class QNexusWidget(qt.QWidget):
             widget._sourceObjectWeakReference = weakref.ref(phynxFile,
                                                  sourceObjectDestroyed)
         widget.setInfoDict(info)
-        # fixme: this first `if` block can be dropped when silx is a hard dependency
+        # todo: this first `if` block can be dropped when silx is a hard dependency
         if dset and Hdf5NodeView is None:
             dataset = phynxFile[name]
             if isinstance(dataset, h5py.Dataset):
@@ -435,56 +435,52 @@ class QNexusWidget(qt.QWidget):
         return widget
 
     def itemRightClickedSlot(self, ddict):
-        filename = ddict['file']
-        name = ddict['name']
-        if ddict['dtype'].startswith('|S'):
-            #handle a right click on a dataset of string type
-            return self.showInfoWidget(filename, name, False)
-            pass
-        elif ddict['dtype'] == '':
-            #handle a right click on a group
-            return self.showInfoWidget(filename, name, False)
-        elif 0:
-            #should I show the option menu?
-            self.showInfoWidget(filename, name, True)
-            return
+        _hdf5WidgetDatasetMenu = qt.QMenu(self)
+        self._lastItemDict = ddict
+        if ddict['dtype'].startswith('|S') or ddict['dtype'] == '':
+            # handle a right click on a group or a dataset of string type
+            _hdf5WidgetDatasetMenu.addAction(QString("Show Information"),
+                                             self._showInfoWidgetSlot)
+            _hdf5WidgetDatasetMenu.exec_(qt.QCursor.pos())
         else:
             #handle a right click on a numeric dataset
-            _hdf5WidgetDatasetMenu = qt.QMenu(self)
             _hdf5WidgetDatasetMenu.addAction(QString("Add to selection table"),
-                                        self._addToSelectionTable)
+                                             self._addToSelectionTable)
 
             if 0:
                 #these two options can be combined into one for the time being
                 _hdf5WidgetDatasetMenu.addAction(QString("Open"),
-                                            self._openDataset)
+                                                 self._openDataset)
                 _hdf5WidgetDatasetMenu.addAction(QString("Show Properties"),
-                                            self._showDatasetProperties)
+                                                 self._showDatasetProperties)
             else:
                 _hdf5WidgetDatasetMenu.addAction(QString("Show Information"),
-                                        self._showInfoWidgetSlot)
-                self._lastDatasetDict= ddict
+                                                 self._showInfoWidgetSlot)
                 _hdf5WidgetDatasetMenu.exec_(qt.QCursor.pos())
-                self._lastDatasetDict= None
-            return
+        self._lastItemDict = None
+        return
 
     def _addToSelectionTable(self, ddict=None):
         if ddict is None:
-            ddict = self._lastDatasetDict
+            ddict = self._lastItemDict
         #handle as a double click
         ddict['event'] = "itemDoubleClicked"
         self.hdf5Slot(ddict)
 
     def _showInfoWidgetSlot(self, ddict=None):
         if ddict is None:
-            ddict = self._lastDatasetDict
-        filename = ddict['file']
-        name = ddict['name']
-        return self.showInfoWidget(filename, name, True)
+            ddict = self._lastItemDict
+        is_numeric_dataset = (not ddict['dtype'].startswith('|S') and not
+                              ddict['dtype'].startswith('|U') and not
+                              ddict['dtype'].startswith('|O') and not
+                              ddict['dtype'] == '')
+        return self.showInfoWidget(ddict['file'],
+                                   ddict['name'],
+                                   dset=is_numeric_dataset)
 
     def _openDataset(self, ddict=None):
         if ddict is None:
-            ddict = self._lastDatasetDict
+            ddict = self._lastItemDict
         filename = ddict['file']
         name = ddict['name']
         self._checkWidgetDict()
@@ -525,7 +521,7 @@ class QNexusWidget(qt.QWidget):
 
     def _showDatasetProperties(self, ddict=None):
         if ddict is None:
-            ddict = self._lastDatasetDict
+            ddict = self._lastItemDict
         filename = ddict['file']
         name = ddict['name']
         return self.showInfoWidget(filename, name)

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -46,10 +46,10 @@ from . import HDF5Widget
 from . import HDF5Info
 from . import HDF5CounterTable
 try:
-    from . import Hdf5DatasetView
+    from . import Hdf5NodeView
 except ImportError:
     from . import HDF5DatasetTable
-    Hdf5DatasetView = None
+    Hdf5NodeView = None
 from PyMca5.PyMcaIO import ConfigDict
 if "PyMcaDirs" in sys.modules:
     from PyMca5 import PyMcaDirs
@@ -414,7 +414,7 @@ class QNexusWidget(qt.QWidget):
                                                  sourceObjectDestroyed)
         widget.setInfoDict(info)
         # fixme: this first `if` block can be dropped when silx is a hard dependency
-        if dset and Hdf5DatasetView is None:
+        if dset and Hdf5NodeView is None:
             dataset = phynxFile[name]
             if isinstance(dataset, h5py.Dataset):
                 if len(dataset.shape):
@@ -425,10 +425,9 @@ class QNexusWidget(qt.QWidget):
                     except:
                         print("Error filling table")
                     widget.addTab(widget.w, 'DataView')
-        elif Hdf5DatasetView is not None:
+        elif Hdf5NodeView is not None:
             data = phynxFile[name]
-            # TODO: rename Hdf5DatasetView to show it can handle groups
-            widget.w = Hdf5DatasetView.Hdf5DatasetView(widget)
+            widget.w = Hdf5NodeView.Hdf5NodeView(widget)
             widget.w.setData(data)
             widget.addTab(widget.w, 'DataView')
 
@@ -492,8 +491,8 @@ class QNexusWidget(qt.QWidget):
         fileIndex = self.data.sourceName.index(filename)
         phynxFile  = self.data._sourceObjectList[fileIndex]
         dataset = phynxFile[name]
-        if Hdf5DatasetView is not None:
-            widget = Hdf5DatasetView.Hdf5DatasetView()
+        if Hdf5NodeView is not None:
+            widget = Hdf5NodeView.Hdf5NodeView()
             widget.setData(dataset)
         else:
             widget = HDF5DatasetTable.HDF5DatasetTable()

--- a/PyMca5/PyMcaPlugins/AdvancedAlignmentScanPlugin.py
+++ b/PyMca5/PyMcaPlugins/AdvancedAlignmentScanPlugin.py
@@ -459,8 +459,7 @@ class AdvancedAlignmentScanPlugin(Plugin1DBase.Plugin1DBase):
         Returns the legends of the curves in the plot winow
         in the order they were added.
         """
-        ret = [legend for (x,y,legend,info) in self._plotWindow.getAllCurves()]
-        return ret
+        return self.getAllCurves(just_legend=True)
 
     # BEGIN Alignment Methods
     def calculateShiftsFitDerivative(self):

--- a/PyMca5/PyMcaPlugins/MedianFilterScanDeglitchPlugin.py
+++ b/PyMca5/PyMcaPlugins/MedianFilterScanDeglitchPlugin.py
@@ -160,7 +160,7 @@ class MedianFilterScanDeglitchPlugin(Plugin1DBase.Plugin1DBase):
 
     def medianThresholdFilter(self, activeOnly, threshold, length):
         if activeOnly:
-            active = self._plotWindow.getActiveCurve()
+            active = self.getActiveCurve()
             if not active:
                 return
             else:
@@ -168,7 +168,7 @@ class MedianFilterScanDeglitchPlugin(Plugin1DBase.Plugin1DBase):
                 self.removeCurve(legend)
                 spectra = [active]
         else:
-            spectra = self._plotWindow.getAllCurves()
+            spectra = self.getAllCurves()
         for (idx, spec) in enumerate(spectra):
             x, y, legend, info = spec
             filtered = medfilt1d(y, length)

--- a/PyMca5/PyMcaPlugins/XASSelfattenuationPlugin.py
+++ b/PyMca5/PyMcaPlugins/XASSelfattenuationPlugin.py
@@ -63,6 +63,7 @@ class XASSelfattenuationPlugin(Plugin1DBase.Plugin1DBase):
         self.widget = None
         self.instance = XASSelfattenuationCorrection.XASSelfattenuationCorrection()
         self.parameters = None
+        self.configuration = None
 
     #Methods to be implemented by the plugin
     def getMethods(self, plottype=None):


### PR DESCRIPTION
This PR provides:
 - a `PluginsToolButton` to load plugins and serve as interface between the silx plot widget and `Plugin1DBase` (from PR #49 with minor modifications)
 - modification to `Plugin1DBase` to support silx plot widgets via  `PluginsToolButton`(form PR #49)
 - a `DataViewerFrame` modified to provide the plugin toolbutton, used in `QNexusWidget`

It makes minor changes to the right click menu behavior in `QNexusWidget` (open a menu also for groups and string datasets).
.  