### PR TITLE
[5.3] ScanWindow based on a silx plot

### DIFF
--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -176,7 +176,12 @@ class Plugin1DBase(object):
         """
 
         if silxPlot is not None:
-            if hasattr(plotWindow, "plot"):  # PluginsToolButton.plot -> silx plot
+            if hasattr(plotWindow, "plot"):
+                # PluginsToolButton.plot -> silx plot
+                self._legacy = False
+            if isinstance(plotWindow, silxPlot):
+                # in case the plugin is used without a PluginToolButton,
+                # like in MedianFilterScanDeglitchPlugin.__main__
                 self._legacy = False
 
     # Window related functions

--- a/PyMca5/PyMcaGui/math/PCAWindow.py
+++ b/PyMca5/PyMcaGui/math/PCAWindow.py
@@ -162,7 +162,7 @@ class PCAParametersDialog(qt.QDialog):
         self.graph.sigPlotSignal.connect(self._graphSlot)
         if not self.__regions:
             #I am adding after instantiation
-            self.mainLayout.insertWidget(2,self.regionsWidget)
+            self.mainLayout.insertWidget(2, self.regionsWidget)
             self.mainLayout.addWidget(self.graph)
         self.__regions = True
 
@@ -172,17 +172,16 @@ class PCAParametersDialog(qt.QDialog):
             toValue   = ddict['to']
             self.graph.setEnabled(True)
             self.graph.clearMarkers()
-            self.graph.insertXMarker(fromValue,
-                                      'From',
-                                       text='From',
-                                       color='blue',
-                                       draggable=True)
-            self.graph.insertXMarker(toValue,
-                                     'To',
-                                      text= 'To',
-                                      color='blue',
-                                      draggable=True)
-            self.graph.replot()
+            self.graph.addXMarker(fromValue,
+                                  'From',
+                                  text='From',
+                                  color='blue',
+                                  draggable=True)
+            self.graph.addXMarker(toValue,
+                                  'To',
+                                  text='To',
+                                  color='blue',
+                                  draggable=True)
         else:
             self.graph.clearMarkers()
             self.graph.setEnabled(False)

--- a/PyMca5/PyMcaGui/math/SGWindow.py
+++ b/PyMca5/PyMcaGui/math/SGWindow.py
@@ -190,10 +190,11 @@ if __name__ == "__main__":
     import numpy
     app = qt.QApplication([])
     if 1:
-        noise = numpy.random.randn(1000.)
-        y=numpy.arange(1000.)
-        w = SGDialog(None, y+numpy.sqrt(y)* noise)
+        noise = numpy.random.randn(1000)
+        y = numpy.arange(1000.)
+        w = SGDialog(None,
+                     y + numpy.sqrt(y) * noise)
     w.show()
-    ret=w.exec_()
+    ret = w.exec_()
     if ret:
         print(w.getParameters())

--- a/PyMca5/PyMcaGui/math/SGWindow.py
+++ b/PyMca5/PyMcaGui/math/SGWindow.py
@@ -27,11 +27,10 @@ __author__ = "V.A. Sole - ESRF Data Analysis"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-import sys
+
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import MaskImageWidget
 from PyMca5.PyMcaGui import ScanWindow
 from PyMca5.PyMcaMath import SGModule
 
@@ -111,8 +110,9 @@ class SGWindow(qt.QWidget):
         self.spectrum = spectrum
         self.parametersWidget = SGParametersWidget(self, length=len(spectrum))
         self.graph = ScanWindow.ScanWindow(self)
-        self.graph.newCurve(self.xValues,
-                        spectrum, "Spectrum", replace=True)
+        self.graph.addCurve(self.xValues,
+                            spectrum, "Spectrum",
+                            replace=True)
         self.mainLayout.addWidget(self.parametersWidget)
         self.mainLayout.addWidget(self.graph)
         self.getParameters = self.parametersWidget.getParameters
@@ -129,13 +129,13 @@ class SGWindow(qt.QWidget):
                                                     degree=degree,
                                                     order=order)
         if order > 0:
-            maptoy2 = True
+            yaxis = "right"
         else:
-            maptoy2 = False
-        self.graph.newCurve(self.xValues,
-                    self.background, "Filtered Spectrum",
-                    replace=False,
-                    maptoy2=maptoy2)
+            yaxis = "left"
+        self.graph.addCurve(self.xValues,
+                            self.background, "Filtered Spectrum",
+                            replace=False,
+                            yaxis=yaxis)
 
         #Force information update
         legend = self.graph.getActiveCurve(just_legend=True)

--- a/PyMca5/PyMcaGui/math/SNIPWindow.py
+++ b/PyMca5/PyMcaGui/math/SNIPWindow.py
@@ -398,8 +398,8 @@ if __name__ == "__main__":
     import numpy
     app = qt.QApplication([])
     if 0:
-        noise = numpy.random.randn(1000.)
-        y=numpy.arange(1000.)
+        noise = numpy.random.randn(1000)
+        y = numpy.arange(1000.)
         w = SNIPDialog(None, y+numpy.sqrt(y)* noise)
     elif len(sys.argv) > 1:
         from PyMca5.PyMcaIO import EdfFile
@@ -413,6 +413,6 @@ if __name__ == "__main__":
                100 * numpy.exp(-(1./20) * ((x-64)*(x-64) + (y-128)*(y-128)))
         w = SNIPDialog(None, data)
     w.show()
-    ret=w.exec_()
+    ret = w.exec_()
     if ret:
         print(w.getParameters())

--- a/PyMca5/PyMcaGui/math/SNIPWindow.py
+++ b/PyMca5/PyMcaGui/math/SNIPWindow.py
@@ -244,8 +244,8 @@ class SNIPWindow(qt.QWidget):
                                                            length=len(spectrum),
                                                            smooth=smooth)
             self.graph = ScanWindow.ScanWindow(self)
-            self.graph.newCurve(self.xValues,
-                            spectrum, "Spectrum", replace=True)
+            self.graph.addCurve(self.xValues,
+                                spectrum, "Spectrum", replace=True)
             self.mainLayout.addWidget(self.parametersWidget)
             self.mainLayout.addWidget(self.graph)
         self.xMarkers = []
@@ -267,31 +267,31 @@ class SNIPWindow(qt.QWidget):
                 yMin, yMax = self.graph.getGraphYLimits()
                 xMean = 0.5 * (xMin + xMax)
                 yMean = 0.5 * (yMin + yMax)
-                self.xMarkers.append(self.graph.insertXMarker(roi_min[1],
-                                                              legend='C Min',
-                                                              text='C Min'))
-                self.xMarkers.append(self.graph.insertXMarker(roi_max[1],
-                                                            legend='C Max',
-                                                            text='C Max'))
-                self.yMarkers.append(self.graph.insertYMarker(roi_min[0],
-                                                            legend='R Min',
-                                                            text='R Min'))
-                self.yMarkers.append(self.graph.insertYMarker(roi_max[0],
-                                                            legend='R Max',
-                                                            text='R Max'))
+                self.xMarkers.append(self.graph.addXMarker(roi_min[1],
+                                                           legend='C Min',
+                                                           text='C Min'))
+                self.xMarkers.append(self.graph.addXMarker(roi_max[1],
+                                                           legend='C Max',
+                                                           text='C Max'))
+                self.yMarkers.append(self.graph.addYMarker(roi_min[0],
+                                                           legend='R Min',
+                                                           text='R Min'))
+                self.yMarkers.append(self.graph.addYMarker(roi_max[0],
+                                                           legend='R Max',
+                                                           text='R Max'))
             else:
-                self.graph.insertXMarker(roi_min[1],
-                                         legend='C Min',
-                                         text='C Min')
-                self.graph.insertXMarker(roi_max[1],
-                                         legend='C Max',
-                                         text='C Max')
-                self.graph.insertYMarker(roi_min[0],
-                                         legend='R Min',
-                                         text='R Min')
-                self.graph.insertYMarker(roi_max[0],
-                                         legend='R Max',
-                                         text='R Max')
+                self.graph.addXMarker(roi_min[1],
+                                      legend='C Min',
+                                      text='C Min')
+                self.graph.addXMarker(roi_max[1],
+                                      legend='C Max',
+                                      text='C Max')
+                self.graph.addYMarker(roi_min[0],
+                                      legend='R Min',
+                                      text='R Min')
+                self.graph.addYMarker(roi_max[0],
+                                      legend='R Max',
+                                      text='R Max')
             self.background = SNIPModule.getImageBackground(self.image, width,
                                                    roi_min=roi_min,
                                                    roi_max=roi_max,
@@ -319,8 +319,8 @@ class SNIPWindow(qt.QWidget):
                 legend0 = "Smoothed Spectrum"
             else:
                 legend0 = "Background"
-            self.graph.addCurve(self.xValues,
-                            self.background, legend0, replace=False)
+            self.graph.addCurve(self.xValues, self.background,
+                                legend0, replace=False)
 
             #Force information update
             legend = self.graph.getActiveCurve(just_legend=True)

--- a/PyMca5/PyMcaGui/math/SimpleActions.py
+++ b/PyMca5/PyMcaGui/math/SimpleActions.py
@@ -1,0 +1,322 @@
+#/*##########################################################################
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""This module defines a set of simple plot actions processing one or all
+plotted curves in a ScanWindow:
+
+    - :class:`AverageAction`
+    - :class:`DerivativeAction`
+    - :class:`SmoothAction`
+    - :class:`SwapSignAction`
+    - :class:`SubtractAction`
+    - :class:`YMinToZeroAction`
+
+"""
+import copy
+
+from silx.gui.plot.actions import PlotAction
+
+from PyMca5.PyMcaGui import PyMcaQt as qt
+from PyMca5.PyMcaMath import SimpleMath
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
+
+if hasattr(qt, 'QString'):
+    QString = qt.QString
+else:
+    QString = qt.safe_str
+
+_simpleMath = SimpleMath.SimpleMath()
+
+
+def _getOneCurve(plot, qwarning=True):
+    """Return active curve if any,
+    else if there is a single curve return it,
+    else return None.
+
+    :param plot: Plot instance
+    :param bool qwarning: If True, display a warning popup to
+        inform that a curve must be selected when function is not
+        successful.
+    """
+    curve = plot.getActiveCurve()
+    if curve is None:
+        curves = plot.getAllCurves()
+        if not curves or len(curves) > 1:
+            if qwarning:
+                _QWarning(msg="You must select a curve.",
+                          parent=plot)
+            return None
+        return curves[0]
+    return curve
+
+
+def _QWarning(msg, parent=None):
+    """Print a warning message in a QMessageBox"""
+    mb = qt.QMessageBox(parent)
+    mb.setIcon(qt.QMessageBox.Warning)
+    mb.setText(msg)
+    mb.exec_()
+
+#
+# def _isActive(legend, plot):
+#     """
+#
+#     :param legend: curve legend
+#     :param plot: plot instance
+#     :return: True or False
+#     """
+#     active_legend = plot.getActiveCurve(just_legend=True)
+#     if active_legend is None:
+#         # No active curve
+#         return False
+#     return legend == active_legend
+
+
+def _updated_info(info0, sourcename, operation):
+    info1 = copy.deepcopy(info0)
+    if not 'operations' in info1:
+        info1['operations'] = []
+    info1['operations'].append(operation)
+    info1['SourceName'] = sourcename
+    if 'selectionlegend' in info1:
+        del info1['selectionlegend']
+    return info1
+
+
+class AverageAction(PlotAction):
+    """Average all curves, clear plot, add average curve
+    """
+    def __init__(self, plot, parent=None):
+        self.icon = qt.QIcon(qt.QPixmap(IconDict["average16"]))
+        PlotAction.__init__(self,
+                            plot,
+                            icon=self.icon,
+                            text='Average Plotted Curves',
+                            tooltip='Replace all curves by the average curve',
+                            triggered=self._averageAllCurves,
+                            parent=parent)
+
+    def _averageAllCurves(self):
+        curves = self.plot.getAllCurves()
+        if not curves:
+            return
+        x0, y0, legend0, info0, _params0 = curves[0]
+        avg_legend = legend0
+        all_x = [x0]
+        all_y = [y0]
+        for x, y, legend, info, params in curves[1:]:
+            avg_legend += " + " + legend
+            all_x.append(x)
+            all_y.append(y)
+
+        avg_info = _updated_info(info0, avg_legend, "average")
+
+        xavg, yavg = _simpleMath.average(all_x, all_y)
+        avg_legend = "(%s)/%d" % (avg_legend, len(curves))
+
+        self.plot.clearCurves()
+        self.plot.addCurve(xavg, yavg, avg_legend,
+                           info=avg_info)
+
+
+class SmoothAction(PlotAction):
+    """Plot smooth of the active curve if any,
+    else plot smooth of the only existing curve if any.
+    """
+    def __init__(self, plot, parent=None):
+        self.icon = qt.QIcon(qt.QPixmap(IconDict["smooth"]))
+        PlotAction.__init__(self,
+                            plot,
+                            icon=self.icon,
+                            text='Smooth Active Curve',
+                            tooltip='Smooth Active Curve',
+                            triggered=self._smoothActiveCurve,
+                            parent=parent)
+
+    def _smoothActiveCurve(self):
+        curve = _getOneCurve(self.plot)
+        if curve is None:
+            return
+        x0, y0, legend0, info0, _params = curve
+
+        x1 = x0 * 1
+        y1 = _simpleMath.smooth(y0)
+
+        if info0.get("operations") is None or \
+                info0["operations"][-1] != "smooth":
+            legend1 = "%s Smooth" % legend0
+        else:
+            # don't repeat "smooth"
+            legend1 = legend0
+
+        info1 = _updated_info(info0, legend0, "smooth")
+
+        self.plot.addCurve(x1, y1, legend1,
+                           info=info1)
+
+
+class DerivativeAction(PlotAction):
+    """Plot derivative of the active curve if any,
+    else the derivative of the only existing curve.
+    """
+    def __init__(self, plot, parent=None):
+        self.icon = qt.QIcon(qt.QPixmap(IconDict["derive"]))
+        PlotAction.__init__(self,
+                            plot,
+                            icon=self.icon,
+                            tooltip='Plot Derivative of Active Curve',
+                            text='Derivate Active Curve',
+                            triggered=self._derivateActiveCurve,
+                            parent=parent)
+
+    def _derivateActiveCurve(self):
+        curve = _getOneCurve(self.plot)
+        if curve is None:
+            return
+        x0, y0, legend0, info0, params0 = curve
+
+        x1, y1 = _simpleMath.derivate(x0, y0)
+        legend1 = legend0 + "'"
+
+        info1 = _updated_info(info0, legend0, "derivate")
+        info1['plot_yaxis'] = "right"
+
+        ylabel1 = params0.get("ylabel")
+        if ylabel1 is None:
+            ylabel1 = "Y"
+
+        self.plot.addCurve(x1, y1, legend1,
+                           ylabel=ylabel1 + "'",
+                           info=info1,
+                           yaxis="right")
+
+
+class SwapSignAction(PlotAction):
+    """Plot the active curve multiplied by -1
+    """
+    def __init__(self, plot, parent=None):
+        self.icon = qt.QIcon(qt.QPixmap(IconDict["swapsign"]))
+        PlotAction.__init__(self,
+                            plot,
+                            icon=self.icon,
+                            text='Multiply Active Curve by -1',
+                            tooltip='Multiply Active Curve by -1',
+                            triggered=self._swapSignCurve,
+                            parent=parent)
+
+    def _swapSignCurve(self):
+        curve = _getOneCurve(self.plot)
+        if curve is None:
+            return
+        x0, y0, legend0, info0, _params = curve
+
+        x1 = 1 * x0
+        y1 = -y0
+        legend1 = "-(%s)" % legend0
+
+        info1 = _updated_info(info0, legend0, "swapsign")
+
+        self.plot.addCurve(x1, y1, legend1,
+                           info=info1)
+
+
+class YMinToZeroAction(PlotAction):
+    """
+
+    """
+    def __init__(self, plot, parent=None):
+        self.icon = qt.QIcon(qt.QPixmap(IconDict["ymintozero"]))
+        PlotAction.__init__(self,
+                            plot,
+                            icon=self.icon,
+                            text='Y Min to Zero',
+                            tooltip='Shift curve vertically to put min value at 0',
+                            triggered=self._yMinToZeroCurve,
+                            parent=parent)
+
+    def _yMinToZeroCurve(self):
+        curve = _getOneCurve(self.plot)
+        if curve is None:
+            return
+        x0, y0, legend0, info0, _params = curve
+
+        x1 = x0 * 1
+        y1 = y0 - min(y0)
+        legend1 = "(%s) - ymin" % legend0
+
+        info1 = _updated_info(info0, legend0, "forceymintozero")
+
+        self.plot.addCurve(x1, y1, legend1,
+                           info=info1)
+
+
+class SubtractAction(PlotAction):
+    """Subtract active curve from all curves.
+
+    """
+    def __init__(self, plot, parent=None):
+        self.icon = qt.QIcon(qt.QPixmap(IconDict["subtract"]))
+        PlotAction.__init__(self,
+                            plot,
+                            icon=self.icon,
+                            text='Subtract Active Curve',
+                            tooltip='Subtract active curve from all curves',
+                            triggered=self._subtractCurve,
+                            parent=parent)
+
+    def _subtractCurve(self):
+        active_curve = _getOneCurve(self.plot)
+        all_curves = self.plot.getAllCurves()
+
+        #############################################################
+        if active_curve is None:
+            return
+
+        x0, y0, legend0, info0, params0 = active_curve
+
+        ylabel0 = params0.get("ylabel", "Y0")
+        if ylabel0 is None:
+            ylabel0 = "Y0"
+
+        for x, y, legend, info, params in all_curves:
+            # (y1 - y0) is equivalent to 2 * average(-y0, y1)
+            XX = [x0, x]
+            YY = [-y0, y]
+            xplot, yplot = _simpleMath.average(XX, YY)
+            yplot *= 2
+            legend1 = "(%s - %s)" % (legend, legend0)
+
+            ylabel = params0.get("ylabel", "Y")
+            if ylabel is None:
+                ylabel = "Y"
+
+            ylabel1 = "(%s - %s)" % (ylabel, ylabel0)
+
+            info1 = _updated_info(info, legend, "subtract")
+            info1['LabelNames'] = [legend1]
+
+            self.plot.removeCurve(legend)
+            self.plot.addCurve(xplot, yplot, legend1,
+                               info=info1, ylabel=ylabel1)

--- a/PyMca5/PyMcaGui/math/fitting/RateLawWindow.py
+++ b/PyMca5/PyMcaGui/math/fitting/RateLawWindow.py
@@ -37,6 +37,7 @@ from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from PyMca5.PyMcaMath.fitting import RateLaw
+from PyMca5.PyMcaGui.PluginsToolButton import PluginsToolButton
 
 from silx.gui.plot import PlotWindow
 DEBUG = 0
@@ -70,6 +71,8 @@ class RateLawMdiArea(qt.QMdiArea):
                               position=True, backend=backend,
                               colormap=False, aspectRatio=False,
                               yInverted=False, roi=False, mask=False)
+            self.pluginsToolButton = PluginsToolButton(plot=plot)
+            plot.toolBar().addWidget(self.pluginsToolButton)
             plot.setWindowTitle(title)
             self.addSubWindow(plot)
             self._windowDict[title] = plot

--- a/PyMca5/PyMcaGui/math/fitting/RateLawWindow.py
+++ b/PyMca5/PyMcaGui/math/fitting/RateLawWindow.py
@@ -30,16 +30,15 @@ __author__ = "V. Armando Sole - ESRF Data Analysis"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-import os
+
 import sys
 import numpy
-import traceback
-import copy
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import PlotWindow
 from PyMca5.PyMcaMath.fitting import RateLaw
+
+from silx.gui.plot import PlotWindow
 DEBUG = 0
 
 class RateLawWindow(qt.QMainWindow):
@@ -67,9 +66,10 @@ class RateLawMdiArea(qt.QMdiArea):
                             "First", "Second"]
         self._windowList.reverse()
         for title in self._windowList:
-            plot = PlotWindow.PlotWindow(self,
-                                         position=True,
-                                         backend=backend)
+            plot = PlotWindow(self,
+                              position=True, backend=backend,
+                              colormap=False, aspectRatio=False,
+                              yInverted=False, roi=False, mask=False)
             plot.setWindowTitle(title)
             self.addSubWindow(plot)
             self._windowDict[title] = plot
@@ -89,16 +89,25 @@ class RateLawMdiArea(qt.QMdiArea):
                                               ylabel=ylabel,
                                               yerror=sigmay,
                                               symbol="o")
+        self._windowDict["Original"].setActiveCurve(legend)
         self.update()
 
     def update(self):
         plot = self._windowDict["Original"]
         activeCurve = plot.getActiveCurve()
-        if not len(activeCurve):
-            return
-        [x, y, legend, info] = activeCurve[:4]
-        xmin, xmax = plot.getGraphXLimits()
-        ymin, ymax = plot.getGraphYLimits()
+        if activeCurve is None:
+            allCurves = plot.getAllCurves()
+            if len(allCurves):
+                activeCurve = allCurves[0]
+            else:
+                return
+        x = activeCurve.getXData(copy=False)
+        y = activeCurve.getYData(copy=False)
+        xlabel = activeCurve.getXLabel()
+        ylabel = activeCurve.getYLabel()
+
+        # xmin, xmax = plot.getGraphXLimits()
+        # ymin, ymax = plot.getGraphYLimits()
         
         result = RateLaw.rateLaw(x, y, sigmay=None)
         labels = ["Zero", "First", "Second"]
@@ -117,8 +126,6 @@ class RateLawMdiArea(qt.QMdiArea):
             stderr = workingResult["stderr"]
             xw = workingResult["x"]
             yw = workingResult["y"]
-            xlabel = info["ylabel"]
-            ylabel = info["ylabel"]
             title = "r = %.5f slope = %.3E +/- %.2E" % (r_value, slope, sigma_slope)
             fit_legend = "%.3g * x + %.3g" % (slope, intercept) 
             if key == "First":
@@ -127,7 +134,7 @@ class RateLawMdiArea(qt.QMdiArea):
                 ylabel = "1 / %s" %  ylabel
             plot.addCurve(xw, yw,
                           legend="Data",
-                          replace=True, replot=False,
+                          replace=True, resetzoom=False,
                           symbol="o",
                           linestyle=" ",
                           ylabel=ylabel)
@@ -135,10 +142,11 @@ class RateLawMdiArea(qt.QMdiArea):
             plot.addCurve(xw, intercept + slope * xw,
                           legend=fit_legend,
                           replace=False,
-                          replot=True,
+                          resetzoom=True,
                           symbol=None,
                           color="red",
                           ylabel=ylabel)
+            plot.setActiveCurve("Data")
             plot.resetZoom()
         self.sigRateLawMdiAreaSignal.emit(result)
 

--- a/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
@@ -532,7 +532,7 @@ if __name__ == "__main__":
         w = XASNormalizationDialog(None, spectrum, energy=energy)
     else:
         from PyMca5 import SpecfitFuns
-        noise = numpy.random.randn(1500.)
+        noise = numpy.random.randn(1500)
         x = 8000. + numpy.arange(1500.)
         y = SpecfitFuns.upstep([100, 8500., 50], x)
         w = XASNormalizationDialog(None, y + numpy.sqrt(y)* noise, energy=x)

--- a/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
+++ b/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
@@ -105,9 +105,9 @@ class MaterialEditor(qt.QWidget):
         if self.__toolMode:
             self.materialGUI.setCurrent(a[0])
             if (self.graph is None):
-                self.graph = PlotWindow(self,
-                                        control=True,
-                                        position=True)
+                self.graph = PlotWindow(self, control=True, position=True,
+                                        colormap=False, aspectRatio=False,
+                                        yInverted=False, roi=False, mask=False)
                 self.graph.setDefaultPlotPoints(True)
             layout.addWidget(self.materialGUI)
             layout.addWidget(self.graph)

--- a/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
+++ b/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
@@ -37,8 +37,8 @@ import numpy
 import traceback
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaPhysics import Elements
-from PyMca5.PyMcaGui import PlotWindow
-ScanWindow = PlotWindow.PlotWindow
+# from PyMca5.PyMcaGui import PlotWindow
+from silx.gui.plot import PlotWindow
 
 if hasattr(qt, "QString"):
     QString = qt.QString
@@ -105,13 +105,10 @@ class MaterialEditor(qt.QWidget):
         if self.__toolMode:
             self.materialGUI.setCurrent(a[0])
             if (self.graph is None):
-                self.graph = ScanWindow(self, newplot=False,
-                                        fit=False,
-                                        plugins=False,
+                self.graph = PlotWindow(self,
                                         control=True,
                                         position=True)
-                self.graph._togglePointsSignal()
-                self.graph.enableOwnSave(True)
+                self.graph.setDefaultPlotPoints(True)
             layout.addWidget(self.materialGUI)
             layout.addWidget(self.graph)
         else:
@@ -174,6 +171,8 @@ class MaterialEditor(qt.QWidget):
                                              density=density, thickness=thickness, listoutput=False)
             addButton = False
             if self.graph is None:
+                # probably dead code (ScanWindow.ScanWindow not imported)
+                # TODO: if needed, this should be updated for silx based ScanWindow
                 self.graphDialog = qt.QDialog(self)
                 self.graphDialog.mainLayout = qt.QVBoxLayout(self.graphDialog)
                 self.graphDialog.mainLayout.setContentsMargins(0, 0, 0, 0)
@@ -216,6 +215,8 @@ class MaterialEditor(qt.QWidget):
                                                                  energy)
             addButton = False
             if self.graph is None:
+                # probably dead code (ScanWindow.ScanWindow not imported)
+                # TODO: if needed, this should be updated for silx based ScanWindow
                 self.graphDialog = qt.QDialog(self)
                 self.graphDialog.mainLayout = qt.QVBoxLayout(self.graphDialog)
                 self.graphDialog.mainLayout.setContentsMargins(0, 0, 0, 0)

--- a/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
+++ b/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
@@ -234,15 +234,13 @@ class MaterialEditor(qt.QWidget):
                                 legend=legend,
                                 xlabel='Energy (keV)',
                                 ylabel='Mass Att. (cm2/g)',
-                                replace=True,
-                                replot=False)
+                                replace=True)
             for legend in ['Compton', 'Photo','Total']:
                 self.graph.addCurve(energy, numpy.array(data[legend.lower()]),
-                                legend=legend,
-                                xlabel='Energy (keV)',
-                                ylabel='Mass Att. (cm2/g)',
-                                replace=False,
-                                replot=False)
+                                    legend=legend,
+                                    xlabel='Energy (keV)',
+                                    ylabel='Mass Att. (cm2/g)',
+                                    replace=False)
             self.graph.setActiveCurve(legend+' '+'Mass Att. (cm2/g)')
             self.graph.setGraphTitle(ddict['Comment'])
             if self.graphDialog is not None:

--- a/PyMca5/PyMcaGui/plotting/MaskImageWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskImageWidget.py
@@ -848,25 +848,17 @@ class MaskImageWidget(qt.QWidget):
         if ddict['event'] == 'ADD':
             for i in range(n):
                 x, y, legend, info = curveList[i]
-                info['profilelabel'] = label
-                if i == (n-1):
-                    replot = True
+                resetzoom = (i == (n-1))
                 self._profileScanWindow.addCurve(x, y, legend=legend, info=info,
-                                                 replot=replot, replace=False)
+                                                 resetzoom=resetzoom, replace=False)
         elif ddict['event'] == 'REPLACE':
             for i in range(n):
                 x, y, legend, info = curveList[i]
                 info['profilelabel'] = label
-                if i in [0, n-1]:
-                    replace = True
-                else:
-                    replace = False
-                if i == (n-1):
-                    replot = True
-                else:
-                    replot = False
+                replace = (i in [0, n-1])
+                resetzoom = (i == (n-1))
                 self._profileScanWindow.addCurve(x, y, legend=legend, info=info,
-                                                 replot=replot, replace=replace)
+                                                 resetzoom=resetzoom, replace=replace)
         elif ddict['event'] == 'REMOVE':
             curveList = self._profileScanWindow.getAllCurves()
             if curveList in [None, []]:
@@ -882,11 +874,8 @@ class MaskImageWidget(qt.QWidget):
             n = len(toDelete)
             for i in range(n):
                 legend = toDelete[i]
-                if i == (n-1):
-                    replot = True
-                else:
-                    replot = False
-                self._profileScanWindow.removeCurve(legend, replot=replot)
+                resetzoom = (i == (n-1))
+                self._profileScanWindow.removeCurve(legend, resetzoom=resetzoom)
 
     def drawOverlayItem(self, x, y, legend=None, info=None, replace=False, replot=True):
         #same call as the plot1D addCurve command

--- a/PyMca5/PyMcaGui/plotting/ProfileScanWidget.py
+++ b/PyMca5/PyMcaGui/plotting/ProfileScanWidget.py
@@ -118,7 +118,7 @@ class ProfileScanWidget(Window):
         elif action == 'REMOVE':
             self.sigRemoveClicked.emit(ddict)
         else:
-            self.replaceAddClicked.emit(ddict)
+            self.sigReplaceClicked.emit(ddict)
 
 def test():
     app = qt.QApplication([])

--- a/PyMca5/PyMcaGui/pymca/LegacyScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/LegacyScanWindow.py
@@ -1,0 +1,1588 @@
+#/*##########################################################################
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""Legacy PyMca ScanWindow, to be replaced by a ScanWindow based on a
+silx PlotWidget.
+This module should not be used anywhere, it will no longer be maintained."""
+__author__ = "V.A. Sole - ESRF Data Analysis"
+__contact__ = "sole@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+import sys
+import os
+import numpy
+#from numpy import argsort, nonzero, take
+import time
+import traceback
+from PyMca5.PyMcaGui import PyMcaQt as qt
+if hasattr(qt, 'QString'):
+    QString = qt.QString
+else:
+    QString = qt.safe_str
+if __name__ == "__main__":
+    app = qt.QApplication([])
+
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
+from PyMca5.PyMcaGui.plotting import PlotWindow
+from . import ScanFit
+from PyMca5.PyMcaMath import SimpleMath
+from PyMca5.PyMcaCore import DataObject
+import copy
+from PyMca5.PyMcaGui import PyMcaPrintPreview
+from PyMca5.PyMcaCore import PyMcaDirs
+from . import ScanWindowInfoWidget
+#implement the plugins interface
+from PyMca5.PyMcaGui import QPyMcaMatplotlibSave1D
+MATPLOTLIB = True
+#force understanding of utf-8 encoding
+#otherways it cannot generate svg output
+try:
+    import encodings.utf_8
+except:
+    #not a big problem
+    pass
+
+PLUGINS_DIR = None
+try:
+    import PyMca5
+    if os.path.exists(os.path.join(os.path.dirname(PyMca5.__file__), "PyMcaPlugins")):
+        from PyMca5 import PyMcaPlugins
+        PLUGINS_DIR = os.path.dirname(PyMcaPlugins.__file__)
+    else:
+        directory = os.path.dirname(__file__)
+        while True:
+            if os.path.exists(os.path.join(directory, "PyMcaPlugins")):
+                PLUGINS_DIR = os.path.join(directory, "PyMcaPlugins")
+                break
+            directory = os.path.dirname(directory)
+            if len(directory) < 5:
+                break
+    userPluginsDirectory = PyMca5.getDefaultUserPluginsDirectory()
+    if userPluginsDirectory is not None:
+        if PLUGINS_DIR is None:
+            PLUGINS_DIR = userPluginsDirectory
+        else:
+            PLUGINS_DIR = [PLUGINS_DIR, userPluginsDirectory]
+except:
+    pass
+
+DEBUG = 0
+
+class ScanWindow(PlotWindow.PlotWindow):
+    def __init__(self, parent=None, name="Scan Window", specfit=None, backend=None,
+                 plugins=True, newplot=True, roi=True, fit=True,
+                 control=True, position=True, info=False, **kw):
+
+        super(ScanWindow, self).__init__(parent,
+                                         newplot=newplot,
+                                         plugins=plugins,
+                                         backend=backend,
+                                         roi=roi,
+                                         fit=fit,
+                                         control=control,
+                                         position=position,
+                                         **kw)
+        self.setDataMargins(0, 0, 0.025, 0.025)
+        #self._togglePointsSignal()
+        self.setPanWithArrowKeys(True)
+        self.setWindowType("SCAN")
+        # this two objects are the same
+        self.dataObjectsList = self._curveList
+        # but this is tricky
+        self.dataObjectsDict = {}
+
+        self.setWindowTitle(name)
+        self.matplotlibDialog = None
+
+        if PLUGINS_DIR is not None:
+            if type(PLUGINS_DIR) == type([]):
+                pluginDir = PLUGINS_DIR
+            else:
+                pluginDir = [PLUGINS_DIR]
+            self.getPlugins(method="getPlugin1DInstance",
+                            directoryList=pluginDir)
+
+        if info:
+            self.scanWindowInfoWidget = ScanWindowInfoWidget.\
+                                            ScanWindowInfoWidget()
+            self.infoDockWidget = qt.QDockWidget(self)
+            self.infoDockWidget.layout().setContentsMargins(0, 0, 0, 0)
+            self.infoDockWidget.setWidget(self.scanWindowInfoWidget)
+            self.infoDockWidget.setWindowTitle(self.windowTitle()+(" Info"))
+            self.addDockWidget(qt.Qt.BottomDockWidgetArea,
+                                   self.infoDockWidget)
+            controlMenu = qt.QMenu()
+            controlMenu.addAction(QString("Show/Hide Legends"),
+                                       self.toggleLegendWidget)
+            controlMenu.addAction(QString("Show/Hide Info"),
+                                       self._toggleInfoWidget)
+            controlMenu.addAction(QString("Toggle Crosshair"),
+                                       self.toggleCrosshairCursor)
+            controlMenu.addAction(QString("Toggle Arrow Keys Panning"),
+                                       self.toggleArrowKeysPanning)
+            self.setControlMenu(controlMenu)
+        else:
+            self.scanWindowInfoWidget = None
+        #self.fig = None
+        if fit:
+            self.scanFit = ScanFit.ScanFit(specfit=specfit)
+        self.printPreview = PyMcaPrintPreview.PyMcaPrintPreview(modal = 0)
+        self.simpleMath = SimpleMath.SimpleMath()
+        self.outputDir = None
+        self.outputFilter = None
+
+        #signals
+        # this one was made in the base class
+        #self.setCallback(self.graphCallback)
+        if fit:
+            from PyMca5.PyMcaGui.math.fitting import SimpleFitGui
+            self.customFit = SimpleFitGui.SimpleFitGui()
+            self.scanFit.sigScanFitSignal.connect(self._scanFitSignalReceived)
+            self.customFit.sigSimpleFitSignal.connect( \
+                            self._customFitSignalReceived)
+
+            self.fitButtonMenu = qt.QMenu()
+            self.fitButtonMenu.addAction(QString("Simple Fit"),
+                                   self._simpleFitSignal)
+            self.fitButtonMenu.addAction(QString("Customized Fit") ,
+                                   self._customFitSignal)
+
+    def _toggleInfoWidget(self):
+        if self.infoDockWidget.isHidden():
+            self.infoDockWidget.show()
+            legend = self.getActiveCurve(just_legend=True)
+            if legend is not None:
+                ddict ={}
+                ddict['event'] = "curveClicked"
+                ddict['label'] = legend
+                ddict['legend'] = legend
+                self.graphCallback(ddict)
+        else:
+            self.infoDockWidget.hide()
+
+    def _buildLegendWidget(self):
+        if self.legendWidget is None:
+            super(ScanWindow, self)._buildLegendWidget()
+            if hasattr(self, "infoDockWidget") and \
+               hasattr(self, "roiDockWidget"):
+                self.tabifyDockWidget(self.infoDockWidget,
+                                      self.roiDockWidget,
+                                      self.legendDockWidget)
+            elif hasattr(self, "infoDockWidget"):
+                self.tabifyDockWidget(self.infoDockWidget,
+                                      self.legendDockWidget)
+
+    def _toggleROI(self, position=None):
+        super(ScanWindow, self)._toggleROI(position=position)
+        if hasattr(self, "infoDockWidget"):
+            self.tabifyDockWidget(self.infoDockWidget,
+                                  self.roiDockWidget)
+
+    def setDispatcher(self, w):
+        w.sigAddSelection.connect(self._addSelection)
+        w.sigRemoveSelection.connect(self._removeSelection)
+        w.sigReplaceSelection.connect(self._replaceSelection)
+
+    def _addSelection(self, selectionlist, replot=True):
+        if DEBUG:
+            print("_addSelection(self, selectionlist)",selectionlist)
+        if type(selectionlist) == type([]):
+            sellist = selectionlist
+        else:
+            sellist = [selectionlist]
+
+        if len(self._curveList):
+            activeCurve = self.getActiveCurve(just_legend=True)
+        else:
+            activeCurve = None
+        nSelection = len(sellist)
+        for selectionIndex in range(nSelection):
+            sel = sellist[selectionIndex]
+            if selectionIndex == (nSelection - 1):
+                actualReplot = replot
+            else:
+                actualReplot = False
+            source = sel['SourceName']
+            key    = sel['Key']
+            legend = sel['legend'] #expected form sourcename + scan key
+            if not ("scanselection" in sel): continue
+            if sel['scanselection'] == "MCA":
+                continue
+            if not sel["scanselection"]:continue
+            if len(key.split(".")) > 2: continue
+            dataObject = sel['dataobject']
+            #only one-dimensional selections considered
+            if dataObject.info["selectiontype"] != "1D": continue
+
+            #there must be something to plot
+            if not hasattr(dataObject, 'y'):
+                continue
+            if not hasattr(dataObject, 'x'):
+                ylen = len(dataObject.y[0])
+                if ylen:
+                    xdata = numpy.arange(ylen).astype(numpy.float)
+                else:
+                    #nothing to be plot
+                    continue
+            if dataObject.x is None:
+                ylen = len(dataObject.y[0])
+                if ylen:
+                    xdata = numpy.arange(ylen).astype(numpy.float)
+                else:
+                    #nothing to be plot
+                    continue
+            elif len(dataObject.x) > 1:
+                if DEBUG:
+                    print("Mesh plots")
+                continue
+            else:
+                xdata = dataObject.x[0]
+            sps_source = False
+            if 'SourceType' in sel:
+                if sel['SourceType'] == 'SPS':
+                    sps_source = True
+
+            if sps_source:
+                ycounter = -1
+                if 'selection' not in dataObject.info:
+                    dataObject.info['selection'] = copy.deepcopy(sel['selection'])
+                for ydata in dataObject.y:
+                    xlabel = None
+                    ylabel = None
+                    ycounter += 1
+                    if dataObject.m is None:
+                        mdata = [numpy.ones(len(ydata)).astype(numpy.float)]
+                    elif len(dataObject.m[0]) > 0:
+                        if len(dataObject.m[0]) == len(ydata):
+                            index = numpy.nonzero(dataObject.m[0])[0]
+                            if not len(index):
+                                continue
+                            xdata = numpy.take(xdata, index)
+                            ydata = numpy.take(ydata, index)
+                            mdata = numpy.take(dataObject.m[0], index)
+                            #A priori the graph only knows about plots
+                            ydata = ydata/mdata
+                        else:
+                            raise ValueError("Monitor data length different than counter data")
+                    else:
+                        mdata = [numpy.ones(len(ydata)).astype(numpy.float)]
+                    ylegend = 'y%d' % ycounter
+                    if dataObject.info['selection'] is not None:
+                        if type(dataObject.info['selection']) == type({}):
+                            if 'x' in dataObject.info['selection']:
+                                #proper scan selection
+                                ilabel = dataObject.info['selection']['y'][ycounter]
+                                ylegend = dataObject.info['LabelNames'][ilabel]
+                                ylabel = ylegend
+                                if sel['selection']['x'] is not None:
+                                    if len(dataObject.info['selection']['x']):
+                                        xlabel = dataObject.info['LabelNames'] \
+                                                    [dataObject.info['selection']['x'][0]]
+                    dataObject.info["xlabel"] = xlabel
+                    dataObject.info["ylabel"] = ylabel
+                    newLegend = legend + " " + ylegend
+                    self.dataObjectsDict[newLegend] = dataObject
+                    self.addCurve(xdata, ydata, legend=newLegend, info=dataObject.info,
+                                                    xlabel=xlabel, ylabel=ylabel, replot=False)
+                    #              replot=actualReplot)
+                    if self.scanWindowInfoWidget is not None:
+                        if not self.infoDockWidget.isHidden():
+                            activeLegend = self.getActiveCurve(just_legend=True)
+                            if activeLegend is not None:
+                                if activeLegend == newLegend:
+                                    self.scanWindowInfoWidget.updateFromDataObject\
+                                                                (dataObject)
+                            else:
+                                dummyDataObject = DataObject.DataObject()
+                                dummyDataObject.y=[numpy.array([])]
+                                dummyDataObject.x=[numpy.array([])]
+                                self.scanWindowInfoWidget.updateFromDataObject(dummyDataObject)
+            else:
+                #we have to loop for all y values
+                ycounter = -1
+                for ydata in dataObject.y:
+                    ylen = len(ydata)
+                    if ylen == 1:
+                        if len(xdata) > 1:
+                            ydata = ydata[0] * numpy.ones(len(xdata)).astype(numpy.float)
+                    elif len(xdata) == 1:
+                        xdata = xdata[0] * numpy.ones(ylen).astype(numpy.float)
+                    ycounter += 1
+                    newDataObject   = DataObject.DataObject()
+                    newDataObject.info = copy.deepcopy(dataObject.info)
+                    if dataObject.m is None:
+                        mdata = numpy.ones(len(ydata)).astype(numpy.float)
+                    elif len(dataObject.m[0]) > 0:
+                        if len(dataObject.m[0]) == len(ydata):
+                            index = numpy.nonzero(dataObject.m[0])[0]
+                            if not len(index):
+                                continue
+                            xdata = numpy.take(xdata, index)
+                            ydata = numpy.take(ydata, index)
+                            mdata = numpy.take(dataObject.m[0], index)
+                            #A priori the graph only knows about plots
+                            ydata = ydata/mdata
+                        elif len(dataObject.m[0]) == 1:
+                            mdata = numpy.ones(len(ydata)).astype(numpy.float)
+                            mdata *= dataObject.m[0][0]
+                            index = numpy.nonzero(dataObject.m[0])[0]
+                            if not len(index):
+                                continue
+                            xdata = numpy.take(xdata, index)
+                            ydata = numpy.take(ydata, index)
+                            mdata = numpy.take(dataObject.m[0], index)
+                            #A priori the graph only knows about plots
+                            ydata = ydata/mdata
+                        else:
+                            raise ValueError("Monitor data length different than counter data")
+                    else:
+                        mdata = numpy.ones(len(ydata)).astype(numpy.float)
+                    newDataObject.x = [xdata]
+                    newDataObject.y = [ydata]
+                    newDataObject.m = [mdata]
+                    newDataObject.info['selection'] = copy.deepcopy(sel['selection'])
+                    ylegend = 'y%d' % ycounter
+                    xlabel = None
+                    ylabel = None
+                    if sel['selection'] is not None:
+                        if type(sel['selection']) == type({}):
+                            if 'x' in sel['selection']:
+                                #proper scan selection
+                                newDataObject.info['selection']['x'] = sel['selection']['x']
+                                newDataObject.info['selection']['y'] = [sel['selection']['y'][ycounter]]
+                                newDataObject.info['selection']['m'] = sel['selection']['m']
+                                ilabel = newDataObject.info['selection']['y'][0]
+                                ylegend = newDataObject.info['LabelNames'][ilabel]
+                                ylabel = ylegend
+                                if len(newDataObject.info['selection']['x']):
+                                    ilabel = newDataObject.info['selection']['x'][0]
+                                    xlabel = newDataObject.info['LabelNames'][ilabel]
+                                else:
+                                    xlabel = "Point number"
+                    if ('operations' in dataObject.info) and len(dataObject.y) == 1:
+                        newDataObject.info['legend'] = legend
+                        symbol = 'x'
+                    else:
+                        symbol=None
+                        newDataObject.info['legend'] = legend + " " + ylegend
+                        newDataObject.info['selectionlegend'] = legend
+                    yaxis = None
+                    if "plot_yaxis" in dataObject.info:
+                        yaxis = dataObject.info["plot_yaxis"]
+                    elif 'operations' in dataObject.info:
+                        if dataObject.info['operations'][-1] == 'derivate':
+                            yaxis = 'right'
+                    #print("sending legend = ", newDataObject.info['legend'], "replot = ", False)
+                    self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
+                    self.addCurve(xdata, ydata, legend=newDataObject.info['legend'],
+                                    info=newDataObject.info,
+                                    symbol=symbol,
+                                    yaxis=yaxis,
+                                    xlabel=xlabel,
+                                    ylabel=ylabel,
+                                    replot=False)
+        self.dataObjectsList = self._curveList
+        try:
+            if activeCurve is None:
+                if len(self._curveList) > 0:
+                    activeCurve = self._curveList[0]
+                ddict = {}
+                ddict['event'] = "curveClicked"
+                ddict['label'] = activeCurve
+                self.graphCallback(ddict)
+        finally:
+            if replot:
+                #self.replot()
+                self.resetZoom()
+        self.updateLegends()
+
+    def _removeSelection(self, selectionlist):
+        if DEBUG:
+            print("_removeSelection(self, selectionlist)",selectionlist)
+        if type(selectionlist) == type([]):
+            sellist = selectionlist
+        else:
+            sellist = [selectionlist]
+
+        removelist = []
+        for sel in sellist:
+            source = sel['SourceName']
+            key    = sel['Key']
+            if not ("scanselection" in sel): continue
+            if sel['scanselection'] == "MCA":
+                continue
+            if not sel["scanselection"]:continue
+            if len(key.split(".")) > 2: continue
+
+            legend = sel['legend'] #expected form sourcename + scan key
+            if type(sel['selection']) == type({}):
+                if 'y' in sel['selection']:
+                    for lName in ['cntlist', 'LabelNames']:
+                        if lName in sel['selection']:
+                            for index in sel['selection']['y']:
+                                removelist.append(legend +" "+\
+                                                  sel['selection'][lName][index])
+
+        if len(removelist):
+            self.removeCurves(removelist)
+
+    def removeCurves(self, removeList, replot=True):
+        for legend in removeList:
+            if legend == removeList[-1]:
+                self.removeCurve(legend, replot=replot)
+            else:
+                self.removeCurve(legend, replot=False)
+            if legend in self.dataObjectsDict:
+                del self.dataObjectsDict[legend]
+        self.dataObjectsList = self._curveList
+
+    def _replaceSelection(self, selectionlist):
+        if DEBUG:
+            print("_replaceSelection(self, selectionlist)",selectionlist)
+        if type(selectionlist) == type([]):
+            sellist = selectionlist
+        else:
+            sellist = [selectionlist]
+
+        doit = 0
+        for sel in sellist:
+            if not ("scanselection" in sel): continue
+            if sel['scanselection'] == "MCA":
+                continue
+            if not sel["scanselection"]:continue
+            if len(sel["Key"].split(".")) > 2: continue
+            dataObject = sel['dataobject']
+            if dataObject.info["selectiontype"] == "1D":
+                if hasattr(dataObject, 'y'):
+                    doit = 1
+                    break
+        if not doit:
+            return
+        self.clearCurves()
+        self.dataObjectsDict={}
+        self.dataObjectsList=self._curveList
+        self._addSelection(selectionlist, replot=True)
+
+    def _handleMarkerEvent(self, ddict):
+        if ddict['event'] == 'markerMoved':
+            label = ddict['label']
+            if label.startswith('ROI'):
+                return self._handleROIMarkerEvent(ddict)
+            else:
+                if DEBUG:
+                    print("Unhandled marker %s" % label)
+                return
+
+    def graphCallback(self, ddict):
+        if DEBUG:
+            print("graphCallback", ddict)
+        if ddict['event'] in ['markerMoved', 'markerSelected']:
+            self._handleMarkerEvent(ddict)
+        elif ddict['event'] in ["mouseMoved", "MouseAt"]:
+            if self._toggleCounter > 0:
+                activeCurve = self.getActiveCurve()
+                if activeCurve in [None, []]:
+                    self._handleMouseMovedEvent(ddict)
+                else:
+                    x, y, legend, info = activeCurve[0:4]
+                    # calculate the maximum distance
+                    xMin, xMax = self.getGraphXLimits()
+                    maxXDistance = abs(xMax - xMin)
+                    yMin, yMax = self.getGraphYLimits()
+                    maxYDistance = abs(yMax - yMin)
+                    if (maxXDistance > 0.0) and (maxYDistance > 0.0):
+                        closestIndex = (pow((x - ddict['x'])/maxXDistance, 2) + \
+                                        pow((y - ddict['y'])/maxYDistance, 2))
+                    else:
+                        closestIndex = (pow(x - ddict['x'], 2) + \
+                                    pow(y - ddict['y'], 2))
+                    xText = '----'
+                    yText = '----'
+                    if len(closestIndex):
+                        closestIndex = closestIndex.argmin()
+                        xCurve = x[closestIndex]
+                        if abs(xCurve - ddict['x']) < (0.05 * maxXDistance):
+                            yCurve = y[closestIndex]
+                            if abs(yCurve - ddict['y']) < (0.05 * maxYDistance):
+                                xText = '%.7g' % xCurve
+                                yText = '%.7g' % yCurve
+                    if xText == '----':
+                        if self.getGraphCursor():
+                            self._xPos.setStyleSheet("color: rgb(255, 0, 0);")
+                            self._yPos.setStyleSheet("color: rgb(255, 0, 0);")
+                            xText = '%.7g' % ddict['x']
+                            yText = '%.7g' % ddict['y']
+                        else:
+                            self._xPos.setStyleSheet("color: rgb(0, 0, 0);")
+                            self._yPos.setStyleSheet("color: rgb(0, 0, 0);")
+                    else:
+                        self._xPos.setStyleSheet("color: rgb(0, 0, 0);")
+                        self._yPos.setStyleSheet("color: rgb(0, 0, 0);")
+                    self._xPos.setText(xText)
+                    self._yPos.setText(yText)
+            else:
+                self._xPos.setStyleSheet("color: rgb(0, 0, 0);")
+                self._yPos.setStyleSheet("color: rgb(0, 0, 0);")
+                self._handleMouseMovedEvent(ddict)
+        elif ddict['event'] in ["curveClicked", "legendClicked"]:
+            legend = ddict["label"]
+            if legend is None:
+                if len(self.dataObjectsList):
+                    legend = self.dataObjectsList[0]
+                else:
+                    return
+            if legend not in self.dataObjectsList:
+                if DEBUG:
+                    print("unknown legend %s" % legend)
+                return
+
+            #force the current x label to the appropriate value
+            dataObject = self.dataObjectsDict[legend]
+            if 'selection' in dataObject.info:
+                ilabel = dataObject.info['selection']['y'][0]
+                ylabel = dataObject.info['LabelNames'][ilabel]
+                if len(dataObject.info['selection']['x']):
+                    ilabel = dataObject.info['selection']['x'][0]
+                    xlabel = dataObject.info['LabelNames'][ilabel]
+                else:
+                    xlabel = "Point Number"
+                if len(dataObject.info['selection']['m']):
+                    ilabel = dataObject.info['selection']['m'][0]
+                    ylabel += "/" + dataObject.info['LabelNames'][ilabel]
+            else:
+                xlabel = dataObject.info.get('xlabel', None)
+                ylabel = dataObject.info.get('ylabel', None)
+            if xlabel is not None:
+                self.setGraphXLabel(xlabel)
+            if ylabel is not None:
+                self.setGraphYLabel(ylabel)
+            self.setGraphTitle(legend)
+            self.setActiveCurve(legend)
+            #self.setGraphTitle(legend)
+            if self.scanWindowInfoWidget is not None:
+                if not self.infoDockWidget.isHidden():
+                    self.scanWindowInfoWidget.updateFromDataObject\
+                                                            (dataObject)
+        elif ddict['event'] == "removeCurveEvent":
+            legend = ddict['legend']
+            self.removeCurves([legend])
+        elif ddict['event'] == "renameCurveEvent":
+            legend = ddict['legend']
+            newlegend = ddict['newlegend']
+            if legend in self.dataObjectsDict:
+                self.dataObjectsDict[newlegend]= copy.deepcopy(self.dataObjectsDict[legend])
+                self.dataObjectsDict[newlegend].info['legend'] = newlegend
+                self.dataObjectsList.append(newlegend)
+                self.removeCurves([legend], replot=False)
+                self.newCurve(self.dataObjectsDict[newlegend].x[0],
+                              self.dataObjectsDict[newlegend].y[0],
+                              legend=self.dataObjectsDict[newlegend].info['legend'])
+
+        #make sure the plot signal is forwarded because we have overwritten
+        #its handling
+        self.sigPlotSignal.emit(ddict)
+
+
+    def _customFitSignalReceived(self, ddict):
+        if ddict['event'] == "FitFinished":
+            newDataObject = self.__customFitDataObject
+
+            xplot = ddict['x']
+            yplot = ddict['yfit']
+            newDataObject.x = [xplot]
+            newDataObject.y = [yplot]
+            newDataObject.m = [numpy.ones(len(yplot)).astype(numpy.float)]
+
+            #here I should check the log or linear status
+            self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
+            self.addCurve(xplot,
+                          yplot,
+                          legend=newDataObject.info['legend'])
+
+    def _scanFitSignalReceived(self, ddict):
+        if DEBUG:
+            print("_scanFitSignalReceived", ddict)
+        if ddict['event'] == "EstimateFinished":
+            return
+        if ddict['event'] == "FitFinished":
+            newDataObject = self.__fitDataObject
+
+            xplot = self.scanFit.specfit.xdata * 1.0
+            yplot = self.scanFit.specfit.gendata(parameters=ddict['data'])
+            newDataObject.x = [xplot]
+            newDataObject.y = [yplot]
+            newDataObject.m = [numpy.ones(len(yplot)).astype(numpy.float)]
+
+            self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
+            self.addCurve(x=xplot, y=yplot, legend=newDataObject.info['legend'])
+
+    def _fitIconSignal(self):
+        if DEBUG:
+            print("_fitIconSignal")
+        self.fitButtonMenu.exec_(self.cursor().pos())
+
+    def _simpleFitSignal(self):
+        if DEBUG:
+            print("_simpleFitSignal")
+        self._QSimpleOperation("fit")
+
+    def _customFitSignal(self):
+        if DEBUG:
+            print("_customFitSignal")
+        self._QSimpleOperation("custom_fit")
+
+    def _saveIconSignal(self):
+        if DEBUG:
+            print("_saveIconSignal")
+        self._QSimpleOperation("save")
+
+    def _averageIconSignal(self):
+        if DEBUG:
+            print("_averageIconSignal")
+        self._QSimpleOperation("average")
+
+    def _smoothIconSignal(self):
+        if DEBUG:
+            print("_smoothIconSignal")
+        self._QSimpleOperation("smooth")
+
+    def _getOutputFileName(self):
+        #get outputfile
+        self.outputDir = PyMcaDirs.outputDir
+        if self.outputDir is None:
+            self.outputDir = os.getcwd()
+            wdir = os.getcwd()
+        elif os.path.exists(self.outputDir):
+            wdir = self.outputDir
+        else:
+            self.outputDir = os.getcwd()
+            wdir = self.outputDir
+
+        filterlist = ['Specfile MCA  *.mca',
+                      'Specfile Scan *.dat',
+                      'Specfile MultiScan *.dat',
+                      'Raw ASCII *.txt',
+                      '","-separated CSV *.csv',
+                      '";"-separated CSV *.csv',
+                      '"tab"-separated CSV *.csv',
+                      'OMNIC CSV *.csv',
+                      'Widget PNG *.png',
+                      'Widget JPG *.jpg',
+                      'Graphics PNG *.png',
+                      'Graphics EPS *.eps',
+                      'Graphics SVG *.svg']
+        fileList, fileFilter = PyMcaFileDialogs.getFileList(self,
+                                     filetypelist=filterlist,
+                                     message="Output File Selection",
+                                     currentdir=wdir,
+                                     single=True,
+                                     mode="SAVE",
+                                     getfilter=True,
+                                     currentfilter=self.outputFilter)
+        if not len(fileList):
+            return
+        filterused = fileFilter.split()
+        filetype = filterused[1]
+        extension = filterused[2]
+        outdir = qt.safe_str(fileList[0])
+        try:
+            self.outputDir  = os.path.dirname(outdir)
+            PyMcaDirs.outputDir = os.path.dirname(outdir)
+        except:
+            print("setting output directory to default")
+            self.outputDir  = os.getcwd()
+        try:
+            outputFile = os.path.basename(outdir)
+        except:
+            outputFile = outdir
+        if len(outputFile) < 5:
+            outputFile = outputFile + extension[-4:]
+        elif outputFile[-4:] != extension[-4:]:
+            outputFile = outputFile + extension[-4:]
+        return os.path.join(self.outputDir, outputFile), filetype, filterused
+
+    def _QSimpleOperation(self, operation):
+        try:
+            self._simpleOperation(operation)
+        except:
+            msg = qt.QMessageBox(self)
+            msg.setIcon(qt.QMessageBox.Critical)
+            msg.setInformativeText(str(sys.exc_info()[1]))
+            msg.setDetailedText(traceback.format_exc())
+            msg.exec_()
+
+    def _saveOperation(self, fileName, fileType, fileFilter):
+        filterused = fileFilter
+        filetype = fileType
+        filename = fileName
+        if os.path.exists(filename):
+            os.remove(filename)
+        if filterused[0].upper() == "WIDGET":
+            fformat = filename[-3:].upper()
+            pixmap = qt.QPixmap.grabWidget(self)
+            if not pixmap.save(filename, fformat):
+                qt.QMessageBox.critical(self,
+                                    "Save Error",
+                                    "%s" % sys.exc_info()[1])
+            return
+        try:
+            if filename[-3:].upper() in ['EPS', 'PNG', 'SVG']:
+                self.graphicsSave(filename)
+                return
+        except:
+            msg = qt.QMessageBox(self)
+            msg.setIcon(qt.QMessageBox.Critical)
+            msg.setText("Graphics Saving Error: %s" % (sys.exc_info()[1]))
+            msg.exec_()
+            return
+        systemline = os.linesep
+        os.linesep = '\n'
+        try:
+            if sys.version < "3.0":
+                ffile=open(filename, "wb")
+            else:
+                ffile=open(filename, "w", newline='')
+        except IOError:
+            msg = qt.QMessageBox(self)
+            msg.setIcon(qt.QMessageBox.Critical)
+            msg.setText("Input Output Error: %s" % (sys.exc_info()[1]))
+            msg.exec_()
+            return
+        x, y, legend, info = self.getActiveCurve()
+        xlabel = info.get("xlabel", "X")
+        ylabel = info.get("ylabel", "Y")
+        if 0:
+            if "selection" in info:
+                if type(info['selection']) == type({}):
+                    if 'x' in info['selection']:
+                        #proper scan selection
+                        ilabel = info['selection']['y'][0]
+                        ylegend = info['LabelNames'][ilabel]
+                        ylabel = ylegend
+                        if info['selection']['x'] is not None:
+                            if len(info['selection']['x']):
+                                xlabel = info['LabelNames'] [info['selection']['x'][0]]
+                            else:
+                                xlabel = "Point number"
+        try:
+            if filetype in ['Scan', 'MultiScan']:
+                ffile.write("#F %s\n" % filename)
+                savingDate = "#D %s\n"%(time.ctime(time.time()))
+                ffile.write(savingDate)
+                ffile.write("\n")
+                ffile.write("#S 1 %s\n" % legend)
+                ffile.write(savingDate)
+                ffile.write("#N 2\n")
+                ffile.write("#L %s  %s\n" % (xlabel, ylabel) )
+                for i in range(len(y)):
+                    ffile.write("%.7g  %.7g\n" % (x[i], y[i]))
+                ffile.write("\n")
+                if filetype == 'MultiScan':
+                    scan_n  = 1
+                    curveList = self.getAllCurves()
+                    for x, y, key, info in curveList:
+                        if key == legend:
+                            continue
+                        xlabel = info.get("xlabel", "X")
+                        ylabel = info.get("ylabel", "Y")
+                        if 0:
+                            if "selection" in info:
+                                if type(info['selection']) == type({}):
+                                    if 'x' in info['selection']:
+                                        #proper scan selection
+                                        ilabel = info['selection']['y'][0]
+                                        ylegend = info['LabelNames'][ilabel]
+                                        ylabel = ylegend
+                                        if info['selection']['x'] is not None:
+                                            if len(info['selection']['x']):
+                                                xlabel = info['LabelNames'] [info['selection']['x'][0]]
+                                            else:
+                                                xlabel = "Point number"
+                        scan_n += 1
+                        ffile.write("#S %d %s\n" % (scan_n, key))
+                        ffile.write(savingDate)
+                        ffile.write("#N 2\n")
+                        ffile.write("#L %s  %s\n" % (xlabel, ylabel) )
+                        for i in range(len(y)):
+                            ffile.write("%.7g  %.7g\n" % (x[i], y[i]))
+                        ffile.write("\n")
+            elif filetype == 'ASCII':
+                for i in range(len(y)):
+                    ffile.write("%.7g  %.7g\n" % (x[i], y[i]))
+            elif filetype == 'CSV':
+                if "," in filterused[0]:
+                    csvseparator = ","
+                elif ";" in filterused[0]:
+                    csvseparator = ";"
+                elif "OMNIC" in filterused[0]:
+                    csvseparator = ","
+                else:
+                    csvseparator = "\t"
+                if "OMNIC" not in filterused[0]:
+                    ffile.write('"%s"%s"%s"\n' % (xlabel,csvseparator,ylabel))
+                for i in range(len(y)):
+                    ffile.write("%.7E%s%.7E\n" % (x[i], csvseparator,y[i]))
+            else:
+                ffile.write("#F %s\n" % filename)
+                ffile.write("#D %s\n"%(time.ctime(time.time())))
+                ffile.write("\n")
+                ffile.write("#S 1 %s\n" % legend)
+                ffile.write("#D %s\n"%(time.ctime(time.time())))
+                ffile.write("#@MCA %16C\n")
+                ffile.write("#@CHANN %d %d %d 1\n" %  (len(y), x[0], x[-1]))
+                ffile.write("#@CALIB %.7g %.7g %.7g\n" % (0, 1, 0))
+                ffile.write(self.array2SpecMca(y))
+                ffile.write("\n")
+            ffile.close()
+            os.linesep = systemline
+        except:
+            os.linesep = systemline
+            raise
+        return
+
+
+    def _simpleOperation(self, operation):
+        if operation == 'subtract':
+            self._subtractOperation()
+            return
+        if operation == "save":
+            #getOutputFileName
+            filename = self._getOutputFileName()
+            if filename is None:
+                return
+            self._saveOperation(filename[0], filename[1], filename[2])
+            return
+        if operation != "average":
+            #get active curve
+            legend = self.getActiveCurveLegend()
+            if legend is None:return
+
+            found = False
+            for key in self.dataObjectsList:
+                if key == legend:
+                    found = True
+                    break
+
+            if found:
+                dataObject = self.dataObjectsDict[legend]
+            else:
+                print("I should not be here")
+                print("active curve =",legend)
+                print("but legend list = ",self.dataObjectsList)
+                return
+            y = dataObject.y[0]
+            if dataObject.x is not None:
+                x = dataObject.x[0]
+            else:
+                x = numpy.arange(len(y)).astype(numpy.float)
+            ilabel = dataObject.info['selection']['y'][0]
+            ylabel = dataObject.info['LabelNames'][ilabel]
+            if len(dataObject.info['selection']['x']):
+                ilabel = dataObject.info['selection']['x'][0]
+                xlabel = dataObject.info['LabelNames'][ilabel]
+            else:
+                xlabel = "Point Number"
+        else:
+            x = []
+            y = []
+            legend = ""
+            i = 0
+            ndata = 0
+            for key in self._curveList:
+                if DEBUG:
+                    print("key -> ", key)
+                if key in self.dataObjectsDict:
+                    x.append(self.dataObjectsDict[key].x[0]) #only the first X
+                    if len(self.dataObjectsDict[key].y) == 1:
+                        y.append(self.dataObjectsDict[key].y[0])
+                    else:
+                        sel_legend = self.dataObjectsDict[key].info['legend']
+                        ilabel = 0
+                        #I have to get the proper y associated to the legend
+                        if sel_legend in key:
+                            if key.index(sel_legend) == 0:
+                                label = key[len(sel_legend):]
+                                while (label.startswith(' ')):
+                                    label = label[1:]
+                                    if not len(label):
+                                        break
+                                if label in self.dataObjectsDict[key].info['LabelNames']:
+                                    ilabel = self.dataObjectsDict[key].info['LabelNames'].index(label)
+                                if DEBUG:
+                                    print("LABEL = ", label)
+                                    print("ilabel = ", ilabel)
+                        y.append(self.dataObjectsDict[key].y[ilabel])
+                    if i == 0:
+                        legend = key
+                        firstcurve = key
+                        i += 1
+                    else:
+                        legend += " + " + key
+                        lastcurve = key
+                    ndata += 1
+            if ndata == 0: return #nothing to average
+            dataObject = self.dataObjectsDict[firstcurve]
+
+        #create the output data object
+        newDataObject = DataObject.DataObject()
+        newDataObject.data = None
+        newDataObject.info = copy.deepcopy(dataObject.info)
+        if 'selectionlegend' in newDataObject.info:
+            del newDataObject.info['selectionlegend']
+        if not ('operations' in newDataObject.info):
+            newDataObject.info['operations'] = []
+        newDataObject.info['operations'].append(operation)
+
+        sel = {}
+        sel['SourceType'] = "Operation"
+        #get new x and new y
+        if operation == "derivate":
+            #xmin and xmax
+            xlimits=self.getGraphXLimits()
+            xplot, yplot = self.simpleMath.derivate(x, y, xlimits=xlimits)
+            ilabel = dataObject.info['selection']['y'][0]
+            ylabel = dataObject.info['LabelNames'][ilabel]
+            newDataObject.info['LabelNames'][ilabel] = ylabel+"'"
+            newDataObject.info['plot_yaxis'] = "right"
+            sel['SourceName'] = legend
+            sel['Key']    = "'"
+            sel['legend'] = legend + sel['Key']
+            outputlegend  = legend + sel['Key']
+        elif operation == "average":
+            xplot, yplot = self.simpleMath.average(x, y)
+            if len(legend) < 80:
+                sel['SourceName'] = legend
+                sel['Key']    = ""
+                sel['legend'] = "(%s)/%d" % (legend, ndata)
+                outputlegend  = "(%s)/%d" % (legend, ndata)
+            else:
+                sel['SourceName'] = legend
+                legend = "Average of %d from %s to %s" % (ndata, firstcurve, lastcurve)
+                sel['Key']    = ""
+                sel['legend'] = legend
+                outputlegend  = legend
+        elif operation == "swapsign":
+            xplot =  x * 1
+            yplot = -y
+            sel['SourceName'] = legend
+            sel['Key']    = ""
+            sel['legend'] = "-(%s)" % legend
+            outputlegend  = "-(%s)" % legend
+        elif operation == "smooth":
+            xplot =  x * 1
+            yplot = self.simpleMath.smooth(y)
+            sel['SourceName'] = legend
+            sel['Key']    = ""
+            sel['legend'] = "%s Smooth" % legend
+            outputlegend  = "%s Smooth" % legend
+            if 'operations' in dataObject.info:
+                if len(dataObject.info['operations']):
+                    if dataObject.info['operations'][-1] == "smooth":
+                        sel['legend'] = legend
+                        outputlegend  = legend
+        elif operation == "forceymintozero":
+            xplot =  x * 1
+            yplot =  y - min(y)
+            sel['SourceName'] = legend
+            sel['Key']    = ""
+            sel['legend'] = "(%s) - ymin" % legend
+            outputlegend  = "(%s) - ymin" % legend
+        elif operation == "fit":
+            #remove a existing fit if present
+            xmin,xmax=self.getGraphXLimits()
+            outputlegend = legend + " Fit"
+            for key in self._curveList:
+                if key == outputlegend:
+                    self.removeCurves([outputlegend], replot=False)
+                    break
+            self.scanFit.setData(x = x,
+                                 y = y,
+                                 xmin = xmin,
+                                 xmax = xmax,
+                                 legend = legend)
+            if self.scanFit.isHidden():
+                self.scanFit.show()
+            self.scanFit.raise_()
+        elif operation == "custom_fit":
+            #remove a existing fit if present
+            xmin, xmax=self.getGraphXLimits()
+            outputlegend = legend + "Custom Fit"
+            keyList = list(self._curveList)
+            for key in keyList:
+                if key == outputlegend:
+                    self.removeCurves([outputlegend], replot=False)
+                    break
+            self.customFit.setData(x = x,
+                                   y = y,
+                                   xmin = xmin,
+                                   xmax = xmax,
+                                   legend = legend)
+            if self.customFit.isHidden():
+                self.customFit.show()
+            self.customFit.raise_()
+        else:
+            raise ValueError("Unknown operation %s" % operation)
+        if operation not in ["fit", "custom_fit"]:
+            newDataObject.x = [xplot]
+            newDataObject.y = [yplot]
+            newDataObject.m = [numpy.ones(len(yplot)).astype(numpy.float)]
+
+        #and add it to the plot
+        if True and (operation not in ['fit', 'custom_fit']):
+            sel['dataobject'] = newDataObject
+            sel['scanselection'] = True
+            sel['selection'] = copy.deepcopy(dataObject.info['selection'])
+            sel['selectiontype'] = "1D"
+            if operation == 'average':
+                self._replaceSelection([sel])
+            elif operation != 'fit':
+                self._addSelection([sel])
+            else:
+                self.__fitDataObject = newDataObject
+                return
+        else:
+            newDataObject.info['legend'] = outputlegend
+            if operation == 'fit':
+                self.__fitDataObject = newDataObject
+                return
+            if operation == 'custom_fit':
+                self.__customFitDataObject = newDataObject
+                return
+
+            self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
+            #here I should check the log or linear status
+            self.addCurve(x=xplot, y=yplot, legend=newDataObject.info['legend'], replot=False)
+        self.replot()
+
+    def graphicsSave(self, filename):
+        #use the plugin interface
+        x, y, legend, info = self.getActiveCurve()[:4]
+        curveList = self.getAllCurves()
+        size = (6, 3) #in inches
+        bw = False
+        if len(curveList) > 1:
+            legends = True
+        else:
+            legends = False
+        if self.matplotlibDialog is None:
+            self.matplotlibDialog = QPyMcaMatplotlibSave1D.\
+                                    QPyMcaMatplotlibSaveDialog(size=size,
+                                                        logx=self._logX,
+                                                        logy=self._logY,
+                                                        legends=legends,
+                                                        bw = bw)
+        mtplt = self.matplotlibDialog.plot
+        mtplt.setParameters({'logy':self._logY,
+                             'logx':self._logX,
+                             'legends':legends,
+                             'bw':bw})
+        xmin, xmax = self.getGraphXLimits()
+        ymin, ymax = self.getGraphYLimits()
+        mtplt.setLimits(xmin, xmax, ymin, ymax)
+
+        legend0 = legend
+        xdata = x
+        ydata = y
+        dataCounter = 1
+        alias = "%c" % (96+dataCounter)
+        mtplt.addDataToPlot( xdata, ydata, legend=legend0, alias=alias )
+        for curve in curveList:
+            xdata, ydata, legend, info = curve[0:4]
+            if legend == legend0:
+                continue
+            dataCounter += 1
+            alias = "%c" % (96+dataCounter)
+            mtplt.addDataToPlot( xdata, ydata, legend=legend, alias=alias )
+
+        if sys.version < '3.0':
+            self.matplotlibDialog.setXLabel(qt.safe_str(self.getGraphXLabel()))
+            self.matplotlibDialog.setYLabel(qt.safe_str(self.getGraphYLabel()))
+        else:
+            self.matplotlibDialog.setXLabel(self.getGraphXLabel())
+            self.matplotlibDialog.setYLabel(self.getGraphYLabel())
+
+        if legends:
+            mtplt.plotLegends()
+        ret = self.matplotlibDialog.exec_()
+        if ret == qt.QDialog.Accepted:
+            mtplt.saveFile(filename)
+        return
+
+    def getActiveCurveLegend(self):
+        return super(ScanWindow,self).getActiveCurve(just_legend=True)
+
+    def _deriveIconSignal(self):
+        if DEBUG:
+            print("_deriveIconSignal")
+        self._QSimpleOperation('derivate')
+
+    def _swapSignIconSignal(self):
+        if DEBUG:
+            print("_swapSignIconSignal")
+        self._QSimpleOperation('swapsign')
+
+    def _yMinToZeroIconSignal(self):
+        if DEBUG:
+            print("_yMinToZeroIconSignal")
+        self._QSimpleOperation('forceymintozero')
+
+    def _subtractIconSignal(self):
+        if DEBUG:
+            print("_subtractIconSignal")
+        self._QSimpleOperation('subtract')
+
+    def _subtractOperation(self):
+        #identical to twice the average with the negative active curve
+        #get active curve
+        legend = self.getActiveCurveLegend()
+        if legend is None:
+            return
+
+        found = False
+        for key in self.dataObjectsList:
+            if key == legend:
+                found = True
+                break
+
+        if found:
+            dataObject = self.dataObjectsDict[legend]
+        else:
+            print("I should not be here")
+            print("active curve =",legend)
+            print("but legend list = ",self.dataObjectsList)
+            return
+        x = dataObject.x[0]
+        y = dataObject.y[0]
+        ilabel = dataObject.info['selection']['y'][0]
+        ylabel = dataObject.info['LabelNames'][ilabel]
+        if len(dataObject.info['selection']['x']):
+            ilabel = dataObject.info['selection']['x'][0]
+            xlabel = dataObject.info['LabelNames'][ilabel]
+        else:
+            xlabel = "Point Number"
+
+        xActive = x
+        yActive = y
+        yActiveLegend = legend
+        yActiveLabel  = ylabel
+        xActiveLabel  = xlabel
+
+        operation = "subtract"
+        sel_list = []
+        i = 0
+        ndata = 0
+        keyList = list(self._curveList)
+        for key in keyList:
+            legend = ""
+            x = [xActive]
+            y = [-yActive]
+            if DEBUG:
+                print("key -> ", key)
+            if key in self.dataObjectsDict:
+                x.append(self.dataObjectsDict[key].x[0]) #only the first X
+                if len(self.dataObjectsDict[key].y) == 1:
+                    y.append(self.dataObjectsDict[key].y[0])
+                    ilabel = self.dataObjectsDict[key].info['selection']['y'][0]
+                else:
+                    sel_legend = self.dataObjectsDict[key].info['legend']
+                    ilabel = self.dataObjectsDict[key].info['selection']['y'][0]
+                    #I have to get the proper y associated to the legend
+                    if sel_legend in key:
+                        if key.index(sel_legend) == 0:
+                            label = key[len(sel_legend):]
+                            while (label.startswith(' ')):
+                                label = label[1:]
+                                if not len(label):
+                                    break
+                            if label in self.dataObjectsDict[key].info['LabelNames']:
+                                ilabel = self.dataObjectsDict[key].info['LabelNames'].index(label)
+                            if DEBUG:
+                                print("LABEL = ", label)
+                                print("ilabel = ", ilabel)
+                    y.append(self.dataObjectsDict[key].y[ilabel])
+                outputlegend = "(%s - %s)" %  (key, yActiveLegend)
+                ndata += 1
+                xplot, yplot = self.simpleMath.average(x, y)
+                yplot *= 2
+                #create the output data object
+                newDataObject = DataObject.DataObject()
+                newDataObject.data = None
+                newDataObject.info.update(self.dataObjectsDict[key].info)
+                if not ('operations' in newDataObject.info):
+                    newDataObject.info['operations'] = []
+                newDataObject.info['operations'].append(operation)
+                newDataObject.info['LabelNames'][ilabel] = "(%s - %s)" %  \
+                                        (newDataObject.info['LabelNames'][ilabel], yActiveLabel)
+                newDataObject.x = [xplot]
+                newDataObject.y = [yplot]
+                newDataObject.m = None
+                sel = {}
+                sel['SourceType'] = "Operation"
+                sel['SourceName'] = key
+                sel['Key']    = ""
+                sel['legend'] = outputlegend
+                sel['dataobject'] = newDataObject
+                sel['scanselection'] = True
+                sel['selection'] = copy.deepcopy(dataObject.info['selection'])
+                #sel['selection']['y'] = [ilabel]
+                sel['selectiontype'] = "1D"
+                sel_list.append(sel)
+        if True:
+            #The legend menu was not working with the next line
+            #but if works if I add the list
+            self._replaceSelection(sel_list)
+        else:
+            oldlist = list(self.dataObjectsDict)
+            self._addSelection(sel_list)
+            self.removeCurves(oldlist)
+
+    #The plugins interface
+    def getGraphYLimits(self):
+        #if the active curve is mapped to second axis
+        #I should give the second axis limits
+        return super(ScanWindow, self).getGraphYLimits()
+
+    #end of plugins interface
+    def addCurve(self, x, y, legend=None, info=None, replace=False, replot=True,
+                 color=None, symbol=None, linestyle=None,
+                 xlabel=None, ylabel=None, yaxis=None,
+                 xerror=None, yerror=None, **kw):
+        if legend in self._curveList:
+            if info is None:
+                info = {}
+            oldStuff = self.getCurve(legend)
+            if len(oldStuff):
+                oldX, oldY, oldLegend, oldInfo = oldStuff
+            else:
+                oldInfo = {}
+            if color is None:
+                color = info.get("plot_color", oldInfo.get("plot_color", None))
+            if symbol is None:
+                symbol =  info.get("plot_symbol",oldInfo.get("plot_symbol", None))
+            if linestyle is None:
+                linestyle =  info.get("plot_linestyle",oldInfo.get("plot_linestyle", None))
+            if yaxis is None:
+                yaxis =  info.get("plot_yaxis",oldInfo.get("plot_yaxis", None))
+        else:
+            if info is None:
+                info = {}
+            if color is None:
+                color = info.get("plot_color", None)
+            if symbol is None:
+                symbol =  info.get("plot_symbol", None)
+            if linestyle is None:
+                linestyle =  info.get("plot_linestyle", None)
+            if yaxis is None:
+                yaxis =  info.get("plot_yaxis", None)
+        if legend in self.dataObjectsDict:
+            # the info is changing
+            super(ScanWindow, self).addCurve(x, y, legend=legend, info=info,
+                                replace=replace, replot=replot, color=color, symbol=symbol,
+                                linestyle=linestyle, xlabel=xlabel, ylabel=ylabel, yaxis=yaxis,
+                                xerror=xerror, yerror=yerror, **kw)
+        else:
+            # create the data object
+            self.newCurve(x, y, legend=legend, info=info,
+                                replace=replace, replot=replot, color=color, symbol=symbol,
+                                linestyle=linestyle, xlabel=xlabel, ylabel=ylabel, yaxis=yaxis,
+                                xerror=xerror, yerror=yerror, **kw)
+
+    def newCurve(self, x, y, legend=None, info=None, replace=False, replot=True,
+                 color=None, symbol=None, linestyle=None,
+                 xlabel=None, ylabel=None, yaxis=None,
+                 xerror=None, yerror=None, **kw):
+        if legend is None:
+            legend = "Unnamed curve 1.1"
+        if xlabel is None:
+            xlabel = "X"
+        if ylabel is None:
+            ylabel = "Y"
+        if info is None:
+            info = {}
+            # this is awfull but I have no other way to pass the plot information ...
+        if color is not None:
+            info["plot_color"] = color
+        if symbol is not None:
+            info["plot_symbol"] = symbol
+        if linestyle is not None:
+            info["plot_linestyle"] = linestyle
+        if yaxis is not None:
+            info["plot_yaxis"] = yaxis
+
+        newDataObject = DataObject.DataObject()
+        newDataObject.x = [x]
+        newDataObject.y = [y]
+        newDataObject.m = None
+        newDataObject.info = copy.deepcopy(info)
+        newDataObject.info['legend'] = legend
+        newDataObject.info['SourceName'] = legend
+        newDataObject.info['Key'] = ""
+        newDataObject.info['selectiontype'] = "1D"
+        newDataObject.info['LabelNames'] = [xlabel, ylabel]
+        newDataObject.info['selection'] = {'x':[0], 'y':[1]}
+        sel_list = []
+        sel = {}
+        sel['SourceType'] = "Operation"
+        sel['SourceName'] = legend
+        sel['Key']    = ""
+        sel['legend'] = legend
+        sel['dataobject'] = newDataObject
+        sel['scanselection'] = True
+        sel['selection'] = {'x':[0], 'y':[1], 'm':[], 'cntlist':[xlabel, ylabel]}
+        #sel['selection']['y'] = [ilabel]
+        sel['selectiontype'] = "1D"
+        sel_list.append(sel)
+        if replace:
+            self._replaceSelection(sel_list)
+        else:
+            self._addSelection(sel_list, replot=replot)
+
+    def printGraph(self):
+        if self.printPreview.printer is None:
+            # setup needed
+            self.printPreview.setup()
+        self._printer = self.printPreview.printer
+        if self._printer is None:
+            # printer was not selected
+            return
+        #self._printer = None
+        if PlotWindow.PlotWidget.SVG:
+            svg = True
+            self._svgRenderer = self.getSvgRenderer()
+        else:
+            svg = False
+            if hasattr(self, "getWidgetHandle"):
+                widget = self.getWidgetHandle()
+            else:
+                widget = self.centralWidget()
+            if hasattr(widget, "grab"):
+                pixmap = widget.grab()
+            else:
+                pixmap = qt.QPixmap.grabWidget(widget)
+
+        title = None
+        comment = None
+        if self.scanWindowInfoWidget is not None:
+            if not self.infoDockWidget.isHidden():
+                info = self.scanWindowInfoWidget.getInfo()
+                title = info['scan'].get('source', None)
+                comment = info['scan'].get('scan', None)+"\n"
+                h, k, l = info['scan'].get('hkl')
+                if h != "----":
+                    comment += "H = %s  K = %s  L = %s\n" % (h, k, l)
+                peak   = info['graph']['peak']
+                peakAt = info['graph']['peakat']
+                fwhm   = info['graph']['fwhm']
+                fwhmAt = info['graph']['fwhmat']
+                com    = info['graph']['com']
+                mean   = info['graph']['mean']
+                std    = info['graph']['std']
+                minimum = info['graph']['min']
+                maximum = info['graph']['max']
+                delta   = info['graph']['delta']
+                xLabel = self.getGraphXLabel()
+                comment += "Peak %s at %s = %s\n" % (peak, xLabel, peakAt)
+                comment += "FWHM %s at %s = %s\n" % (fwhm, xLabel, fwhmAt)
+                comment += "COM = %s  Mean = %s  STD = %s\n" % (com, mean, std)
+                comment += "Min = %s  Max = %s  Delta = %s\n" % (minimum,
+                                                                maximum,
+                                                                delta)
+
+        if hasattr(self, "scanFit"):
+            if not self.scanFit.isHidden():
+                if comment is None:
+                    comment = ""
+                comment += "\n"
+                comment += self.scanFit.getText()
+
+        if svg:
+            self.printPreview.addSvgItem(self._svgRenderer,
+                                    title=None,
+                                    comment=comment,
+                                    commentPosition="LEFT")
+        else:
+            self.printPreview.addPixmap(pixmap,
+                                    title=None,
+                                    comment=comment,
+                                    commentPosition="LEFT")
+        if self.printPreview.isHidden():
+            self.printPreview.show()
+        self.printPreview.raise_()
+
+    def getSvgRenderer(self, printer=None):
+        if printer is None:
+            if self.printPreview.printer is None:
+                # setup needed
+                self.printPreview.setup()
+            self._printer = self.printPreview.printer
+            printer = self._printer
+        if printer is None:
+            # printer was not selected
+            # return a renderer without adjusting the viewbox
+            if sys.version < '3.0':
+                import cStringIO as StringIO
+                imgData = StringIO.StringIO()
+            else:
+                from io import StringIO
+                imgData = StringIO()
+            self.saveGraph(imgData, fileFormat='svg')
+            imgData.flush()
+            imgData.seek(0)
+            svgData = imgData.read()
+            imgData = None
+            svgRenderer = qt.QSvgRenderer()
+            svgRenderer._svgRawData = svgData
+            svgRenderer._svgRendererData = qt.QXmlStreamReader(svgData)
+            if not svgRenderer.load(svgRenderer._svgRendererData):
+                raise RuntimeError("Cannot interpret svg data")
+            return svgRenderer
+
+        # we have what is to be printed
+        if sys.version < '3.0':
+            import cStringIO as StringIO
+            imgData = StringIO.StringIO()
+        else:
+            from io import StringIO
+            imgData = StringIO()
+        self.saveGraph(imgData, fileFormat='svg')
+        imgData.flush()
+        imgData.seek(0)
+        svgData = imgData.read()
+        imgData = None
+        svgRenderer = qt.QSvgRenderer()
+
+        #svgRenderer = PlotWindow.PlotWindow.getSvgRenderer(self)
+
+        # we have to specify the bounding box
+        config = self.getPrintConfiguration()
+        width = config['width']
+        height = config['height']
+        xOffset = config['xOffset']
+        yOffset = config['yOffset']
+        units = config['units']
+        keepAspectRatio = config['keepAspectRatio']
+
+
+        dpix    = printer.logicalDpiX()
+        dpiy    = printer.logicalDpiY()
+
+        # get the available space
+        availableWidth = printer.width()
+        availableHeight = printer.height()
+
+        # convert the offsets to dpi
+        if units.lower() in ['inch', 'inches']:
+            xOffset = xOffset * dpix
+            yOffset = yOffset * dpiy
+            if width is not None:
+                width = width * dpix
+            if height is not None:
+                height = height * dpiy
+        elif units.lower() in ['cm', 'centimeters']:
+            xOffset = (xOffset/2.54) * dpix
+            yOffset = (yOffset/2.54) * dpiy
+            if width is not None:
+                width = (width/2.54) * dpix
+            if height is not None:
+                height = (height/2.54) * dpiy
+        else:
+            # page units
+            xOffset = availableWidth * xOffset
+            yOffset = availableHeight * yOffset
+            if width is not None:
+                width = availableWidth * width
+            if height is not None:
+                height = availableHeight * height
+
+        availableWidth -= xOffset
+        availableHeight -= yOffset
+
+        if width is not None:
+            if (availableWidth + 0.1) < width:
+                txt = "Available width  %f is less than requested width %f" % \
+                              (availableWidth, width)
+                raise ValueError(txt)
+            availableWidth = width
+        if height is not None:
+            if (availableHeight + 0.1) < height:
+                txt = "Available height  %f is less than requested height %f" % \
+                              (availableHeight, height)
+                raise ValueError(txt)
+            availableHeight = height
+
+        if keepAspectRatio:
+            #get the aspect ratio
+            widget = self.getWidgetHandle()
+            if widget is None:
+                # does this make sense?
+                graphWidth = availableWidth
+                graphHeight = availableHeight
+            else:
+                graphWidth = float(widget.width())
+                graphHeight = float(widget.height())
+
+            graphRatio = graphHeight / graphWidth
+            # that ratio has to be respected
+
+            bodyWidth = availableWidth
+            bodyHeight = availableWidth * graphRatio
+
+            if bodyHeight > availableHeight:
+                bodyHeight = availableHeight
+                bodyWidth = bodyHeight / graphRatio
+        else:
+            bodyWidth = availableWidth
+            bodyHeight = availableHeight
+
+        body = qt.QRectF(xOffset,
+                         yOffset,
+                         bodyWidth,
+                         bodyHeight)
+        # this does not work if I set the svgData before
+        svgRenderer.setViewBox(body)
+        svgRenderer._viewBox = body
+        if not sys.version.startswith("2"):
+            svgData = svgData.encode(encoding="utf-8",
+                                     errors="replace")
+        svgRenderer._svgRawData = svgData
+        svgRenderer._svgRendererData = qt.QXmlStreamReader(svgData)
+
+        if not svgRenderer.load(svgRenderer._svgRendererData):
+            raise RuntimeError("Cannot interpret svg data")
+        return svgRenderer
+
+def test():
+    w = ScanWindow()
+    x = numpy.arange(1000.)
+    y =  10 * x + 10000. * numpy.exp(-0.5*(x-500)*(x-500)/400)
+    w.addCurve(x, y, legend="dummy", replot=True, replace=True)
+    w.resetZoom()
+    app.lastWindowClosed.connect(app.quit)
+    w.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    test()

--- a/PyMca5/PyMcaGui/pymca/McaWindow.py
+++ b/PyMca5/PyMcaGui/pymca/McaWindow.py
@@ -45,7 +45,7 @@ import copy
 
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaGui import IconDict
-from . import ScanWindow
+from . import LegacyScanWindow     # TODO: fix McaWindow to use new silx based ScanWindow
 from . import McaCalibrationControlGUI
 from PyMca5.PyMcaIO import ConfigDict
 from PyMca5.PyMcaGui import McaAdvancedFit
@@ -68,11 +68,11 @@ except:
     #not a big problem
     pass
 DEBUG = 0
-class McaWindow(ScanWindow.ScanWindow):
+class McaWindow(LegacyScanWindow.ScanWindow):
     def __init__(self, parent=None, name="Mca Window", specfit=None, backend=None,
                  plugins=True, newplot=False, roi=True, fit=True, **kw):
 
-        ScanWindow.ScanWindow.__init__(self, parent,
+        LegacyScanWindow.ScanWindow.__init__(self, parent,
                                          name=name,
                                          newplot=newplot,
                                          plugins=plugins,

--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -267,7 +267,7 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
                 self.mcaWindow = McaWindow.McaWindow(backend=backend)
                 self.scanWindow = ScanWindow.ScanWindow(info=True,
                                                         backend=backend)
-                self.scanWindow._togglePointsSignal()
+                self.scanWindow.getCurveStyleAction().trigger()
                 if OBJECT3D:
                     self.glWindow = SceneGLWindow.SceneGLWindow()
                 self.mainTabWidget.addTab(self.mcaWindow, "MCA")

--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -333,7 +333,7 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
                      self._startupSelection(source=kw['spec'],
                                                 selection=None)
 
-    def connectDispatcher(self, viewer, dispatcher = None):
+    def connectDispatcher(self, viewer, dispatcher=None):
         #I could connect sourceWidget to myself and then
         #pass the selections to the active window!!
         #That will be made in a next iteration I guess
@@ -446,13 +446,15 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
                 except:
                     pass
                 if hkl:
-                    imageWindow = PyMcaHKLImageWindow.PyMcaHKLImageWindow(name = legend,
-                                correlator = self.imageWindowCorrelator,
-                                scanwindow=self.scanWindow)
+                    imageWindow = PyMcaHKLImageWindow.PyMcaHKLImageWindow(
+                            name=legend,
+                            correlator=self.imageWindowCorrelator,
+                            scanwindow=self.scanWindow)
                 else:
-                    imageWindow = PyMcaImageWindow.PyMcaImageWindow(name = legend,
-                                correlator = self.imageWindowCorrelator,
-                                scanwindow=self.scanWindow)
+                    imageWindow = PyMcaImageWindow.PyMcaImageWindow(
+                            name=legend,
+                            correlator=self.imageWindowCorrelator,
+                            scanwindow=self.scanWindow)
                 self.imageWindowDict[legend] = imageWindow
 
                 imageWindow.sigAddImageClicked.connect( \
@@ -1348,8 +1350,10 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
             self.saveMenu.addAction("Active Mca",
                              self.mcaWindow._saveIconSignal)
         elif text.upper() == 'SCAN':
-            self.saveMenu.addAction("Active Scan",
-                             self.scanWindow._saveIconSignal)
+            self.saveMenu.addAction(
+                    "Active Scan",
+                    self.scanWindow.getSaveAction().trigger)
+
         elif text in self.imageWindowDict.keys():
             self.saveMenu.addAction("Active Image",
                   self.imageWindowDict[text].graphWidget._saveIconSignal)

--- a/PyMca5/PyMcaGui/pymca/ScanFitToolButton.py
+++ b/PyMca5/PyMcaGui/pymca/ScanFitToolButton.py
@@ -1,0 +1,156 @@
+#/*##########################################################################
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""This module defines a QToolButton opening a fit menu when clicked:
+
+    - :class:`ScanFitToolButton`
+
+This button takes a plot object as constructor parameter.
+"""
+
+
+import silx.gui.icons
+
+from PyMca5.PyMcaGui import PyMcaQt as qt
+from PyMca5.PyMcaGui.math.fitting import SimpleFitGui
+from PyMca5.PyMcaGui.pymca import ScanFit
+
+
+if hasattr(qt, 'QString'):
+    QString = qt.QString
+else:
+    QString = qt.safe_str
+
+
+class ScanFitToolButton(qt.QToolButton):
+    def __init__(self, plot, parent=None):
+        """QAction offering a menu with two fit options: simple fit
+        and custom fit.
+
+        :param plot: :class:`ScanWindow` instance on which to operate
+        :param parent: Parent QObject. If parent is an action group the action
+            will be automatically inserted into the group.
+        """
+        qt.QToolButton.__init__(self, parent)
+        self.setIcon(silx.gui.icons.getQIcon('math-fit'))
+        self.setToolTip("Fit of Active Curve")
+        self.clicked.connect(self._buttonClicked)
+
+        self.plot = plot
+
+        if not hasattr(self.plot, "scanFit"):
+            self.scanFit = ScanFit.ScanFit()
+        else:
+            # ScanWindow can define a customized scanFit with custom fit functions
+            self.scanFit = self.plot.scanFit
+        self.scanFit.sigScanFitSignal.connect(
+                self._scanFitSignalReceived)
+
+        self.customFit = SimpleFitGui.SimpleFitGui()
+        self.customFit.sigSimpleFitSignal.connect(
+                self._customFitSignalReceived)
+
+        self.fitButtonMenu = qt.QMenu()
+        self.fitButtonMenu.addAction(
+                QString("Simple Fit"),
+                self._scanFitSignal)
+        self.fitButtonMenu.addAction(
+                QString("Customized Fit"),
+                self._customFitSignal)
+
+        self._scanFitLegend = None
+        self._customFitLegend = None
+
+    def _buttonClicked(self):
+        """Display a menu to select simple fit or custom fit.
+
+        Selecting simple fit calls :meth:`_scanFitSignal`.
+        Selecting customized fit calls :meth:`_customFitSignal`.
+        """
+        self.fitButtonMenu.exec_(self.plot.cursor().pos())
+
+    def _getOneCurve(self):
+        """Return active curve if any. Else return first curve, if any.
+        Else return None
+        :return: [x, y, legend, info, params] or None"""
+        curve = self.plot.getActiveCurve()
+        if curve is None:
+            curves = self.plot.getAllCurves()
+            if len(curves):
+                curve = curves[0]
+        return curve
+
+    def _showFitWidget(self):
+        """Initialize fit dialog widget and raise it.
+
+        :attr:`_activeFitDialog` must be set to :attr:`scanFit` or
+        :attr:`customFit` before this method is called.
+        """
+        curve = self._getOneCurve()
+        if curve is None:
+            return
+        x, y, legend, info, params = curve
+
+        xmin, xmax = self.plot.getGraphXLimits()
+
+        fitLegend = legend + " Fit"
+        if fitLegend in self.plot.getAllCurves(just_legend=True):
+                self.plot.removeCurve(fitLegend)
+
+        if self._activeFitDialog is self.scanFit:
+            self._scanFitLegend = fitLegend
+        elif self._activeFitDialog is self.customFit:
+            self._customFitLegend = fitLegend
+
+        self._activeFitDialog.setData(x=x,
+                                      y=y,
+                                      xmin=xmin,
+                                      xmax=xmax,
+                                      legend=legend)
+        if self._activeFitDialog.isHidden():
+            self._activeFitDialog.show()
+        self._activeFitDialog.raise_()
+
+    def _scanFitSignal(self):
+        self._activeFitDialog = self.scanFit
+        self._showFitWidget()
+
+    def _customFitSignal(self):
+        self._activeFitDialog = self.customFit
+        self._showFitWidget()
+
+    def _scanFitSignalReceived(self, ddict):
+        if ddict['event'] == "FitFinished":
+            xplot = self.scanFit.specfit.xdata * 1.0
+            yplot = self.scanFit.specfit.gendata(parameters=ddict['data'])
+
+            self.plot.addCurve(x=xplot, y=yplot, legend=self._scanFitLegend)
+
+    def _customFitSignalReceived(self, ddict):
+        if ddict['event'] == "FitFinished":
+            xplot = ddict['x']
+            yplot = ddict['yfit']
+
+            self.plot.addCurve(xplot, yplot, legend=self._customFitLegend)

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -222,6 +222,8 @@ class ScanWindow(BaseScanWindow):
 
         self.dataObjectsDict = {}
 
+        self.sigContentChanged.connect(self._handleContentChanged)
+
     @property
     def dataObjectsList(self):
         return self.getAllCurves(just_legend=True)
@@ -229,6 +231,10 @@ class ScanWindow(BaseScanWindow):
     @property
     def _curveList(self):
         return self.getAllCurves(just_legend=True)
+
+    def _handleContentChanged(self, action, kind, legend):
+        if action == 'remove' and kind == "curve":
+            self.removeCurves([legend])
 
     def setDispatcher(self, w):
         w.sigAddSelection.connect(self._addSelection)

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -23,245 +23,236 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
-__contact__ = "sole@esrf.fr"
-__license__ = "MIT"
-__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-import sys
+"""This module defines a :class:`ScanWindow` inheriting a *silx*
+:class:`PlotWindow` with additional tools and actions.
+The main addition is a :class:`PluginsToolButton` button added to the toolbar,
+to open a menu with plugins."""
+
 import os
+import copy
+import logging
 import numpy
-#from numpy import argsort, nonzero, take
-import time
-import traceback
+
+from silx.gui.plot import PlotWindow
+
+import PyMca5
+from PyMca5.PyMcaGui.pymca import ScanWindowInfoWidget
 from PyMca5.PyMcaGui import PyMcaQt as qt
+from PyMca5.PyMcaGui.PluginsToolButton import PluginsToolButton
+from PyMca5.PyMcaGui.math import SimpleActions
+from PyMca5.PyMcaGui.pymca import ScanFit
+from PyMca5.PyMcaGui.pymca.ScanFitToolButton import ScanFitToolButton
+from PyMca5.PyMcaCore import DataObject
+
+
 if hasattr(qt, 'QString'):
     QString = qt.QString
 else:
     QString = qt.safe_str
-if __name__ == "__main__":
-    app = qt.QApplication([])
-
-from PyMca5.PyMcaGui.io import PyMcaFileDialogs
-from PyMca5.PyMcaGui.plotting import PlotWindow
-from . import ScanFit
-from PyMca5.PyMcaMath import SimpleMath
-from PyMca5.PyMcaCore import DataObject
-import copy
-from PyMca5.PyMcaGui import PyMcaPrintPreview
-from PyMca5.PyMcaCore import PyMcaDirs
-from . import ScanWindowInfoWidget
-#implement the plugins interface
-from PyMca5.PyMcaGui import QPyMcaMatplotlibSave1D
-MATPLOTLIB = True
-#force understanding of utf-8 encoding
-#otherways it cannot generate svg output
-try:
-    import encodings.utf_8
-except:
-    #not a big problem
-    pass
 
 PLUGINS_DIR = None
-try:
-    import PyMca5
-    if os.path.exists(os.path.join(os.path.dirname(PyMca5.__file__), "PyMcaPlugins")):
-        from PyMca5 import PyMcaPlugins
-        PLUGINS_DIR = os.path.dirname(PyMcaPlugins.__file__)
+
+if os.path.exists(os.path.join(os.path.dirname(PyMca5.__file__), "PyMcaPlugins")):
+    from PyMca5 import PyMcaPlugins
+    PLUGINS_DIR = os.path.dirname(PyMcaPlugins.__file__)
+else:
+    directory = os.path.dirname(__file__)
+    while True:
+        if os.path.exists(os.path.join(directory, "PyMcaPlugins")):
+            PLUGINS_DIR = os.path.join(directory, "PyMcaPlugins")
+            break
+        directory = os.path.dirname(directory)
+        if len(directory) < 5:
+            break
+userPluginsDirectory = PyMca5.getDefaultUserPluginsDirectory()
+if userPluginsDirectory is not None:
+    if PLUGINS_DIR is None:
+        PLUGINS_DIR = userPluginsDirectory
     else:
-        directory = os.path.dirname(__file__)
-        while True:
-            if os.path.exists(os.path.join(directory, "PyMcaPlugins")):
-                PLUGINS_DIR = os.path.join(directory, "PyMcaPlugins")
-                break
-            directory = os.path.dirname(directory)
-            if len(directory) < 5:
-                break
-    userPluginsDirectory = PyMca5.getDefaultUserPluginsDirectory()
-    if userPluginsDirectory is not None:
-        if PLUGINS_DIR is None:
-            PLUGINS_DIR = userPluginsDirectory
-        else:
-            PLUGINS_DIR = [PLUGINS_DIR, userPluginsDirectory]
-except:
-    pass
+        PLUGINS_DIR = [PLUGINS_DIR, userPluginsDirectory]
 
-DEBUG = 0
 
-class ScanWindow(PlotWindow.PlotWindow):
-    def __init__(self, parent=None, name="Scan Window", specfit=None, backend=None,
-                 plugins=True, newplot=True, roi=True, fit=True,
-                 control=True, position=True, info=False, **kw):
+_logger = logging.getLogger(__name__)
+_logger.setLevel(logging.DEBUG)
 
-        super(ScanWindow, self).__init__(parent,
-                                         newplot=newplot,
-                                         plugins=plugins,
-                                         backend=backend,
-                                         roi=roi,
-                                         fit=fit,
-                                         control=control,
-                                         position=position,
-                                         **kw)
+
+class BaseScanWindow(PlotWindow):
+    """:class:`PlotWindow` augmented with plugins, fitting actions,
+    a widget for displaying scan metadata and simple curve processing actions.
+    """
+    def __init__(self, parent=None, name="Scan Window", fit=True, backend=None,
+                 plugins=True, control=True, position=True, roi=True,
+                 specfit=None, info=False):
+        super(BaseScanWindow, self).__init__(parent,
+                                             backend=backend,
+                                             roi=roi,
+                                             control=control,
+                                             position=position,
+                                             mask=False,
+                                             colormap=False)
         self.setDataMargins(0, 0, 0.025, 0.025)
-        #self._togglePointsSignal()
         self.setPanWithArrowKeys(True)
-        self.setWindowType("SCAN")
-        # this two objects are the same
-        self.dataObjectsList = self._curveList
-        # but this is tricky
-        self.dataObjectsDict = {}
+        self._plotType = "SCAN"     # needed by legacy plugins
 
         self.setWindowTitle(name)
-        self.matplotlibDialog = None
 
-        if PLUGINS_DIR is not None:
-            if type(PLUGINS_DIR) == type([]):
-                pluginDir = PLUGINS_DIR
-            else:
-                pluginDir = [PLUGINS_DIR]
-            self.getPlugins(method="getPlugin1DInstance",
-                            directoryList=pluginDir)
+        # Toolbar
+        # self.toolBar().setIconSize(qt.QSize(15, 18))
+        self._toolbar = qt.QToolBar(self)
+        # self._toolbar.setIconSize(qt.QSize(15, 18))
 
+        self.addToolBar(self._toolbar)
+
+        if fit:
+            # attr needed by scanFitToolButton
+            self.scanFit = ScanFit.ScanFit(specfit=specfit)
+            scanFitToolButton = ScanFitToolButton(self)
+            self._toolbar.addWidget(scanFitToolButton)
+
+        self.avgAction = SimpleActions.AverageAction(plot=self)
+        self.derivativeAction = SimpleActions.DerivativeAction(plot=self)
+        self.smoothAction = SimpleActions.SmoothAction(plot=self)
+        self.swapSignAction = SimpleActions.SwapSignAction(plot=self)
+        self.yMinToZero = SimpleActions.YMinToZeroAction(plot=self)
+        self.subtractAction = SimpleActions.SubtractAction(plot=self)
+
+        self._toolbar.addAction(self.avgAction)
+        self._toolbar.addAction(self.derivativeAction)
+        self._toolbar.addAction(self.smoothAction)
+        self._toolbar.addAction(self.swapSignAction)
+        self._toolbar.addAction(self.yMinToZero)
+        self._toolbar.addAction(self.subtractAction)
+
+        if plugins:
+            pluginsToolButton = PluginsToolButton(plot=self)
+
+            if PLUGINS_DIR is not None:
+                if isinstance(PLUGINS_DIR, list):
+                    pluginDir = PLUGINS_DIR
+                else:
+                    pluginDir = [PLUGINS_DIR]
+                pluginsToolButton.getPlugins(
+                        method="getPlugin1DInstance",
+                        directoryList=pluginDir)
+            self._toolbar.addWidget(pluginsToolButton)
+
+        self.scanWindowInfoWidget = None
+        self.infoDockWidget = None
         if info:
             self.scanWindowInfoWidget = ScanWindowInfoWidget.\
                                             ScanWindowInfoWidget()
             self.infoDockWidget = qt.QDockWidget(self)
             self.infoDockWidget.layout().setContentsMargins(0, 0, 0, 0)
             self.infoDockWidget.setWidget(self.scanWindowInfoWidget)
-            self.infoDockWidget.setWindowTitle(self.windowTitle()+(" Info"))
+            self.infoDockWidget.setWindowTitle("Scan Info")
             self.addDockWidget(qt.Qt.BottomDockWidgetArea,
-                                   self.infoDockWidget)
-            controlMenu = qt.QMenu()
-            controlMenu.addAction(QString("Show/Hide Legends"),
-                                       self.toggleLegendWidget)
-            controlMenu.addAction(QString("Show/Hide Info"),
-                                       self._toggleInfoWidget)
-            controlMenu.addAction(QString("Toggle Crosshair"),
-                                       self.toggleCrosshairCursor)
-            controlMenu.addAction(QString("Toggle Arrow Keys Panning"),
-                                       self.toggleArrowKeysPanning)
-            self.setControlMenu(controlMenu)
-        else:
-            self.scanWindowInfoWidget = None
-        #self.fig = None
-        if fit:
-            self.scanFit = ScanFit.ScanFit(specfit=specfit)
-        self.printPreview = PyMcaPrintPreview.PyMcaPrintPreview(modal = 0)
-        self.simpleMath = SimpleMath.SimpleMath()
-        self.outputDir = None
-        self.outputFilter = None
+                               self.infoDockWidget)
 
-        #signals
-        # this one was made in the base class
-        #self.setCallback(self.graphCallback)
-        if fit:
-            from PyMca5.PyMcaGui.math.fitting import SimpleFitGui
-            self.customFit = SimpleFitGui.SimpleFitGui()
-            self.scanFit.sigScanFitSignal.connect(self._scanFitSignalReceived)
-            self.customFit.sigSimpleFitSignal.connect( \
-                            self._customFitSignalReceived)
+            self.sigActiveCurveChanged.connect(self.__updateInfoWidget)
 
-            self.fitButtonMenu = qt.QMenu()
-            self.fitButtonMenu.addAction(QString("Simple Fit"),
-                                   self._simpleFitSignal)
-            self.fitButtonMenu.addAction(QString("Customized Fit") ,
-                                   self._customFitSignal)
+    def _customControlButtonMenu(self):
+        """Display Options button sub-menu. Overloaded to add
+        _toggleInfoAction"""
+        # overloaded from PlotWindow to add "Show/Hide Info"
+        controlMenu = self.controlButton.menu()
+        controlMenu.clear()
+        controlMenu.addAction(self.getLegendsDockWidget().toggleViewAction())
 
-    def _toggleInfoWidget(self):
-        if self.infoDockWidget.isHidden():
-            self.infoDockWidget.show()
-            legend = self.getActiveCurve(just_legend=True)
-            if legend is not None:
-                ddict ={}
-                ddict['event'] = "curveClicked"
-                ddict['label'] = legend
-                ddict['legend'] = legend
-                self.graphCallback(ddict)
-        else:
-            self.infoDockWidget.hide()
+        if self.infoDockWidget is not None:
+            controlMenu.addAction(self.infoDockWidget.toggleViewAction())
+        controlMenu.addAction(self.getRoiAction())
+        controlMenu.addAction(self.getMaskAction())
+        controlMenu.addAction(self.getConsoleAction())
 
-    def _buildLegendWidget(self):
-        if self.legendWidget is None:
-            super(ScanWindow, self)._buildLegendWidget()
-            if hasattr(self, "infoDockWidget") and \
-               hasattr(self, "roiDockWidget"):
-                self.tabifyDockWidget(self.infoDockWidget,
-                                      self.roiDockWidget,
-                                      self.legendDockWidget)
-            elif hasattr(self, "infoDockWidget"):
-                self.tabifyDockWidget(self.infoDockWidget,
-                                      self.legendDockWidget)
+        controlMenu.addSeparator()
+        controlMenu.addAction(self.getCrosshairAction())
+        controlMenu.addAction(self.getPanWithArrowKeysAction())
 
-    def _toggleROI(self, position=None):
-        super(ScanWindow, self)._toggleROI(position=position)
-        if hasattr(self, "infoDockWidget"):
-            self.tabifyDockWidget(self.infoDockWidget,
-                                  self.roiDockWidget)
+    def __updateInfoWidget(self, previous_legend, legend):
+        x, y, legend, info, params = self.getCurve(legend)
+        self.scanWindowInfoWidget.updateFromXYInfo(x, y, info)
+
+    def setWindowType(self, wtype=None):
+        if wtype not in [None, "SCAN", "MCA"]:
+            raise AttributeError("Unsupported window type %s." % wtype)
+        self._plotType = wtype
+
+
+class ScanWindow(BaseScanWindow):
+    """ScanWindow, adding dataObject management to BaseScanWindow
+    """
+
+    def __init__(self, parent=None, name="Scan Window", fit=True, backend=None,
+                 plugins=True, control=True, position=True, roi=True,
+                 specfit=None, info=False):
+        BaseScanWindow.__init__(self,
+                                parent, name, fit, backend,
+                                plugins, control, position, roi,
+                                specfit, info)
+
+        self.dataObjectsDict = {}
+
+    @property
+    def dataObjectsList(self):
+        return self.getAllCurves(just_legend=True)
+
+    @property
+    def _curveList(self):
+        return self.getAllCurves(just_legend=True)
 
     def setDispatcher(self, w):
         w.sigAddSelection.connect(self._addSelection)
         w.sigRemoveSelection.connect(self._removeSelection)
         w.sigReplaceSelection.connect(self._replaceSelection)
 
-    def _addSelection(self, selectionlist, replot=True):
-        if DEBUG:
-            print("_addSelection(self, selectionlist)",selectionlist)
-        if type(selectionlist) == type([]):
-            sellist = selectionlist
-        else:
-            sellist = [selectionlist]
+    def _addSelection(self, selectionlist, resetzoom=True, replot=None):
+        """Add curves to plot and data objects to :attr:`dataObjectsDict`
+        """
+        _logger.debug("_addSelection(self, selectionlist) " +
+                      str(selectionlist))
+        if replot is not None:
+            _logger.warning(
+                    'deprecated replot argument, use resetzoom instead')
+            resetzoom = replot and resetzoom
 
-        if len(self._curveList):
+        sellist = selectionlist if isinstance(selectionlist, list) else \
+            [selectionlist]
+
+        if len(self.getAllCurves(just_legend=True)):
             activeCurve = self.getActiveCurve(just_legend=True)
         else:
             activeCurve = None
         nSelection = len(sellist)
         for selectionIndex in range(nSelection):
             sel = sellist[selectionIndex]
-            if selectionIndex == (nSelection - 1):
-                actualReplot = replot
-            else:
-                actualReplot = False
-            source = sel['SourceName']
-            key    = sel['Key']
-            legend = sel['legend'] #expected form sourcename + scan key
-            if not ("scanselection" in sel): continue
-            if sel['scanselection'] == "MCA":
+            key = sel['Key']
+            legend = sel['legend']  # expected form sourcename + scan key
+            if "scanselection" not in sel or not sel["scanselection"] or \
+                            sel['scanselection'] == "MCA":
                 continue
-            if not sel["scanselection"]:continue
-            if len(key.split(".")) > 2: continue
+            if len(key.split(".")) > 2:
+                continue
             dataObject = sel['dataobject']
-            #only one-dimensional selections considered
-            if dataObject.info["selectiontype"] != "1D": continue
+            # only one-dimensional selections considered
+            if dataObject.info["selectiontype"] != "1D":
+                continue
 
-            #there must be something to plot
+            # there must be something to plot
             if not hasattr(dataObject, 'y'):
                 continue
-            if not hasattr(dataObject, 'x'):
+            if getattr(dataObject, 'x', None) is None:
                 ylen = len(dataObject.y[0])
-                if ylen:
-                    xdata = numpy.arange(ylen).astype(numpy.float)
-                else:
-                    #nothing to be plot
+                if not ylen:
+                    # nothing to be plot
                     continue
-            if dataObject.x is None:
-                ylen = len(dataObject.y[0])
-                if ylen:
-                    xdata = numpy.arange(ylen).astype(numpy.float)
-                else:
-                    #nothing to be plot
-                    continue
+                xdata = numpy.arange(ylen).astype(numpy.float)
             elif len(dataObject.x) > 1:
-                if DEBUG:
-                    print("Mesh plots")
+                # mesh plot
                 continue
             else:
                 xdata = dataObject.x[0]
-            sps_source = False
-            if 'SourceType' in sel:
-                if sel['SourceType'] == 'SPS':
-                    sps_source = True
 
-            if sps_source:
+            if sel.get('SourceType') == "SPS":
                 ycounter = -1
                 if 'selection' not in dataObject.info:
                     dataObject.info['selection'] = copy.deepcopy(sel['selection'])
@@ -269,93 +260,84 @@ class ScanWindow(PlotWindow.PlotWindow):
                     xlabel = None
                     ylabel = None
                     ycounter += 1
-                    if dataObject.m is None:
-                        mdata = [numpy.ones(len(ydata)).astype(numpy.float)]
-                    elif len(dataObject.m[0]) > 0:
-                        if len(dataObject.m[0]) == len(ydata):
-                            index = numpy.nonzero(dataObject.m[0])[0]
-                            if not len(index):
-                                continue
-                            xdata = numpy.take(xdata, index)
-                            ydata = numpy.take(ydata, index)
-                            mdata = numpy.take(dataObject.m[0], index)
-                            #A priori the graph only knows about plots
-                            ydata = ydata/mdata
-                        else:
+                    # normalize ydata with monitor
+                    if dataObject.m is not None and len(dataObject.m[0]) > 0:
+                        if len(dataObject.m[0]) != len(ydata):
                             raise ValueError("Monitor data length different than counter data")
-                    else:
-                        mdata = [numpy.ones(len(ydata)).astype(numpy.float)]
+                        index = numpy.nonzero(dataObject.m[0])[0]
+                        if not len(index):
+                            continue
+                        xdata = numpy.take(xdata, index)
+                        ydata = numpy.take(ydata, index)
+                        mdata = numpy.take(dataObject.m[0], index)
+                        # A priori the graph only knows about plots
+                        ydata = ydata / mdata
                     ylegend = 'y%d' % ycounter
-                    if dataObject.info['selection'] is not None:
-                        if type(dataObject.info['selection']) == type({}):
-                            if 'x' in dataObject.info['selection']:
-                                #proper scan selection
-                                ilabel = dataObject.info['selection']['y'][ycounter]
-                                ylegend = dataObject.info['LabelNames'][ilabel]
-                                ylabel = ylegend
-                                if sel['selection']['x'] is not None:
-                                    if len(dataObject.info['selection']['x']):
-                                        xlabel = dataObject.info['LabelNames'] \
-                                                    [dataObject.info['selection']['x'][0]]
+                    if isinstance(dataObject.info['selection'], dict):
+                        if 'x' in dataObject.info['selection']:
+                            # proper scan selection
+                            ilabel = dataObject.info['selection']['y'][ycounter]
+                            ylegend = dataObject.info['LabelNames'][ilabel]
+                            ylabel = ylegend
+                            if sel['selection']['x'] is not None:
+                                if len(dataObject.info['selection']['x']):
+                                    xlabel = dataObject.info['LabelNames'] \
+                                        [dataObject.info['selection']['x'][0]]
                     dataObject.info["xlabel"] = xlabel
                     dataObject.info["ylabel"] = ylabel
                     newLegend = legend + " " + ylegend
                     self.dataObjectsDict[newLegend] = dataObject
                     self.addCurve(xdata, ydata, legend=newLegend, info=dataObject.info,
-                                                    xlabel=xlabel, ylabel=ylabel, replot=False)
-                    #              replot=actualReplot)
+                                  xlabel=xlabel, ylabel=ylabel)
                     if self.scanWindowInfoWidget is not None:
                         if not self.infoDockWidget.isHidden():
                             activeLegend = self.getActiveCurve(just_legend=True)
-                            if activeLegend is not None:
-                                if activeLegend == newLegend:
-                                    self.scanWindowInfoWidget.updateFromDataObject\
-                                                                (dataObject)
+                            if activeLegend == newLegend:
+                                self.scanWindowInfoWidget.updateFromDataObject \
+                                    (dataObject)
                             else:
+                                # TODO: better to implement scanWindowInfoWidget.clear
                                 dummyDataObject = DataObject.DataObject()
-                                dummyDataObject.y=[numpy.array([])]
-                                dummyDataObject.x=[numpy.array([])]
+                                dummyDataObject.y = [numpy.array([])]
+                                dummyDataObject.x = [numpy.array([])]
                                 self.scanWindowInfoWidget.updateFromDataObject(dummyDataObject)
             else:
-                #we have to loop for all y values
+                # we have to loop for all y values
                 ycounter = -1
                 for ydata in dataObject.y:
                     ylen = len(ydata)
-                    if ylen == 1:
-                        if len(xdata) > 1:
-                            ydata = ydata[0] * numpy.ones(len(xdata)).astype(numpy.float)
+                    if ylen == 1 and len(xdata) > 1:
+                        ydata = ydata[0] * numpy.ones(len(xdata)).astype(numpy.float)
                     elif len(xdata) == 1:
                         xdata = xdata[0] * numpy.ones(ylen).astype(numpy.float)
                     ycounter += 1
-                    newDataObject   = DataObject.DataObject()
+                    newDataObject = DataObject.DataObject()
                     newDataObject.info = copy.deepcopy(dataObject.info)
-                    if dataObject.m is None:
+                    if dataObject.m is None or len(dataObject.m[0]) == 0:
                         mdata = numpy.ones(len(ydata)).astype(numpy.float)
-                    elif len(dataObject.m[0]) > 0:
-                        if len(dataObject.m[0]) == len(ydata):
-                            index = numpy.nonzero(dataObject.m[0])[0]
-                            if not len(index):
-                                continue
-                            xdata = numpy.take(xdata, index)
-                            ydata = numpy.take(ydata, index)
-                            mdata = numpy.take(dataObject.m[0], index)
-                            #A priori the graph only knows about plots
-                            ydata = ydata/mdata
-                        elif len(dataObject.m[0]) == 1:
-                            mdata = numpy.ones(len(ydata)).astype(numpy.float)
-                            mdata *= dataObject.m[0][0]
-                            index = numpy.nonzero(dataObject.m[0])[0]
-                            if not len(index):
-                                continue
-                            xdata = numpy.take(xdata, index)
-                            ydata = numpy.take(ydata, index)
-                            mdata = numpy.take(dataObject.m[0], index)
-                            #A priori the graph only knows about plots
-                            ydata = ydata/mdata
-                        else:
-                            raise ValueError("Monitor data length different than counter data")
+                    elif len(dataObject.m[0]) == len(ydata):
+                        index = numpy.nonzero(dataObject.m[0])[0]
+                        if not len(index):
+                            continue
+                        xdata = numpy.take(xdata, index)
+                        ydata = numpy.take(ydata, index)
+                        mdata = numpy.take(dataObject.m[0], index)
+                        # A priori the graph only knows about plots
+                        ydata = ydata / mdata
+                    elif len(dataObject.m[0]) == 1:
+                        mdata = numpy.ones(len(ydata)).astype(numpy.float)
+                        mdata *= dataObject.m[0][0]
+                        index = numpy.nonzero(dataObject.m[0])[0]
+                        if not len(index):
+                            continue
+                        xdata = numpy.take(xdata, index)
+                        ydata = numpy.take(ydata, index)
+                        mdata = numpy.take(dataObject.m[0], index)
+                        # A priori the graph only knows about plots
+                        ydata = ydata / mdata
                     else:
-                        mdata = numpy.ones(len(ydata)).astype(numpy.float)
+                        raise ValueError("Monitor data length different than counter data")
+
                     newDataObject.x = [xdata]
                     newDataObject.y = [ydata]
                     newDataObject.m = [mdata]
@@ -363,26 +345,24 @@ class ScanWindow(PlotWindow.PlotWindow):
                     ylegend = 'y%d' % ycounter
                     xlabel = None
                     ylabel = None
-                    if sel['selection'] is not None:
-                        if type(sel['selection']) == type({}):
-                            if 'x' in sel['selection']:
-                                #proper scan selection
-                                newDataObject.info['selection']['x'] = sel['selection']['x']
-                                newDataObject.info['selection']['y'] = [sel['selection']['y'][ycounter]]
-                                newDataObject.info['selection']['m'] = sel['selection']['m']
-                                ilabel = newDataObject.info['selection']['y'][0]
-                                ylegend = newDataObject.info['LabelNames'][ilabel]
-                                ylabel = ylegend
-                                if len(newDataObject.info['selection']['x']):
-                                    ilabel = newDataObject.info['selection']['x'][0]
-                                    xlabel = newDataObject.info['LabelNames'][ilabel]
-                                else:
-                                    xlabel = "Point number"
+                    if isinstance(sel['selection'], dict) and 'x' in sel['selection']:
+                        # proper scan selection
+                        newDataObject.info['selection']['x'] = sel['selection']['x']
+                        newDataObject.info['selection']['y'] = [sel['selection']['y'][ycounter]]
+                        newDataObject.info['selection']['m'] = sel['selection']['m']
+                        ilabel = newDataObject.info['selection']['y'][0]
+                        ylegend = newDataObject.info['LabelNames'][ilabel]
+                        ylabel = ylegend
+                        if len(newDataObject.info['selection']['x']):
+                            ilabel = newDataObject.info['selection']['x'][0]
+                            xlabel = newDataObject.info['LabelNames'][ilabel]
+                        else:
+                            xlabel = "Point number"
                     if ('operations' in dataObject.info) and len(dataObject.y) == 1:
                         newDataObject.info['legend'] = legend
                         symbol = 'x'
                     else:
-                        symbol=None
+                        symbol = None
                         newDataObject.info['legend'] = legend + " " + ylegend
                         newDataObject.info['selectionlegend'] = legend
                     yaxis = None
@@ -391,925 +371,144 @@ class ScanWindow(PlotWindow.PlotWindow):
                     elif 'operations' in dataObject.info:
                         if dataObject.info['operations'][-1] == 'derivate':
                             yaxis = 'right'
-                    #print("sending legend = ", newDataObject.info['legend'], "replot = ", False)
                     self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
                     self.addCurve(xdata, ydata, legend=newDataObject.info['legend'],
-                                    info=newDataObject.info,
-                                    symbol=symbol,
-                                    yaxis=yaxis,
-                                    xlabel=xlabel,
-                                    ylabel=ylabel,
-                                    replot=False)
-        self.dataObjectsList = self._curveList
+                                  info=newDataObject.info,
+                                  symbol=symbol,
+                                  yaxis=yaxis,
+                                  xlabel=xlabel,
+                                  ylabel=ylabel)
         try:
             if activeCurve is None:
-                if len(self._curveList) > 0:
-                    activeCurve = self._curveList[0]
-                ddict = {}
-                ddict['event'] = "curveClicked"
-                ddict['label'] = activeCurve
-                self.graphCallback(ddict)
+                self.setActiveCurve(self._curveList[0])
         finally:
-            if replot:
-                #self.replot()
+            if resetzoom:
                 self.resetZoom()
-        self.updateLegends()
 
     def _removeSelection(self, selectionlist):
-        if DEBUG:
-            print("_removeSelection(self, selectionlist)",selectionlist)
-        if type(selectionlist) == type([]):
-            sellist = selectionlist
-        else:
-            sellist = [selectionlist]
+        _logger.debug("_removeSelection(self, selectionlist) " +
+                      str(selectionlist))
+
+        sellist = selectionlist if isinstance(selectionlist, list) else \
+            [selectionlist]
 
         removelist = []
         for sel in sellist:
-            source = sel['SourceName']
-            key    = sel['Key']
-            if not ("scanselection" in sel): continue
+            key = sel['Key']
+            if "scanselection" not in sel or not sel["scanselection"]:
+                continue
             if sel['scanselection'] == "MCA":
                 continue
-            if not sel["scanselection"]:continue
-            if len(key.split(".")) > 2: continue
+            if len(key.split(".")) > 2:
+                continue
 
-            legend = sel['legend'] #expected form sourcename + scan key
-            if type(sel['selection']) == type({}):
-                if 'y' in sel['selection']:
-                    for lName in ['cntlist', 'LabelNames']:
-                        if lName in sel['selection']:
-                            for index in sel['selection']['y']:
-                                removelist.append(legend +" "+\
-                                                  sel['selection'][lName][index])
+            legend = sel['legend']  # expected form sourcename + scan key
+            if isinstance(sel['selection'], dict) and 'y' in sel['selection']:
+                for lName in ['cntlist', 'LabelNames']:
+                    if lName in sel['selection']:
+                        for index in sel['selection']['y']:
+                            removelist.append(legend + " " +
+                                              sel['selection'][lName][index])
 
         if len(removelist):
             self.removeCurves(removelist)
 
-    def removeCurves(self, removeList, replot=True):
-        for legend in removeList:
-            if legend == removeList[-1]:
-                self.removeCurve(legend, replot=replot)
-            else:
-                self.removeCurve(legend, replot=False)
-            if legend in self.dataObjectsDict:
-                del self.dataObjectsDict[legend]
-        self.dataObjectsList = self._curveList
-
     def _replaceSelection(self, selectionlist):
-        if DEBUG:
-            print("_replaceSelection(self, selectionlist)",selectionlist)
-        if type(selectionlist) == type([]):
-            sellist = selectionlist
-        else:
-            sellist = [selectionlist]
+        """Delete existing curves and data objects, then add new selection.
+        """
+        _logger.debug("_replaceSelection(self, selectionlist) " +
+                      str(selectionlist))
 
-        doit = 0
+        sellist = selectionlist if isinstance(selectionlist, list) else \
+            [selectionlist]
+
+        doit = False
         for sel in sellist:
-            if not ("scanselection" in sel): continue
+            if "scanselection" not in sel or not sel["scanselection"]:
+                continue
             if sel['scanselection'] == "MCA":
                 continue
-            if not sel["scanselection"]:continue
-            if len(sel["Key"].split(".")) > 2: continue
+            if len(sel["Key"].split(".")) > 2:
+                continue
             dataObject = sel['dataobject']
             if dataObject.info["selectiontype"] == "1D":
                 if hasattr(dataObject, 'y'):
-                    doit = 1
+                    doit = True
                     break
         if not doit:
             return
         self.clearCurves()
-        self.dataObjectsDict={}
-        self.dataObjectsList=self._curveList
-        self._addSelection(selectionlist, replot=True)
+        self.dataObjectsDict = {}
+        self._addSelection(selectionlist, resetzoom=True)
 
-    def _handleMarkerEvent(self, ddict):
-        if ddict['event'] == 'markerMoved':
-            label = ddict['label']
-            if label.startswith('ROI'):
-                return self._handleROIMarkerEvent(ddict)
-            else:
-                if DEBUG:
-                    print("Unhandled marker %s" % label)
-                return
-
-    def graphCallback(self, ddict):
-        if DEBUG:
-            print("graphCallback", ddict)
-        if ddict['event'] in ['markerMoved', 'markerSelected']:
-            self._handleMarkerEvent(ddict)
-        elif ddict['event'] in ["mouseMoved", "MouseAt"]:
-            if self._toggleCounter > 0:
-                activeCurve = self.getActiveCurve()
-                if activeCurve in [None, []]:
-                    self._handleMouseMovedEvent(ddict)
-                else:
-                    x, y, legend, info = activeCurve[0:4]
-                    # calculate the maximum distance
-                    xMin, xMax = self.getGraphXLimits()
-                    maxXDistance = abs(xMax - xMin)
-                    yMin, yMax = self.getGraphYLimits()
-                    maxYDistance = abs(yMax - yMin)
-                    if (maxXDistance > 0.0) and (maxYDistance > 0.0):
-                        closestIndex = (pow((x - ddict['x'])/maxXDistance, 2) + \
-                                        pow((y - ddict['y'])/maxYDistance, 2))
-                    else:
-                        closestIndex = (pow(x - ddict['x'], 2) + \
-                                    pow(y - ddict['y'], 2))
-                    xText = '----'
-                    yText = '----'
-                    if len(closestIndex):
-                        closestIndex = closestIndex.argmin()
-                        xCurve = x[closestIndex]
-                        if abs(xCurve - ddict['x']) < (0.05 * maxXDistance):
-                            yCurve = y[closestIndex]
-                            if abs(yCurve - ddict['y']) < (0.05 * maxYDistance):
-                                xText = '%.7g' % xCurve
-                                yText = '%.7g' % yCurve
-                    if xText == '----':
-                        if self.getGraphCursor():
-                            self._xPos.setStyleSheet("color: rgb(255, 0, 0);")
-                            self._yPos.setStyleSheet("color: rgb(255, 0, 0);")
-                            xText = '%.7g' % ddict['x']
-                            yText = '%.7g' % ddict['y']
-                        else:
-                            self._xPos.setStyleSheet("color: rgb(0, 0, 0);")
-                            self._yPos.setStyleSheet("color: rgb(0, 0, 0);")
-                    else:
-                        self._xPos.setStyleSheet("color: rgb(0, 0, 0);")
-                        self._yPos.setStyleSheet("color: rgb(0, 0, 0);")
-                    self._xPos.setText(xText)
-                    self._yPos.setText(yText)
-            else:
-                self._xPos.setStyleSheet("color: rgb(0, 0, 0);")
-                self._yPos.setStyleSheet("color: rgb(0, 0, 0);")
-                self._handleMouseMovedEvent(ddict)
-        elif ddict['event'] in ["curveClicked", "legendClicked"]:
-            legend = ddict["label"]
-            if legend is None:
-                if len(self.dataObjectsList):
-                    legend = self.dataObjectsList[0]
-                else:
-                    return
-            if legend not in self.dataObjectsList:
-                if DEBUG:
-                    print("unknown legend %s" % legend)
-                return
-
-            #force the current x label to the appropriate value
-            dataObject = self.dataObjectsDict[legend]
-            if 'selection' in dataObject.info:
-                ilabel = dataObject.info['selection']['y'][0]
-                ylabel = dataObject.info['LabelNames'][ilabel]
-                if len(dataObject.info['selection']['x']):
-                    ilabel = dataObject.info['selection']['x'][0]
-                    xlabel = dataObject.info['LabelNames'][ilabel]
-                else:
-                    xlabel = "Point Number"
-                if len(dataObject.info['selection']['m']):
-                    ilabel = dataObject.info['selection']['m'][0]
-                    ylabel += "/" + dataObject.info['LabelNames'][ilabel]
-            else:
-                xlabel = dataObject.info.get('xlabel', None)
-                ylabel = dataObject.info.get('ylabel', None)
-            if xlabel is not None:
-                self.setGraphXLabel(xlabel)
-            if ylabel is not None:
-                self.setGraphYLabel(ylabel)
-            self.setGraphTitle(legend)
-            self.setActiveCurve(legend)
-            #self.setGraphTitle(legend)
-            if self.scanWindowInfoWidget is not None:
-                if not self.infoDockWidget.isHidden():
-                    self.scanWindowInfoWidget.updateFromDataObject\
-                                                            (dataObject)
-        elif ddict['event'] == "removeCurveEvent":
-            legend = ddict['legend']
-            self.removeCurves([legend])
-        elif ddict['event'] == "renameCurveEvent":
-            legend = ddict['legend']
-            newlegend = ddict['newlegend']
+    def removeCurves(self, removeList):
+        for legend in removeList:
+            self.removeCurve(legend)
             if legend in self.dataObjectsDict:
-                self.dataObjectsDict[newlegend]= copy.deepcopy(self.dataObjectsDict[legend])
-                self.dataObjectsDict[newlegend].info['legend'] = newlegend
-                self.dataObjectsList.append(newlegend)
-                self.removeCurves([legend], replot=False)
-                self.newCurve(self.dataObjectsDict[newlegend].x[0],
-                              self.dataObjectsDict[newlegend].y[0],
-                              legend=self.dataObjectsDict[newlegend].info['legend'])
+                del self.dataObjectsDict[legend]
 
-        #make sure the plot signal is forwarded because we have overwritten
-        #its handling
-        self.sigPlotSignal.emit(ddict)
-
-
-    def _customFitSignalReceived(self, ddict):
-        if ddict['event'] == "FitFinished":
-            newDataObject = self.__customFitDataObject
-
-            xplot = ddict['x']
-            yplot = ddict['yfit']
-            newDataObject.x = [xplot]
-            newDataObject.y = [yplot]
-            newDataObject.m = [numpy.ones(len(yplot)).astype(numpy.float)]
-
-            #here I should check the log or linear status
-            self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
-            self.addCurve(xplot,
-                          yplot,
-                          legend=newDataObject.info['legend'])
-
-    def _scanFitSignalReceived(self, ddict):
-        if DEBUG:
-            print("_scanFitSignalReceived", ddict)
-        if ddict['event'] == "EstimateFinished":
-            return
-        if ddict['event'] == "FitFinished":
-            newDataObject = self.__fitDataObject
-
-            xplot = self.scanFit.specfit.xdata * 1.0
-            yplot = self.scanFit.specfit.gendata(parameters=ddict['data'])
-            newDataObject.x = [xplot]
-            newDataObject.y = [yplot]
-            newDataObject.m = [numpy.ones(len(yplot)).astype(numpy.float)]
-
-            self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
-            self.addCurve(x=xplot, y=yplot, legend=newDataObject.info['legend'])
-
-    def _fitIconSignal(self):
-        if DEBUG:
-            print("_fitIconSignal")
-        self.fitButtonMenu.exec_(self.cursor().pos())
-
-    def _simpleFitSignal(self):
-        if DEBUG:
-            print("_simpleFitSignal")
-        self._QSimpleOperation("fit")
-
-    def _customFitSignal(self):
-        if DEBUG:
-            print("_customFitSignal")
-        self._QSimpleOperation("custom_fit")
-
-    def _saveIconSignal(self):
-        if DEBUG:
-            print("_saveIconSignal")
-        self._QSimpleOperation("save")
-
-    def _averageIconSignal(self):
-        if DEBUG:
-            print("_averageIconSignal")
-        self._QSimpleOperation("average")
-
-    def _smoothIconSignal(self):
-        if DEBUG:
-            print("_smoothIconSignal")
-        self._QSimpleOperation("smooth")
-
-    def _getOutputFileName(self):
-        #get outputfile
-        self.outputDir = PyMcaDirs.outputDir
-        if self.outputDir is None:
-            self.outputDir = os.getcwd()
-            wdir = os.getcwd()
-        elif os.path.exists(self.outputDir):
-            wdir = self.outputDir
-        else:
-            self.outputDir = os.getcwd()
-            wdir = self.outputDir
-
-        filterlist = ['Specfile MCA  *.mca',
-                      'Specfile Scan *.dat',
-                      'Specfile MultiScan *.dat',
-                      'Raw ASCII *.txt',
-                      '","-separated CSV *.csv',
-                      '";"-separated CSV *.csv',
-                      '"tab"-separated CSV *.csv',
-                      'OMNIC CSV *.csv',
-                      'Widget PNG *.png',
-                      'Widget JPG *.jpg',
-                      'Graphics PNG *.png',
-                      'Graphics EPS *.eps',
-                      'Graphics SVG *.svg']
-        fileList, fileFilter = PyMcaFileDialogs.getFileList(self,
-                                     filetypelist=filterlist,
-                                     message="Output File Selection",
-                                     currentdir=wdir,
-                                     single=True,
-                                     mode="SAVE",
-                                     getfilter=True,
-                                     currentfilter=self.outputFilter)
-        if not len(fileList):
-            return
-        filterused = fileFilter.split()
-        filetype = filterused[1]
-        extension = filterused[2]
-        outdir = qt.safe_str(fileList[0])
-        try:
-            self.outputDir  = os.path.dirname(outdir)
-            PyMcaDirs.outputDir = os.path.dirname(outdir)
-        except:
-            print("setting output directory to default")
-            self.outputDir  = os.getcwd()
-        try:
-            outputFile = os.path.basename(outdir)
-        except:
-            outputFile = outdir
-        if len(outputFile) < 5:
-            outputFile = outputFile + extension[-4:]
-        elif outputFile[-4:] != extension[-4:]:
-            outputFile = outputFile + extension[-4:]
-        return os.path.join(self.outputDir, outputFile), filetype, filterused
-
-    def _QSimpleOperation(self, operation):
-        try:
-            self._simpleOperation(operation)
-        except:
-            msg = qt.QMessageBox(self)
-            msg.setIcon(qt.QMessageBox.Critical)
-            msg.setInformativeText(str(sys.exc_info()[1]))
-            msg.setDetailedText(traceback.format_exc())
-            msg.exec_()
-
-    def _saveOperation(self, fileName, fileType, fileFilter):
-        filterused = fileFilter
-        filetype = fileType
-        filename = fileName
-        if os.path.exists(filename):
-            os.remove(filename)
-        if filterused[0].upper() == "WIDGET":
-            fformat = filename[-3:].upper()
-            pixmap = qt.QPixmap.grabWidget(self)
-            if not pixmap.save(filename, fformat):
-                qt.QMessageBox.critical(self,
-                                    "Save Error",
-                                    "%s" % sys.exc_info()[1])
-            return
-        try:
-            if filename[-3:].upper() in ['EPS', 'PNG', 'SVG']:
-                self.graphicsSave(filename)
-                return
-        except:
-            msg = qt.QMessageBox(self)
-            msg.setIcon(qt.QMessageBox.Critical)
-            msg.setText("Graphics Saving Error: %s" % (sys.exc_info()[1]))
-            msg.exec_()
-            return
-        systemline = os.linesep
-        os.linesep = '\n'
-        try:
-            if sys.version < "3.0":
-                ffile=open(filename, "wb")
-            else:
-                ffile=open(filename, "w", newline='')
-        except IOError:
-            msg = qt.QMessageBox(self)
-            msg.setIcon(qt.QMessageBox.Critical)
-            msg.setText("Input Output Error: %s" % (sys.exc_info()[1]))
-            msg.exec_()
-            return
-        x, y, legend, info = self.getActiveCurve()
-        xlabel = info.get("xlabel", "X")
-        ylabel = info.get("ylabel", "Y")
-        if 0:
-            if "selection" in info:
-                if type(info['selection']) == type({}):
-                    if 'x' in info['selection']:
-                        #proper scan selection
-                        ilabel = info['selection']['y'][0]
-                        ylegend = info['LabelNames'][ilabel]
-                        ylabel = ylegend
-                        if info['selection']['x'] is not None:
-                            if len(info['selection']['x']):
-                                xlabel = info['LabelNames'] [info['selection']['x'][0]]
-                            else:
-                                xlabel = "Point number"
-        try:
-            if filetype in ['Scan', 'MultiScan']:
-                ffile.write("#F %s\n" % filename)
-                savingDate = "#D %s\n"%(time.ctime(time.time()))
-                ffile.write(savingDate)
-                ffile.write("\n")
-                ffile.write("#S 1 %s\n" % legend)
-                ffile.write(savingDate)
-                ffile.write("#N 2\n")
-                ffile.write("#L %s  %s\n" % (xlabel, ylabel) )
-                for i in range(len(y)):
-                    ffile.write("%.7g  %.7g\n" % (x[i], y[i]))
-                ffile.write("\n")
-                if filetype == 'MultiScan':
-                    scan_n  = 1
-                    curveList = self.getAllCurves()
-                    for x, y, key, info in curveList:
-                        if key == legend:
-                            continue
-                        xlabel = info.get("xlabel", "X")
-                        ylabel = info.get("ylabel", "Y")
-                        if 0:
-                            if "selection" in info:
-                                if type(info['selection']) == type({}):
-                                    if 'x' in info['selection']:
-                                        #proper scan selection
-                                        ilabel = info['selection']['y'][0]
-                                        ylegend = info['LabelNames'][ilabel]
-                                        ylabel = ylegend
-                                        if info['selection']['x'] is not None:
-                                            if len(info['selection']['x']):
-                                                xlabel = info['LabelNames'] [info['selection']['x'][0]]
-                                            else:
-                                                xlabel = "Point number"
-                        scan_n += 1
-                        ffile.write("#S %d %s\n" % (scan_n, key))
-                        ffile.write(savingDate)
-                        ffile.write("#N 2\n")
-                        ffile.write("#L %s  %s\n" % (xlabel, ylabel) )
-                        for i in range(len(y)):
-                            ffile.write("%.7g  %.7g\n" % (x[i], y[i]))
-                        ffile.write("\n")
-            elif filetype == 'ASCII':
-                for i in range(len(y)):
-                    ffile.write("%.7g  %.7g\n" % (x[i], y[i]))
-            elif filetype == 'CSV':
-                if "," in filterused[0]:
-                    csvseparator = ","
-                elif ";" in filterused[0]:
-                    csvseparator = ";"
-                elif "OMNIC" in filterused[0]:
-                    csvseparator = ","
-                else:
-                    csvseparator = "\t"
-                if "OMNIC" not in filterused[0]:
-                    ffile.write('"%s"%s"%s"\n' % (xlabel,csvseparator,ylabel))
-                for i in range(len(y)):
-                    ffile.write("%.7E%s%.7E\n" % (x[i], csvseparator,y[i]))
-            else:
-                ffile.write("#F %s\n" % filename)
-                ffile.write("#D %s\n"%(time.ctime(time.time())))
-                ffile.write("\n")
-                ffile.write("#S 1 %s\n" % legend)
-                ffile.write("#D %s\n"%(time.ctime(time.time())))
-                ffile.write("#@MCA %16C\n")
-                ffile.write("#@CHANN %d %d %d 1\n" %  (len(y), x[0], x[-1]))
-                ffile.write("#@CALIB %.7g %.7g %.7g\n" % (0, 1, 0))
-                ffile.write(self.array2SpecMca(y))
-                ffile.write("\n")
-            ffile.close()
-            os.linesep = systemline
-        except:
-            os.linesep = systemline
-            raise
-        return
-
-
-    def _simpleOperation(self, operation):
-        if operation == 'subtract':
-            self._subtractOperation()
-            return
-        if operation == "save":
-            #getOutputFileName
-            filename = self._getOutputFileName()
-            if filename is None:
-                return
-            self._saveOperation(filename[0], filename[1], filename[2])
-            return
-        if operation != "average":
-            #get active curve
-            legend = self.getActiveCurveLegend()
-            if legend is None:return
-
-            found = False
-            for key in self.dataObjectsList:
-                if key == legend:
-                    found = True
-                    break
-
-            if found:
-                dataObject = self.dataObjectsDict[legend]
-            else:
-                print("I should not be here")
-                print("active curve =",legend)
-                print("but legend list = ",self.dataObjectsList)
-                return
-            y = dataObject.y[0]
-            if dataObject.x is not None:
-                x = dataObject.x[0]
-            else:
-                x = numpy.arange(len(y)).astype(numpy.float)
-            ilabel = dataObject.info['selection']['y'][0]
-            ylabel = dataObject.info['LabelNames'][ilabel]
-            if len(dataObject.info['selection']['x']):
-                ilabel = dataObject.info['selection']['x'][0]
-                xlabel = dataObject.info['LabelNames'][ilabel]
-            else:
-                xlabel = "Point Number"
-        else:
-            x = []
-            y = []
-            legend = ""
-            i = 0
-            ndata = 0
-            for key in self._curveList:
-                if DEBUG:
-                    print("key -> ", key)
-                if key in self.dataObjectsDict:
-                    x.append(self.dataObjectsDict[key].x[0]) #only the first X
-                    if len(self.dataObjectsDict[key].y) == 1:
-                        y.append(self.dataObjectsDict[key].y[0])
-                    else:
-                        sel_legend = self.dataObjectsDict[key].info['legend']
-                        ilabel = 0
-                        #I have to get the proper y associated to the legend
-                        if sel_legend in key:
-                            if key.index(sel_legend) == 0:
-                                label = key[len(sel_legend):]
-                                while (label.startswith(' ')):
-                                    label = label[1:]
-                                    if not len(label):
-                                        break
-                                if label in self.dataObjectsDict[key].info['LabelNames']:
-                                    ilabel = self.dataObjectsDict[key].info['LabelNames'].index(label)
-                                if DEBUG:
-                                    print("LABEL = ", label)
-                                    print("ilabel = ", ilabel)
-                        y.append(self.dataObjectsDict[key].y[ilabel])
-                    if i == 0:
-                        legend = key
-                        firstcurve = key
-                        i += 1
-                    else:
-                        legend += " + " + key
-                        lastcurve = key
-                    ndata += 1
-            if ndata == 0: return #nothing to average
-            dataObject = self.dataObjectsDict[firstcurve]
-
-        #create the output data object
-        newDataObject = DataObject.DataObject()
-        newDataObject.data = None
-        newDataObject.info = copy.deepcopy(dataObject.info)
-        if 'selectionlegend' in newDataObject.info:
-            del newDataObject.info['selectionlegend']
-        if not ('operations' in newDataObject.info):
-            newDataObject.info['operations'] = []
-        newDataObject.info['operations'].append(operation)
-
-        sel = {}
-        sel['SourceType'] = "Operation"
-        #get new x and new y
-        if operation == "derivate":
-            #xmin and xmax
-            xlimits=self.getGraphXLimits()
-            xplot, yplot = self.simpleMath.derivate(x, y, xlimits=xlimits)
-            ilabel = dataObject.info['selection']['y'][0]
-            ylabel = dataObject.info['LabelNames'][ilabel]
-            newDataObject.info['LabelNames'][ilabel] = ylabel+"'"
-            newDataObject.info['plot_yaxis'] = "right"
-            sel['SourceName'] = legend
-            sel['Key']    = "'"
-            sel['legend'] = legend + sel['Key']
-            outputlegend  = legend + sel['Key']
-        elif operation == "average":
-            xplot, yplot = self.simpleMath.average(x, y)
-            if len(legend) < 80:
-                sel['SourceName'] = legend
-                sel['Key']    = ""
-                sel['legend'] = "(%s)/%d" % (legend, ndata)
-                outputlegend  = "(%s)/%d" % (legend, ndata)
-            else:
-                sel['SourceName'] = legend
-                legend = "Average of %d from %s to %s" % (ndata, firstcurve, lastcurve)
-                sel['Key']    = ""
-                sel['legend'] = legend
-                outputlegend  = legend
-        elif operation == "swapsign":
-            xplot =  x * 1
-            yplot = -y
-            sel['SourceName'] = legend
-            sel['Key']    = ""
-            sel['legend'] = "-(%s)" % legend
-            outputlegend  = "-(%s)" % legend
-        elif operation == "smooth":
-            xplot =  x * 1
-            yplot = self.simpleMath.smooth(y)
-            sel['SourceName'] = legend
-            sel['Key']    = ""
-            sel['legend'] = "%s Smooth" % legend
-            outputlegend  = "%s Smooth" % legend
-            if 'operations' in dataObject.info:
-                if len(dataObject.info['operations']):
-                    if dataObject.info['operations'][-1] == "smooth":
-                        sel['legend'] = legend
-                        outputlegend  = legend
-        elif operation == "forceymintozero":
-            xplot =  x * 1
-            yplot =  y - min(y)
-            sel['SourceName'] = legend
-            sel['Key']    = ""
-            sel['legend'] = "(%s) - ymin" % legend
-            outputlegend  = "(%s) - ymin" % legend
-        elif operation == "fit":
-            #remove a existing fit if present
-            xmin,xmax=self.getGraphXLimits()
-            outputlegend = legend + " Fit"
-            for key in self._curveList:
-                if key == outputlegend:
-                    self.removeCurves([outputlegend], replot=False)
-                    break
-            self.scanFit.setData(x = x,
-                                 y = y,
-                                 xmin = xmin,
-                                 xmax = xmax,
-                                 legend = legend)
-            if self.scanFit.isHidden():
-                self.scanFit.show()
-            self.scanFit.raise_()
-        elif operation == "custom_fit":
-            #remove a existing fit if present
-            xmin, xmax=self.getGraphXLimits()
-            outputlegend = legend + "Custom Fit"
-            keyList = list(self._curveList)
-            for key in keyList:
-                if key == outputlegend:
-                    self.removeCurves([outputlegend], replot=False)
-                    break
-            self.customFit.setData(x = x,
-                                   y = y,
-                                   xmin = xmin,
-                                   xmax = xmax,
-                                   legend = legend)
-            if self.customFit.isHidden():
-                self.customFit.show()
-            self.customFit.raise_()
-        else:
-            raise ValueError("Unknown operation %s" % operation)
-        if operation not in ["fit", "custom_fit"]:
-            newDataObject.x = [xplot]
-            newDataObject.y = [yplot]
-            newDataObject.m = [numpy.ones(len(yplot)).astype(numpy.float)]
-
-        #and add it to the plot
-        if True and (operation not in ['fit', 'custom_fit']):
-            sel['dataobject'] = newDataObject
-            sel['scanselection'] = True
-            sel['selection'] = copy.deepcopy(dataObject.info['selection'])
-            sel['selectiontype'] = "1D"
-            if operation == 'average':
-                self._replaceSelection([sel])
-            elif operation != 'fit':
-                self._addSelection([sel])
-            else:
-                self.__fitDataObject = newDataObject
-                return
-        else:
-            newDataObject.info['legend'] = outputlegend
-            if operation == 'fit':
-                self.__fitDataObject = newDataObject
-                return
-            if operation == 'custom_fit':
-                self.__customFitDataObject = newDataObject
-                return
-
-            self.dataObjectsDict[newDataObject.info['legend']] = newDataObject
-            #here I should check the log or linear status
-            self.addCurve(x=xplot, y=yplot, legend=newDataObject.info['legend'], replot=False)
-        self.replot()
-
-    def graphicsSave(self, filename):
-        #use the plugin interface
-        x, y, legend, info = self.getActiveCurve()[:4]
-        curveList = self.getAllCurves()
-        size = (6, 3) #in inches
-        bw = False
-        if len(curveList) > 1:
-            legends = True
-        else:
-            legends = False
-        if self.matplotlibDialog is None:
-            self.matplotlibDialog = QPyMcaMatplotlibSave1D.\
-                                    QPyMcaMatplotlibSaveDialog(size=size,
-                                                        logx=self._logX,
-                                                        logy=self._logY,
-                                                        legends=legends,
-                                                        bw = bw)
-        mtplt = self.matplotlibDialog.plot
-        mtplt.setParameters({'logy':self._logY,
-                             'logx':self._logX,
-                             'legends':legends,
-                             'bw':bw})
-        xmin, xmax = self.getGraphXLimits()
-        ymin, ymax = self.getGraphYLimits()
-        mtplt.setLimits(xmin, xmax, ymin, ymax)
-
-        legend0 = legend
-        xdata = x
-        ydata = y
-        dataCounter = 1
-        alias = "%c" % (96+dataCounter)
-        mtplt.addDataToPlot( xdata, ydata, legend=legend0, alias=alias )
-        for curve in curveList:
-            xdata, ydata, legend, info = curve[0:4]
-            if legend == legend0:
-                continue
-            dataCounter += 1
-            alias = "%c" % (96+dataCounter)
-            mtplt.addDataToPlot( xdata, ydata, legend=legend, alias=alias )
-
-        if sys.version < '3.0':
-            self.matplotlibDialog.setXLabel(qt.safe_str(self.getGraphXLabel()))
-            self.matplotlibDialog.setYLabel(qt.safe_str(self.getGraphYLabel()))
-        else:
-            self.matplotlibDialog.setXLabel(self.getGraphXLabel())
-            self.matplotlibDialog.setYLabel(self.getGraphYLabel())
-
-        if legends:
-            mtplt.plotLegends()
-        ret = self.matplotlibDialog.exec_()
-        if ret == qt.QDialog.Accepted:
-            mtplt.saveFile(filename)
-        return
-
-    def getActiveCurveLegend(self):
-        return super(ScanWindow,self).getActiveCurve(just_legend=True)
-
-    def _deriveIconSignal(self):
-        if DEBUG:
-            print("_deriveIconSignal")
-        self._QSimpleOperation('derivate')
-
-    def _swapSignIconSignal(self):
-        if DEBUG:
-            print("_swapSignIconSignal")
-        self._QSimpleOperation('swapsign')
-
-    def _yMinToZeroIconSignal(self):
-        if DEBUG:
-            print("_yMinToZeroIconSignal")
-        self._QSimpleOperation('forceymintozero')
-
-    def _subtractIconSignal(self):
-        if DEBUG:
-            print("_subtractIconSignal")
-        self._QSimpleOperation('subtract')
-
-    def _subtractOperation(self):
-        #identical to twice the average with the negative active curve
-        #get active curve
-        legend = self.getActiveCurveLegend()
-        if legend is None:
-            return
-
-        found = False
-        for key in self.dataObjectsList:
-            if key == legend:
-                found = True
-                break
-
-        if found:
-            dataObject = self.dataObjectsDict[legend]
-        else:
-            print("I should not be here")
-            print("active curve =",legend)
-            print("but legend list = ",self.dataObjectsList)
-            return
-        x = dataObject.x[0]
-        y = dataObject.y[0]
-        ilabel = dataObject.info['selection']['y'][0]
-        ylabel = dataObject.info['LabelNames'][ilabel]
-        if len(dataObject.info['selection']['x']):
-            ilabel = dataObject.info['selection']['x'][0]
-            xlabel = dataObject.info['LabelNames'][ilabel]
-        else:
-            xlabel = "Point Number"
-
-        xActive = x
-        yActive = y
-        yActiveLegend = legend
-        yActiveLabel  = ylabel
-        xActiveLabel  = xlabel
-
-        operation = "subtract"
-        sel_list = []
-        i = 0
-        ndata = 0
-        keyList = list(self._curveList)
-        for key in keyList:
-            legend = ""
-            x = [xActive]
-            y = [-yActive]
-            if DEBUG:
-                print("key -> ", key)
-            if key in self.dataObjectsDict:
-                x.append(self.dataObjectsDict[key].x[0]) #only the first X
-                if len(self.dataObjectsDict[key].y) == 1:
-                    y.append(self.dataObjectsDict[key].y[0])
-                    ilabel = self.dataObjectsDict[key].info['selection']['y'][0]
-                else:
-                    sel_legend = self.dataObjectsDict[key].info['legend']
-                    ilabel = self.dataObjectsDict[key].info['selection']['y'][0]
-                    #I have to get the proper y associated to the legend
-                    if sel_legend in key:
-                        if key.index(sel_legend) == 0:
-                            label = key[len(sel_legend):]
-                            while (label.startswith(' ')):
-                                label = label[1:]
-                                if not len(label):
-                                    break
-                            if label in self.dataObjectsDict[key].info['LabelNames']:
-                                ilabel = self.dataObjectsDict[key].info['LabelNames'].index(label)
-                            if DEBUG:
-                                print("LABEL = ", label)
-                                print("ilabel = ", ilabel)
-                    y.append(self.dataObjectsDict[key].y[ilabel])
-                outputlegend = "(%s - %s)" %  (key, yActiveLegend)
-                ndata += 1
-                xplot, yplot = self.simpleMath.average(x, y)
-                yplot *= 2
-                #create the output data object
-                newDataObject = DataObject.DataObject()
-                newDataObject.data = None
-                newDataObject.info.update(self.dataObjectsDict[key].info)
-                if not ('operations' in newDataObject.info):
-                    newDataObject.info['operations'] = []
-                newDataObject.info['operations'].append(operation)
-                newDataObject.info['LabelNames'][ilabel] = "(%s - %s)" %  \
-                                        (newDataObject.info['LabelNames'][ilabel], yActiveLabel)
-                newDataObject.x = [xplot]
-                newDataObject.y = [yplot]
-                newDataObject.m = None
-                sel = {}
-                sel['SourceType'] = "Operation"
-                sel['SourceName'] = key
-                sel['Key']    = ""
-                sel['legend'] = outputlegend
-                sel['dataobject'] = newDataObject
-                sel['scanselection'] = True
-                sel['selection'] = copy.deepcopy(dataObject.info['selection'])
-                #sel['selection']['y'] = [ilabel]
-                sel['selectiontype'] = "1D"
-                sel_list.append(sel)
-        if True:
-            #The legend menu was not working with the next line
-            #but if works if I add the list
-            self._replaceSelection(sel_list)
-        else:
-            oldlist = list(self.dataObjectsDict)
-            self._addSelection(sel_list)
-            self.removeCurves(oldlist)
-
-    #The plugins interface
-    def getGraphYLimits(self):
-        #if the active curve is mapped to second axis
-        #I should give the second axis limits
-        return super(ScanWindow, self).getGraphYLimits()
-
-    #end of plugins interface
-    def addCurve(self, x, y, legend=None, info=None, replace=False, replot=True,
-                 color=None, symbol=None, linestyle=None,
-                 xlabel=None, ylabel=None, yaxis=None,
+    def addCurve(self, x, y, legend=None, info=None, replace=False,
+                 resetzoom=False, replot=True, color=None, symbol=None,
+                 linestyle=None, xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, **kw):
+        """Add a curve. If a curve with the same legend already exists,
+        the unspecified parameters (color, symbol, linestyle, yaxis) are
+        assumed to be identical to the parameters of the existing curve."""
         if legend in self._curveList:
             if info is None:
                 info = {}
             oldStuff = self.getCurve(legend)
-            if len(oldStuff):
-                oldX, oldY, oldLegend, oldInfo = oldStuff
+            if oldStuff is not None:
+                oldX, oldY, oldLegend, oldInfo, oldParams = oldStuff
             else:
                 oldInfo = {}
             if color is None:
-                color = info.get("plot_color", oldInfo.get("plot_color", None))
+                color = info.get("plot_color",
+                                 oldInfo.get("plot_color", None))
             if symbol is None:
-                symbol =  info.get("plot_symbol",oldInfo.get("plot_symbol", None))
+                symbol = info.get("plot_symbol",
+                                  oldInfo.get("plot_symbol", None))
             if linestyle is None:
-                linestyle =  info.get("plot_linestyle",oldInfo.get("plot_linestyle", None))
+                linestyle = info.get("plot_linestyle",
+                                     oldInfo.get("plot_linestyle", None))
             if yaxis is None:
-                yaxis =  info.get("plot_yaxis",oldInfo.get("plot_yaxis", None))
+                yaxis = info.get("plot_yaxis",
+                                 oldInfo.get("plot_yaxis", None))
         else:
             if info is None:
                 info = {}
             if color is None:
                 color = info.get("plot_color", None)
             if symbol is None:
-                symbol =  info.get("plot_symbol", None)
+                symbol = info.get("plot_symbol", None)
             if linestyle is None:
-                linestyle =  info.get("plot_linestyle", None)
+                linestyle = info.get("plot_linestyle", None)
             if yaxis is None:
-                yaxis =  info.get("plot_yaxis", None)
+                yaxis = info.get("plot_yaxis", None)
         if legend in self.dataObjectsDict:
             # the info is changing
-            super(ScanWindow, self).addCurve(x, y, legend=legend, info=info,
-                                replace=replace, replot=replot, color=color, symbol=symbol,
-                                linestyle=linestyle, xlabel=xlabel, ylabel=ylabel, yaxis=yaxis,
-                                xerror=xerror, yerror=yerror, **kw)
+            super(ScanWindow, self).addCurve(
+                    x, y, legend=legend, info=info, replot=replot,
+                    replace=replace, color=color, symbol=symbol,
+                    linestyle=linestyle, xlabel=xlabel, ylabel=ylabel,
+                    yaxis=yaxis, xerror=xerror, yerror=yerror,
+                    resetzoom=resetzoom, **kw)
         else:
             # create the data object
-            self.newCurve(x, y, legend=legend, info=info,
-                                replace=replace, replot=replot, color=color, symbol=symbol,
-                                linestyle=linestyle, xlabel=xlabel, ylabel=ylabel, yaxis=yaxis,
-                                xerror=xerror, yerror=yerror, **kw)
+            self.newCurve(
+                    x, y, legend=legend, info=info, replot=replot,
+                    replace=replace, color=color, symbol=symbol,
+                    linestyle=linestyle, xlabel=xlabel, ylabel=ylabel,
+                    yaxis=yaxis, xerror=xerror, yerror=yerror,
+                    resetzoom=resetzoom, **kw)
 
-    def newCurve(self, x, y, legend=None, info=None, replace=False, replot=True,
-                 color=None, symbol=None, linestyle=None,
-                 xlabel=None, ylabel=None, yaxis=None,
+    def newCurve(self, x, y, legend=None, info=None, replace=False,
+                 resetzoom=False, replot=True, color=None, symbol=None,
+                 linestyle=None, xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, **kw):
+        """
+        Create and add a data object to :attr:`dataObjectsDict`
+        """
         if legend is None:
             legend = "Unnamed curve 1.1"
         if xlabel is None:
@@ -1318,7 +517,6 @@ class ScanWindow(PlotWindow.PlotWindow):
             ylabel = "Y"
         if info is None:
             info = {}
-            # this is awfull but I have no other way to pass the plot information ...
         if color is not None:
             info["plot_color"] = color
         if symbol is not None:
@@ -1338,243 +536,44 @@ class ScanWindow(PlotWindow.PlotWindow):
         newDataObject.info['Key'] = ""
         newDataObject.info['selectiontype'] = "1D"
         newDataObject.info['LabelNames'] = [xlabel, ylabel]
-        newDataObject.info['selection'] = {'x':[0], 'y':[1]}
-        sel_list = []
-        sel = {}
-        sel['SourceType'] = "Operation"
-        sel['SourceName'] = legend
-        sel['Key']    = ""
-        sel['legend'] = legend
-        sel['dataobject'] = newDataObject
-        sel['scanselection'] = True
-        sel['selection'] = {'x':[0], 'y':[1], 'm':[], 'cntlist':[xlabel, ylabel]}
-        #sel['selection']['y'] = [ilabel]
-        sel['selectiontype'] = "1D"
-        sel_list.append(sel)
+        newDataObject.info['selection'] = {'x': [0], 'y': [1]}
+
+        sel = {'SourceType': "Operation",
+               'SourceName': legend,
+               'Key': "",
+               'legend': legend,
+               'dataobject': newDataObject,
+               'scanselection': True,
+               'selection': {'x': [0], 'y': [1], 'm': [],
+                             'cntlist': [xlabel, ylabel]},
+               'selectiontype': "1D"}
+        sel_list = [sel]
         if replace:
             self._replaceSelection(sel_list)
         else:
-            self._addSelection(sel_list, replot=replot)
+            self._addSelection(sel_list, resetzoom=replot)
 
-    def printGraph(self):
-        if self.printPreview.printer is None:
-            # setup needed
-            self.printPreview.setup()
-        self._printer = self.printPreview.printer
-        if self._printer is None:
-            # printer was not selected
-            return
-        #self._printer = None
-        if PlotWindow.PlotWidget.SVG:
-            svg = True
-            self._svgRenderer = self.getSvgRenderer()
-        else:
-            svg = False
-            if hasattr(self, "getWidgetHandle"):
-                widget = self.getWidgetHandle()
-            else:
-                widget = self.centralWidget()
-            if hasattr(widget, "grab"):
-                pixmap = widget.grab()
-            else:
-                pixmap = qt.QPixmap.grabWidget(widget)
-
-        title = None
-        comment = None
-        if self.scanWindowInfoWidget is not None:
-            if not self.infoDockWidget.isHidden():
-                info = self.scanWindowInfoWidget.getInfo()
-                title = info['scan'].get('source', None)
-                comment = info['scan'].get('scan', None)+"\n"
-                h, k, l = info['scan'].get('hkl')
-                if h != "----":
-                    comment += "H = %s  K = %s  L = %s\n" % (h, k, l)
-                peak   = info['graph']['peak']
-                peakAt = info['graph']['peakat']
-                fwhm   = info['graph']['fwhm']
-                fwhmAt = info['graph']['fwhmat']
-                com    = info['graph']['com']
-                mean   = info['graph']['mean']
-                std    = info['graph']['std']
-                minimum = info['graph']['min']
-                maximum = info['graph']['max']
-                delta   = info['graph']['delta']
-                xLabel = self.getGraphXLabel()
-                comment += "Peak %s at %s = %s\n" % (peak, xLabel, peakAt)
-                comment += "FWHM %s at %s = %s\n" % (fwhm, xLabel, fwhmAt)
-                comment += "COM = %s  Mean = %s  STD = %s\n" % (com, mean, std)
-                comment += "Min = %s  Max = %s  Delta = %s\n" % (minimum,
-                                                                maximum,
-                                                                delta)
-
-        if hasattr(self, "scanFit"):
-            if not self.scanFit.isHidden():
-                if comment is None:
-                    comment = ""
-                comment += "\n"
-                comment += self.scanFit.getText()
-
-        if svg:
-            self.printPreview.addSvgItem(self._svgRenderer,
-                                    title=None,
-                                    comment=comment,
-                                    commentPosition="LEFT")
-        else:
-            self.printPreview.addPixmap(pixmap,
-                                    title=None,
-                                    comment=comment,
-                                    commentPosition="LEFT")
-        if self.printPreview.isHidden():
-            self.printPreview.show()
-        self.printPreview.raise_()
-
-    def getSvgRenderer(self, printer=None):
-        if printer is None:
-            if self.printPreview.printer is None:
-                # setup needed
-                self.printPreview.setup()
-            self._printer = self.printPreview.printer
-            printer = self._printer
-        if printer is None:
-            # printer was not selected
-            # return a renderer without adjusting the viewbox
-            if sys.version < '3.0':
-                import cStringIO as StringIO
-                imgData = StringIO.StringIO()
-            else:
-                from io import StringIO
-                imgData = StringIO()
-            self.saveGraph(imgData, fileFormat='svg')
-            imgData.flush()
-            imgData.seek(0)
-            svgData = imgData.read()
-            imgData = None
-            svgRenderer = qt.QSvgRenderer()
-            svgRenderer._svgRawData = svgData
-            svgRenderer._svgRendererData = qt.QXmlStreamReader(svgData)
-            if not svgRenderer.load(svgRenderer._svgRendererData):
-                raise RuntimeError("Cannot interpret svg data")
-            return svgRenderer
-
-        # we have what is to be printed
-        if sys.version < '3.0':
-            import cStringIO as StringIO
-            imgData = StringIO.StringIO()
-        else:
-            from io import StringIO
-            imgData = StringIO()
-        self.saveGraph(imgData, fileFormat='svg')
-        imgData.flush()
-        imgData.seek(0)
-        svgData = imgData.read()
-        imgData = None
-        svgRenderer = qt.QSvgRenderer()
-
-        #svgRenderer = PlotWindow.PlotWindow.getSvgRenderer(self)
-
-        # we have to specify the bounding box
-        config = self.getPrintConfiguration()
-        width = config['width']
-        height = config['height']
-        xOffset = config['xOffset']
-        yOffset = config['yOffset']
-        units = config['units']
-        keepAspectRatio = config['keepAspectRatio']
-
-
-        dpix    = printer.logicalDpiX()
-        dpiy    = printer.logicalDpiY()
-
-        # get the available space
-        availableWidth = printer.width()
-        availableHeight = printer.height()
-
-        # convert the offsets to dpi
-        if units.lower() in ['inch', 'inches']:
-            xOffset = xOffset * dpix
-            yOffset = yOffset * dpiy
-            if width is not None:
-                width = width * dpix
-            if height is not None:
-                height = height * dpiy
-        elif units.lower() in ['cm', 'centimeters']:
-            xOffset = (xOffset/2.54) * dpix
-            yOffset = (yOffset/2.54) * dpiy
-            if width is not None:
-                width = (width/2.54) * dpix
-            if height is not None:
-                height = (height/2.54) * dpiy
-        else:
-            # page units
-            xOffset = availableWidth * xOffset
-            yOffset = availableHeight * yOffset
-            if width is not None:
-                width = availableWidth * width
-            if height is not None:
-                height = availableHeight * height
-
-        availableWidth -= xOffset
-        availableHeight -= yOffset
-
-        if width is not None:
-            if (availableWidth + 0.1) < width:
-                txt = "Available width  %f is less than requested width %f" % \
-                              (availableWidth, width)
-                raise ValueError(txt)
-            availableWidth = width
-        if height is not None:
-            if (availableHeight + 0.1) < height:
-                txt = "Available height  %f is less than requested height %f" % \
-                              (availableHeight, height)
-                raise ValueError(txt)
-            availableHeight = height
-
-        if keepAspectRatio:
-            #get the aspect ratio
-            widget = self.getWidgetHandle()
-            if widget is None:
-                # does this make sense?
-                graphWidth = availableWidth
-                graphHeight = availableHeight
-            else:
-                graphWidth = float(widget.width())
-                graphHeight = float(widget.height())
-
-            graphRatio = graphHeight / graphWidth
-            # that ratio has to be respected
-
-            bodyWidth = availableWidth
-            bodyHeight = availableWidth * graphRatio
-
-            if bodyHeight > availableHeight:
-                bodyHeight = availableHeight
-                bodyWidth = bodyHeight / graphRatio
-        else:
-            bodyWidth = availableWidth
-            bodyHeight = availableHeight
-
-        body = qt.QRectF(xOffset,
-                         yOffset,
-                         bodyWidth,
-                         bodyHeight)
-        # this does not work if I set the svgData before
-        svgRenderer.setViewBox(body)
-        svgRenderer._viewBox = body
-        if not sys.version.startswith("2"):
-            svgData = svgData.encode(encoding="utf-8",
-                                     errors="replace")
-        svgRenderer._svgRawData = svgData
-        svgRenderer._svgRendererData = qt.QXmlStreamReader(svgData)
-
-        if not svgRenderer.load(svgRenderer._svgRendererData):
-            raise RuntimeError("Cannot interpret svg data")
-        return svgRenderer
 
 def test():
-    w = ScanWindow()
+    import numpy
+    app = qt.QApplication([])
+    w = ScanWindow(info=True)
     x = numpy.arange(1000.)
-    y =  10 * x + 10000. * numpy.exp(-0.5*(x-500)*(x-500)/400)
-    w.addCurve(x, y, legend="dummy", replot=True, replace=True)
+    y1 = 10 * x + 10000. * numpy.exp(-0.5*(x-500)*(x-500)/400)
+    y2 = y1 + 5000. * numpy.exp(-0.5*(x-700)*(x-700)/200)
+    y3 = y1 + 7000. * numpy.exp(-0.5*(x-200)*(x-200)/1000)
+    w.addCurve(x, y1, legend="dummy1",
+               info={"SourceName": "Synthetic data 1 (linear+gaussian)",
+                     "hkl": [1.1, 1.2, 1.3],
+                     "Header": ["#S 1 toto"]})
+    w.addCurve(x, y2, legend="dummy2",
+               info={"SourceName": "Synthetic data 2",
+                     "hkl": [2.1, 2.2, 2.3],
+                     "Header": ["#S 2"]})
+    w.addCurve(x, y3, legend="dummy3",
+               info={"SourceName": "Synthetic data 3",
+                     "hkl": ["3.1", 3.2, 3.3],
+                     "Header": ["#S 3"]})
     w.resetZoom()
     app.lastWindowClosed.connect(app.quit)
     w.show()

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -170,6 +170,8 @@ class BaseScanWindow(PlotWindow):
 
             self.sigActiveCurveChanged.connect(self.__updateInfoWidget)
 
+        self.sigActiveCurveChanged.connect(self.__updateGraphTitle)
+
     def _customControlButtonMenu(self):
         """Display Options button sub-menu. Overloaded to add
         _toggleInfoAction"""
@@ -189,8 +191,16 @@ class BaseScanWindow(PlotWindow):
         controlMenu.addAction(self.getPanWithArrowKeysAction())
 
     def __updateInfoWidget(self, previous_legend, legend):
+        """Called on active curve changed, to update the info widget"""
         x, y, legend, info, params = self.getCurve(legend)
         self.scanWindowInfoWidget.updateFromXYInfo(x, y, info)
+
+    def __updateGraphTitle(self, previous_legend, legend):
+        """Called on active curve changed, to update the graph title"""
+        if legend is None and previous_legend is not None:
+            self.setGraphTitle()
+        elif legend is not None:
+            self.setGraphTitle(legend)
 
     def setWindowType(self, wtype=None):
         if wtype not in [None, "SCAN", "MCA"]:

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -91,15 +91,15 @@ class BaseScanWindow(PlotWindow):
                                              mask=False,
                                              colormap=False)
         self.setDataMargins(0, 0, 0.025, 0.025)
+        self.setIconSize(qt.QSize(20, 20))
+
         self.setPanWithArrowKeys(True)
         self._plotType = "SCAN"     # needed by legacy plugins
 
         self.setWindowTitle(name)
 
         # Toolbar
-        # self.toolBar().setIconSize(qt.QSize(15, 18))
         self._toolbar = qt.QToolBar(self)
-        # self._toolbar.setIconSize(qt.QSize(15, 18))
 
         self.addToolBar(self._toolbar)
 

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -460,7 +460,7 @@ class ScanWindow(BaseScanWindow):
                 del self.dataObjectsDict[legend]
 
     def addCurve(self, x, y, legend=None, info=None, replace=False,
-                 resetzoom=False, color=None, symbol=None,
+                 resetzoom=True, color=None, symbol=None,
                  linestyle=None, xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, **kw):
         """Add a curve. If a curve with the same legend already exists,
@@ -519,7 +519,7 @@ class ScanWindow(BaseScanWindow):
                     resetzoom=resetzoom, **kw)
 
     def newCurve(self, x, y, legend=None, info=None, replace=False,
-                 resetzoom=False, color=None, symbol=None,
+                 resetzoom=True, color=None, symbol=None,
                  linestyle=None, xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, **kw):
         """

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -73,7 +73,7 @@ if userPluginsDirectory is not None:
 
 
 _logger = logging.getLogger(__name__)
-_logger.setLevel(logging.DEBUG)
+# _logger.setLevel(logging.DEBUG)
 
 
 class BaseScanWindow(PlotWindow):
@@ -448,12 +448,16 @@ class ScanWindow(BaseScanWindow):
                 del self.dataObjectsDict[legend]
 
     def addCurve(self, x, y, legend=None, info=None, replace=False,
-                 resetzoom=False, replot=True, color=None, symbol=None,
+                 resetzoom=False, color=None, symbol=None,
                  linestyle=None, xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, **kw):
         """Add a curve. If a curve with the same legend already exists,
         the unspecified parameters (color, symbol, linestyle, yaxis) are
         assumed to be identical to the parameters of the existing curve."""
+        if "replot" in kw:
+            _logger.warning("addCurve deprecated replot argument, "
+                            "use resetzoom instead")
+            resetzoom = kw["replot"] and resetzoom
         if legend in self._curveList:
             if info is None:
                 info = {}
@@ -488,7 +492,7 @@ class ScanWindow(BaseScanWindow):
         if legend in self.dataObjectsDict:
             # the info is changing
             super(ScanWindow, self).addCurve(
-                    x, y, legend=legend, info=info, replot=replot,
+                    x, y, legend=legend, info=info,
                     replace=replace, color=color, symbol=symbol,
                     linestyle=linestyle, xlabel=xlabel, ylabel=ylabel,
                     yaxis=yaxis, xerror=xerror, yerror=yerror,
@@ -496,19 +500,23 @@ class ScanWindow(BaseScanWindow):
         else:
             # create the data object
             self.newCurve(
-                    x, y, legend=legend, info=info, replot=replot,
+                    x, y, legend=legend, info=info,
                     replace=replace, color=color, symbol=symbol,
                     linestyle=linestyle, xlabel=xlabel, ylabel=ylabel,
                     yaxis=yaxis, xerror=xerror, yerror=yerror,
                     resetzoom=resetzoom, **kw)
 
     def newCurve(self, x, y, legend=None, info=None, replace=False,
-                 resetzoom=False, replot=True, color=None, symbol=None,
+                 resetzoom=False, color=None, symbol=None,
                  linestyle=None, xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, **kw):
         """
         Create and add a data object to :attr:`dataObjectsDict`
         """
+        if "replot" in kw:
+            _logger.warning("addCurve deprecated replot argument, "
+                            "use resetzoom instead")
+            resetzoom = kw["replot"] and resetzoom
         if legend is None:
             legend = "Unnamed curve 1.1"
         if xlabel is None:
@@ -551,7 +559,7 @@ class ScanWindow(BaseScanWindow):
         if replace:
             self._replaceSelection(sel_list)
         else:
-            self._addSelection(sel_list, resetzoom=replot)
+            self._addSelection(sel_list, resetzoom=resetzoom)
 
 
 def test():

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -89,7 +89,10 @@ class BaseScanWindow(PlotWindow):
                                              control=control,
                                              position=position,
                                              mask=False,
-                                             colormap=False)
+                                             colormap=False,
+                                             aspectRatio=False,
+                                             yInverted=False,
+                                             copy=False)
         self.setDataMargins(0, 0, 0.025, 0.025)
         self.setIconSize(qt.QSize(20, 20))
 

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -101,7 +101,12 @@ class BaseScanWindow(PlotWindow):
 
         self.setWindowTitle(name)
 
-        # Toolbar
+        # Toolbar:
+        # hide zoom and pan mode button
+        self.zoomModeAction.setVisible(False)
+        self.panModeAction.setVisible(False)
+
+        # additional buttons
         self._toolbar = qt.QToolBar(self)
 
         self.addToolBar(self._toolbar)

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -123,18 +123,30 @@ class BaseScanWindow(PlotWindow):
         self._toolbar.addAction(self.yMinToZero)
         self._toolbar.addAction(self.subtractAction)
 
+        self.pluginsToolButton = None
+        """Plugins tool button, used to load and call plugins.
+        It inherits the PluginLoader API:
+
+            - getPlugins
+            - getPluginDirectoryList
+            - setPluginDirectoryList
+
+        It can be None, if plugins are disabled when initializing
+        the ScanWindow.
+        """
+
         if plugins:
-            pluginsToolButton = PluginsToolButton(plot=self)
+            self.pluginsToolButton = PluginsToolButton(plot=self)
 
             if PLUGINS_DIR is not None:
                 if isinstance(PLUGINS_DIR, list):
                     pluginDir = PLUGINS_DIR
                 else:
                     pluginDir = [PLUGINS_DIR]
-                pluginsToolButton.getPlugins(
+                self.pluginsToolButton.getPlugins(
                         method="getPlugin1DInstance",
                         directoryList=pluginDir)
-            self._toolbar.addWidget(pluginsToolButton)
+            self._toolbar.addWidget(self.pluginsToolButton)
 
         self.scanWindowInfoWidget = None
         self.infoDockWidget = None

--- a/PyMca5/PyMcaGui/pymca/ScanWindowInfoWidget.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindowInfoWidget.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -28,7 +28,7 @@ __author__ = "V.A. Sole - ESRF Data Analysis"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-import sys
+
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
 QTVERSION = qt.qVersion()
@@ -43,44 +43,46 @@ This module implements an info widget containing :
 """
 
 
-DEBUG=0
-STATISTICS=1
+DEBUG = 0
+STATISTICS = 1
+
+
 class SpecArithmetic(object):
     """
     This class tries to mimic SPEC operations.
     Correct peak positions and fwhm information
     have to be made via a fit.
     """
+
     def search_peak(self, xdata, ydata):
-         """
-         Search a peak and its position in arrays xdata ad ydata.
-         Return three integer:
-           - peak position
-           - peak value
-           - index of peak position in array xdata
-             This result may accelerate the fwhm search.
-         """
-         ydata = numpy.array(ydata, copy=False)
-         ymax   = ydata[numpy.isfinite(ydata)].max()
-         idx    = self.__give_index(ymax, ydata)
-         return xdata[idx], ymax, idx
+        """
+        Search a peak and its position in arrays xdata ad ydata.
+        Return three integer:
+          - peak position
+          - peak value
+          - index of peak position in array xdata
+            This result may accelerate the fwhm search.
+        """
+        ydata = numpy.array(ydata, copy=False)
+        ymax = ydata[numpy.isfinite(ydata)].max()
+        idx = self.__give_index(ymax, ydata)
+        return xdata[idx], ymax, idx
 
-
-    def search_com(self, xdata,ydata):
+    @staticmethod
+    def search_com(xdata, ydata):
         """
         Return the center of mass in arrays xdata and ydata
         """
-        num    = numpy.sum(xdata*ydata)
-        denom  = numpy.sum(ydata)
+        num = numpy.sum(xdata * ydata)
+        denom = numpy.sum(ydata)
         if abs(denom) > 0:
-           result = num/denom
+            result = num / denom
         else:
-           result = 0
+            result = 0
 
         return result
 
-
-    def search_fwhm(self, xdata,ydata,peak=None,index=None):
+    def search_fwhm(self, xdata, ydata, peak=None, index=None):
         """
         Search a fwhm and its center in arrays xdata and ydatas.
         If no fwhm is found, (0,0) is returned.
@@ -88,23 +90,23 @@ class SpecArithmetic(object):
         accelerate calculation
         """
         if peak is None or index is None:
-            x,mypeak,index_peak = self.search_peak(xdata,ydata)
+            x, mypeak, index_peak = self.search_peak(xdata, ydata)
         else:
-            mypeak     = peak
+            mypeak = peak
             index_peak = index
 
-        hm = mypeak/2
+        hm = mypeak / 2
         idx = index_peak
 
         try:
             while ydata[idx] >= hm:
-               idx = idx-1
+                idx -= 1
             x0 = float(xdata[idx])
-            x1 = float(xdata[idx+1])
+            x1 = float(xdata[idx + 1])
             y0 = float(ydata[idx])
-            y1 = float(ydata[idx+1])
+            y1 = float(ydata[idx + 1])
 
-            lhmx = (hm*(x1-x0) - (y0*x1)+(y1*x0)) / (y1-y0)
+            lhmx = (hm * (x1 - x0) - (y0 * x1) + (y1 * x0)) / (y1 - y0)
         except ZeroDivisionError:
             lhmx = 0
         except IndexError:
@@ -113,38 +115,39 @@ class SpecArithmetic(object):
         idx = index_peak
         try:
             while ydata[idx] >= hm:
-                idx = idx+1
+                idx += 1
 
-            x0 = float(xdata[idx-1])
+            x0 = float(xdata[idx - 1])
             x1 = float(xdata[idx])
-            y0 = float(ydata[idx-1])
+            y0 = float(ydata[idx - 1])
             y1 = float(ydata[idx])
 
-            uhmx = (hm*(x1-x0) - (y0*x1)+(y1*x0)) / (y1-y0)
+            uhmx = (hm * (x1 - x0) - (y0 * x1) + (y1 * x0)) / (y1 - y0)
         except ZeroDivisionError:
             uhmx = 0
         except IndexError:
             uhmx = xdata[-1]
 
-        FWHM  = uhmx - lhmx
-        CFWHM = (uhmx+lhmx)/2
-        return FWHM,CFWHM
+        fwhm = uhmx - lhmx
+        cfwhm = (uhmx + lhmx) / 2
+        return fwhm, cfwhm
 
+    @staticmethod
+    def __give_index(elem, array):
+        """
+        Return the index of elem in array
+        """
+        mylist = array.tolist()
+        return mylist.index(elem)
 
-    def __give_index(self, elem,array):
-         """
-         Return the index of elem in array
-         """
-         mylist = array.tolist()
-         return mylist.index(elem)
 
 class HKL(qt.QWidget):
-    def __init__(self, parent = None, h= "", k= "", l=""):
+
+    def __init__(self, parent=None, h="", k="", l=""):
         qt.QWidget.__init__(self, parent)
         layout = qt.QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
-
 
         hlabel = qt.QLabel(self)
         hlabel.setText('H:')
@@ -176,91 +179,98 @@ class HKL(qt.QWidget):
 
     def setHKL(self, h="", k="", l=""):
         dformat = "%.4f"
-        if type(h) == type (""):
+        if isinstance(h, str):
             self.h.setText(h)
         else:
             self.h.setText(dformat % h)
-        if type(k) == type (""):
+        if isinstance(k, str):
             self.k.setText(k)
         else:
             self.k.setText(dformat % k)
-        if type(l) == type (""):
+        if isinstance(l, str):
             self.l.setText(l)
         else:
             self.l.setText(dformat % l)
 
+
 class GraphInfoWidget(qt.QWidget):
+    """Widget displaying statistics about curve data:
+    peak info (x position, y value, fwhm, center of fwhm), max y value,
+    min y value, delta y, mean y, center of mass of y values, standard
+    deviation of y.
+
+    This information is extracted directly from the curve data."""
     def __init__(self, parent):
         qt.QWidget.__init__(self, parent)
         layout = qt.QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
 
-        #peak
-        peak   = qt.QLabel(self)
+        # peak
+        peak = qt.QLabel(self)
         peak.setText("Peak:  ")
         self.peak = qt.QLineEdit(self)
         self.peak.setReadOnly(True)
-        hboxPeak   = qt.QWidget(self)
+        hboxPeak = qt.QWidget(self)
         hboxPeak.l = qt.QHBoxLayout(hboxPeak)
         hboxPeak.l.setContentsMargins(0, 0, 0, 0)
         hboxPeak.l.setSpacing(0)
-        peakAt     = qt.QLabel(hboxPeak)
+        peakAt = qt.QLabel(hboxPeak)
         peakAt.setText(" at:")
         self.peakAt = qt.QLineEdit(hboxPeak)
         self.peak.setReadOnly(True)
         hboxPeak.l.addWidget(peakAt)
         hboxPeak.l.addWidget(self.peakAt)
 
-        #fwhm
-        fwhm   = qt.QLabel(self)
+        # fwhm
+        fwhm = qt.QLabel(self)
         fwhm.setText("Fwhm: ")
         self.fwhm = qt.QLineEdit(self)
         self.fwhm.setReadOnly(True)
-        hboxFwhm   = qt.QWidget(self)
+        hboxFwhm = qt.QWidget(self)
         hboxFwhm.l = qt.QHBoxLayout(hboxFwhm)
         hboxFwhm.l.setContentsMargins(0, 0, 0, 0)
         hboxFwhm.l.setSpacing(0)
-        fwhmAt     = qt.QLabel(hboxFwhm)
+        fwhmAt = qt.QLabel(hboxFwhm)
         fwhmAt.setText(" at:")
         self.fwhmAt = qt.QLineEdit(hboxFwhm)
         self.fwhm.setReadOnly(True)
         hboxFwhm.l.addWidget(fwhmAt)
         hboxFwhm.l.addWidget(self.fwhmAt)
 
-        #statistics
-        #COM
-        com   = qt.QLabel(self)
+        # statistics
+        # COM
+        com = qt.QLabel(self)
         com.setText("COM:")
         self.com = qt.QLineEdit(self)
         self.com.setReadOnly(True)
 
-        #mean
-        mean   = qt.QLabel(self)
+        # mean
+        mean = qt.QLabel(self)
         mean.setText("Mean:")
         self.mean = qt.QLineEdit(self)
         self.mean.setReadOnly(True)
 
-        #STD
-        std   = qt.QLabel(self)
+        # STD
+        std = qt.QLabel(self)
         std.setText("STD:")
         self.std = qt.QLineEdit(self)
         self.std.setReadOnly(True)
 
-        #Max
-        maximum   = qt.QLabel(self)
+        # Max
+        maximum = qt.QLabel(self)
         maximum.setText("Max:")
-        self.maximum= qt.QLineEdit(self)
+        self.maximum = qt.QLineEdit(self)
         self.maximum.setReadOnly(True)
 
-        #mean
-        minimum   = qt.QLabel(self)
+        # mean
+        minimum = qt.QLabel(self)
         minimum.setText("Min:")
-        self.minimum= qt.QLineEdit(self)
+        self.minimum = qt.QLineEdit(self)
         self.minimum.setReadOnly(True)
 
-        #STD
-        delta   = qt.QLabel(self)
+        # STD
+        delta = qt.QLabel(self)
         delta.setText("Delta:")
         self.delta = qt.QLineEdit(self)
         self.delta.setReadOnly(True)
@@ -286,59 +296,46 @@ class GraphInfoWidget(qt.QWidget):
         layout.addWidget(self.delta,    1, 8)
         self.specArithmetic = SpecArithmetic()
 
-    def updateFromDataObject(self, dataObject):
-        ydata = numpy.ravel(dataObject.y[0])
-        ylen = len(ydata)
-        if ylen:
-            if dataObject.x is None:
-                xdata = numpy.arange(ylen).astype(numpy.float)
-            elif not len(dataObject.x):
-                xdata = numpy.arange(ylen).astype(numpy.float)
-            else:
-                xdata = numpy.ravel(dataObject.x[0])
-        else:
-            xdata = None
-        self.updateFromXY(xdata, ydata)
-
-
     def updateFromXY(self, xdata, ydata):
         if len(ydata):
-            peakpos,peak,myidx = self.specArithmetic.search_peak(xdata,ydata)
-            com                = self.specArithmetic.search_com(xdata,ydata)
-            fwhm,cfwhm         = self.specArithmetic.search_fwhm(xdata,ydata,
-                                                  peak=peak,index=myidx)
-            ymax  = max(ydata)
-            ymin  = min(ydata)
+            peakpos, peak, myidx = self.specArithmetic.search_peak(
+                xdata, ydata)
+            com = self.specArithmetic.search_com(xdata, ydata)
+            fwhm, cfwhm = self.specArithmetic.search_fwhm(xdata, ydata,
+                                                          peak=peak, index=myidx)
+            ymax = max(ydata)
+            ymin = min(ydata)
             ymean = sum(ydata) / len(ydata)
             if len(ydata) > 1:
-                ystd  = numpy.sqrt(sum((ydata-ymean)*(ydata-ymean))/len(ydata))
+                ystd = numpy.sqrt(
+                    sum((ydata - ymean) * (ydata - ymean)) / len(ydata))
             else:
                 ystd = 0
-            delta   = ymax - ymin
+            delta = ymax - ymin
             fformat = "%.7g"
             peakpos = fformat % peakpos
-            peak    = fformat % peak
-            myidx   = "%d" % myidx
-            com     = fformat % com
-            fwhm    = fformat % fwhm
-            cfwhm   = fformat % cfwhm
-            ymean   = fformat % ymean
-            ystd    = fformat % ystd
-            ymax    = fformat % ymax
-            ymin    = fformat % ymin
-            delta   = fformat % delta
+            peak = fformat % peak
+            # myidx = "%d" % myidx
+            com = fformat % com
+            fwhm = fformat % fwhm
+            cfwhm = fformat % cfwhm
+            ymean = fformat % ymean
+            ystd = fformat % ystd
+            ymax = fformat % ymax
+            ymin = fformat % ymin
+            delta = fformat % delta
         else:
             peakpos = "----"
-            peak    = "----"
-            myidx   = "----"
-            com     = "----"
-            fwhm    = "----"
-            cfwhm   = "----"
-            ymean   = "----"
-            ystd    = "----"
-            ymax    = "----"
-            ymin    = "----"
-            delta   = "----"
+            peak = "----"
+            # myidx = "----"
+            com = "----"
+            fwhm = "----"
+            cfwhm = "----"
+            ymean = "----"
+            ystd = "----"
+            ymax = "----"
+            ymin = "----"
+            delta = "----"
         self.peak.setText(peak)
         self.peakAt.setText(peakpos)
         self.fwhm.setText(fwhm)
@@ -351,29 +348,32 @@ class GraphInfoWidget(qt.QWidget):
         self.delta.setText(delta)
 
     def getInfo(self):
-        ddict={}
-        ddict['peak']   = self.peak.text()
-        ddict['peakat'] = self.peakAt.text()
-        ddict['fwhm']   = self.fwhm.text()
-        ddict['fwhmat'] = self.fwhmAt.text()
-        ddict['com']    = self.com.text()
-        ddict['mean']   = self.mean.text()
-        ddict['std']    = self.std.text()
-        ddict['min']    = self.minimum.text()
-        ddict['max']    = self.maximum.text()
-        ddict['delta']  = self.delta.text()
-        return ddict
-
+        return {
+            'peak': self.peak.text(),
+            'peakat': self.peakAt.text(),
+            'fwhm': self.fwhm.text(),
+            'fwhmat': self.fwhmAt.text(),
+            'com': self.com.text(),
+            'mean': self.mean.text(),
+            'std': self.std.text(),
+            'min': self.minimum.text(),
+            'max': self.maximum.text(),
+            'delta': self.delta.text(),
+        }
 
 
 class ScanInfoWidget(qt.QWidget):
-    def __init__(self, parent = None):
+    """Widget displaying curve metadata:
+    data source, first scan header line, H, K, L
+
+    This information is extracted from the curve info dict."""
+    def __init__(self, parent=None):
         qt.QWidget.__init__(self, parent)
         layout = qt.QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(2)
 
-        #scan info
+        # scan info
         hBox = qt.QWidget(self)
         hBoxLayout = qt.QHBoxLayout(hBox)
         hBoxLayout.setContentsMargins(0, 0, 0, 0)
@@ -392,22 +392,21 @@ class ScanInfoWidget(qt.QWidget):
 
         self.hkl = HKL(self)
         layout.addWidget(hBox, 0, 0, 1, 7)
-        #layout.addWidget(self.sourceLabel, 0, 1)#, 1, 9)
+        # layout.addWidget(self.sourceLabel, 0, 1)#, 1, 9)
         layout.addWidget(scanLabel,        1, 0)
         layout.addWidget(self.scanLabel,   1, 1)
         layout.addWidget(self.hkl,         1, 4, 1, 3)
 
-    def updateFromDataObject(self, dataObject):
-        info = dataObject.info
+    def updateFromInfoDict(self, info):
         source = info.get('SourceName', None)
         if source is None:
             self.sourceLabel.setText("")
         else:
-            if type(source) == type(""):
+            if isinstance(source, str):
                 self.sourceLabel.setText(source)
             else:
                 self.sourceLabel.setText(source[0])
-        scan   = info.get('Header', None)
+        scan = info.get('Header', None)
         if scan is None:
             scan = ""
             if "envdict" in info:
@@ -415,63 +414,55 @@ class ScanInfoWidget(qt.QWidget):
             self.scanLabel.setText(scan)
         else:
             self.scanLabel.setText(scan[0])
-        hkl    = info.get('hkl', None)
+        hkl = info.get('hkl', None)
         if hkl is None:
             self.hkl.setHKL("----", "----", "----")
         else:
             self.hkl.setHKL(*hkl)
 
     def getInfo(self):
-        ddict = {}
-        ddict['source'] = self.sourceLabel.text()
-        ddict['scan'] = self.scanLabel.text()
-        ddict['hkl'] = ["%s" % self.hkl.h.text(),
-                        "%s" % self.hkl.k.text(),
-                        "%s" % self.hkl.l.text()]
-        return ddict
+        return {
+            'source': self.sourceLabel.text(),
+            'scan': self.scanLabel.text(),
+            'hkl': ["%s" % self.hkl.h.text(),
+                    "%s" % self.hkl.k.text(),
+                    "%s" % self.hkl.l.text()]
+        }
+
 
 class ScanWindowInfoWidget(qt.QWidget):
-    def __init__(self, parent = None):
+
+    def __init__(self, parent=None):
         qt.QWidget.__init__(self, parent)
         layout = qt.QVBoxLayout(self)
         layout.setContentsMargins(2, 2, 2, 2)
         layout.setSpacing(2)
 
-        self.scanInfo  = ScanInfoWidget(self)
+        self.scanInfo = ScanInfoWidget(self)
         self.graphInfo = GraphInfoWidget(self)
 
         layout.addWidget(self.scanInfo)
         layout.addWidget(self.graphInfo)
-        #print "hiding graph info"
-        #self.graphInfo.hide()
 
-    def updateFromDataObject(self, dataObject):
-        self.scanInfo.updateFromDataObject(dataObject)
-        self.graphInfo.updateFromDataObject(dataObject)
+    def updateFromXYInfo(self, xdata, ydata, info):
+        self.scanInfo.updateFromInfoDict(info)
+        self.graphInfo.updateFromXY(xdata, ydata)
 
     def getInfo(self):
-        ddict = {}
-        ddict['scan']  = self.scanInfo.getInfo()
-        ddict['graph'] = self.graphInfo.getInfo()
-        return ddict
+        return {
+            'scan': self.scanInfo.getInfo(),
+            'graph': self.graphInfo.getInfo()
+        }
+
 
 def test():
-        app = qt.QApplication([])
-        w   = ScanWindowInfoWidget()
-        app.lastWindowClosed.connect(app.quit)
-        """
-        winfo.grid(sticky='wesn')
-        if STATISTICS:
-          winfo.configure(h=65,k=45621,l=32132,peak=6666876,
-                            fwhm=0.2154,com=544,
-                            ymax=10.,ymin=4,ystd=1,ymean=5)
-        else:
-          winfo.configure(h=65,k=45621,l=32132,peak=6666876,
-                        fwhm=0.2154,com=544)
-        """
-        w.show()
-        app.exec_()
+    app = qt.QApplication([])
+    w = ScanWindowInfoWidget()
+    app.lastWindowClosed.connect(app.quit)
+    w.show()
+    app.exec_()
 
 
 if __name__ == '__main__':
-        test()
+    test()
+

--- a/PyMca5/PyMcaGui/pymca/SumRulesTool.py
+++ b/PyMca5/PyMcaGui/pymca/SumRulesTool.py
@@ -37,14 +37,16 @@ import numpy
 from PyMca5.PyMcaMath.fitting.SpecfitFuns import upstep, downstep
 
 from PyMca5.PyMca import PyMcaQt as qt
-from PyMca5.PyMca import PlotWindow as DataDisplay
+
 from PyMca5.PyMca import Elements
 from PyMca5.PyMca import ConfigDict
 
 from PyMca5.PyMca import PyMcaDataDir, PyMcaDirs
 from PyMca5.PyMca import QSpecFileWidget
 from PyMca5.PyMca import SpecFileDataSource
-from PyMca5.PyMcaGui import IconDict
+
+from silx.gui.plot import PlotWindow as DataDisplay
+from silx.gui.plot.LegendSelector import LegendsDockWidget
 
 if hasattr(qt, "QString"):
     QString = qt.QString
@@ -154,9 +156,9 @@ class MarkerSpinBox(qt.QDoubleSpinBox):
         self.window = window
         self.plotWindow = plotWindow
         #self.graph = graph
-        self.markerID = self.plotWindow.insertXMarker(0.,
-                                                      legend=label,
-                                                      text=label)
+        self.markerID = self.plotWindow.addXMarker(0.,
+                                                   legend=label,
+                                                   text=label)
 
         # Initialize
         self.setMinimum(0.)
@@ -198,7 +200,7 @@ class MarkerSpinBox(qt.QDoubleSpinBox):
 
     def showMarker(self):
         self.plotWindow.removeMarker(self.label)
-        self.markerID = self.plotWindow.insertXMarker(
+        self.markerID = self.plotWindow.addXMarker(
                                 self.value(),
                                 legend=self.label,
                                 text=self.label,
@@ -218,7 +220,7 @@ class MarkerSpinBox(qt.QDoubleSpinBox):
             draggable  = False
         # Make shure that the marker is deleted
         # If marker is not present, removeMarker just passes..
-        self.markerID = self.plotWindow.insertXMarker(
+        self.markerID = self.plotWindow.addXMarker(
                                 self.value(),
                                 legend=self.label,
                                 text=self.label,
@@ -245,7 +247,7 @@ class MarkerSpinBox(qt.QDoubleSpinBox):
                 print('_valueChanged -- Sorry, it ain\'t gonna float: %s'%str(val))
             return
         # Marker of same label as self.label gets replaced..
-        self.markerID = self.plotWindow.insertXMarker(
+        self.markerID = self.plotWindow.addXMarker(
                                 val,
                                 legend=self.label,
                                 text=self.label,
@@ -370,45 +372,22 @@ class SumRulesWindow(qt.QMainWindow):
     def __init__(self, parent=None):
         qt.QMainWindow.__init__(self, parent)
         self.setWindowTitle('Sum Rules Tool')
-        if hasattr(DataDisplay,'PlotWindow'):
-            self.plotWindow = DataDisplay.PlotWindow(
-                parent=self,
-                backend=None,
-                plugins=False, # Hide plugin tool button
-                newplot=False, # Hide mirror active curve, ... functionality
-                roi=False,     # No ROI widget
-                control=False, # Hide option button
-                position=True, # Show x,y position display
-                kw={'logx': False, # Hide logarithmic x-scale tool button
-                    'logy': False, # Hide logarithmic y-scale tool button
-                    'flip': False, # Hide whatever this does
-                    'fit': False}) # Hide simple fit tool button
-            self.plotWindow._buildLegendWidget()
-        else:
-            self.plotWindow = DataDisplay.ScanWindow(self)
+        self.plotWindow = DataDisplay(
+            parent=self,
+            roi=False,      # No ROI widget
+            control=False,  # hide option button, legend widget added later
+            position=True,  # Show x,y position display
+            fit=False,      # Hide simple fit tool button
+            colormap=False,
+            aspectRatio=False,
+            yInverted=False,
+            copy=False,
+            print_=False,
+            mask=False)
 
-        # Hide Buttons in the toolbar
-        if hasattr(self.plotWindow,'scanWindowInfoWidget'):
-            # Get rid of scanInfoWidget
-            self.plotWindow.scanWindowInfoWidget.hide()
-            self.plotWindow.graph.enablemarkermode()
-            # Hide unnecessary buttons in the toolbar
-            toolbarChildren = self.plotWindow.toolBar
-            # QWidget.findChildren(<qt-type>) matches
-            # all child widgets with the specified type
-            toolbarButtons  = toolbarChildren.findChildren(qt.QToolButton)
-            toolbarButtons[3].hide() # LogX
-            toolbarButtons[4].hide() # LogY
-            toolbarButtons[6].hide() # Simple Fit
-            toolbarButtons[7].hide() # Average Plotted Curves
-            toolbarButtons[8].hide() # Derivative
-            toolbarButtons[9].hide() # Smooth
-            toolbarButtons[11].hide() # Set active to zero
-            toolbarButtons[12].hide() # Subtract active curve
-            toolbarButtons[13].hide() # Save active curve
-            toolbarButtons[14].hide() # Plugins
-        else:
-            self.plotWindow
+        self._legendsDockWidget = LegendsDockWidget(plot=self.plotWindow)
+        self.plotWindow.addDockWidget(qt.Qt.RightDockWidgetArea,
+                                      self._legendsDockWidget)
 
         self.__savedConf = False
         self.__savedData = False
@@ -822,8 +801,8 @@ class SumRulesWindow(qt.QMainWindow):
         self.buttonEstimate.setShortcut(qt.Qt.CTRL+qt.Qt.Key_E)
         self.buttonEstimate.clicked.connect(self.estimate)
         self.buttonEstimate.setEnabled(False)
-        self.plotWindow.toolBar.addSeparator()
-        self.plotWindow.toolBar.addWidget(self.buttonEstimate)
+        self.plotWindow.toolBar().addSeparator()
+        self.plotWindow.toolBar().addWidget(self.buttonEstimate)
 
         self.plotWindow.sigPlotSignal.connect(self._handlePlotSignal)
 
@@ -1349,10 +1328,7 @@ class SumRulesWindow(qt.QMainWindow):
                         tmp = float(value)
                         obj.setValue(tmp)
                     except ValueError:
-                        if hasattr(self.plotWindow,'graph'):
-                            xmin, xmax = self.plotWindow.graph.getX1AxisLimits()
-                        else:
-                            xmin, xmax = self.plotWindow.getGraphXLimits()
+                        xmin, xmax = self.plotWindow.getGraphXLimits()
                         tmp = xmin + (xmax-xmin)/10.
                         if DEBUG:
                             msg  = 'setValuesDict -- Float conversion failed'
@@ -1416,7 +1392,6 @@ class SumRulesWindow(qt.QMainWindow):
         # Add spectrum to plotWindow using the
         if identifier == 'xmcd':
             self.xmcdData = (xSorted, ySorted)
-            #self.plotWindow.graph.mapToY2(intLegend)
         elif identifier == 'xas':
             self.xasData  = (xSorted, ySorted)
         # Trigger replot when data is added
@@ -1599,36 +1574,25 @@ class SumRulesWindow(qt.QMainWindow):
                                  model,
                                  self.__xasBGmodel,
                                  {},
-                                 replot=False)
+                                 resetzoom=False)
         self.plotWindow.addCurve(x,
                                  preModel,
                                  'Pre BG model',
                                  {},
-                                 replot=False)
+                                 resetzoom=False)
         self.plotWindow.addCurve(x,
                                  postModel,
                                  'Post BG model',
                                  {},
-                                 replot=False)
-        if hasattr(self.plotWindow, 'graph'):
-            self.plotWindow.graph.replot()
-        else:
-            self.plotWindow.replot()
-            self.plotWindow.updateLegends()
+                                 resetzoom=False)
 
     def plotOnDemand(self, window):
         # Remove all curves
-        if hasattr(self.plotWindow,'graph'):
-            legends = self.plotWindow.getAllCurves(just_legend=True)
-            for legend in legends:
-                self.plotWindow.removeCurve(legend, replot=False)
-        else:
-            self.plotWindow.clearCurves()
+        self.plotWindow.clearCurves()
         if (self.xmcdData is None) or (self.xasData is None):
             # Nothing to do
             return
         xyList  = []
-        mapToY2 = False
         window = window.lower()
         if window == self.__tabElem:
             if self.xmcdCorrData is not None:
@@ -1706,27 +1670,22 @@ class SumRulesWindow(qt.QMainWindow):
                     legend=legend,
                     info=info,
                     replace=False,
-                    replot=True)
-        # Assure margins in plot when using matplotlibbacken
-        if not hasattr(self.plotWindow, 'graph'):
-            if DEBUG == 1:
-                print('plotOnDemand -- Setting margins..')
-                print('\txmin:',xmin,'xmax:',xmax)
-                print('\tymin:',ymin,'ymax:',ymax)
-            # Pass if no curves present
-            curves = self.plotWindow.getAllCurves(just_legend=True)
-            if len(curves) == 0:
-                # At this point xymin, xymax should be infinite..
-                pass
-            xmargin = 0.1 * (xmax - xmin)
-            ymargin = 0.1 * (ymax - ymin)
-            self.plotWindow.setGraphXLimits(xmin-xmargin,
-                                            xmax+xmargin)
-            self.plotWindow.setGraphYLimits(ymin-ymargin,
-                                            ymax+ymargin)
-            # Need to force replot here for correct display
-            self.plotWindow.replot()
-            self.plotWindow.updateLegends()
+                    resetzoom=True)
+        # Assure margins in plot when using matplotlibbackend
+        if DEBUG == 1:
+            print('plotOnDemand -- Setting margins..')
+            print('\txmin:',xmin,'xmax:',xmax)
+            print('\tymin:',ymin,'ymax:',ymax)
+        # Pass if no curves present
+        if not len(self.plotWindow.getAllCurves(just_legend=True)):
+            # At this point xymin, xymax should be infinite..
+            pass
+        xmargin = 0.1 * (xmax - xmin)
+        ymargin = 0.1 * (ymax - ymin)
+        self.plotWindow.setGraphXLimits(xmin-xmargin,
+                                        xmax+xmargin)
+        self.plotWindow.setGraphYLimits(ymin-ymargin,
+                                        ymax+ymargin)
 
     def addMarker(self, window, label='X MARKER', xpos=None, unit=''):
         # Add spinbox controlling the marker

--- a/PyMca5/PyMcaPlugins/AdvancedAlignmentScanPlugin.py
+++ b/PyMca5/PyMcaPlugins/AdvancedAlignmentScanPlugin.py
@@ -1083,7 +1083,7 @@ if __name__ == "__main__":
     a.show()
 
     x = numpy.arange(250, 750, 2, dtype=float)
-    y1 = 1.0 + 50.0 * numpy.exp(-0.001*(x-500)**2) + 2.*numpy.random.random(250.)
-    y2 = 1.0 + 20.5 * numpy.exp(-0.005*(x-600)**2) + 2.*numpy.random.random(250.)
+    y1 = 1.0 + 50.0 * numpy.exp(-0.001*(x-500)**2) + 2.*numpy.random.random(250)
+    y2 = 1.0 + 20.5 * numpy.exp(-0.005*(x-600)**2) + 2.*numpy.random.random(250)
 
     app.exec_()

--- a/PyMca5/PyMcaPlugins/AlignmentScanPlugin.py
+++ b/PyMca5/PyMcaPlugins/AlignmentScanPlugin.py
@@ -205,18 +205,18 @@ if __name__ == "__main__":
     import os
     try:
         from PyMca5.PyMcaGui import PyMcaQt as qt
-        from PyMca5.PyMcaGui.plotting import PlotWindow
+        from PyMca5.PyMcaGui.pymca import ScanWindow
         app = qt.QApplication([])
         QT = True
-        plot = PlotWindow.PlotWindow()
+        plot = ScanWindow.ScanWindow()
     except:
         # test without graphical interface
         QT = False
         from PyMca5.PyMcaGraph import Plot
         plot = Plot.Plot()
     pluginDir = [os.path.dirname(__file__)]
-    plot.getPlugins(method="getPlugin1DInstance",
-                directoryList=pluginDir)
+    plot.pluginsToolButton.getPlugins(method="getPlugin1DInstance",
+                                      directoryList=pluginDir)
     i = numpy.arange(1000.)
     y1 = 10.0 + 5000.0 * numpy.exp(-0.01*(i-50)**2)
     y2 = 10.0 + 5000.0 * numpy.exp(-((i-55)/5.)**2)

--- a/PyMca5/PyMcaPlugins/KineticsPlugin.py
+++ b/PyMca5/PyMcaPlugins/KineticsPlugin.py
@@ -176,10 +176,9 @@ def getPlugin1DInstance(plotWindow, **kw):
     return ob
 
 if __name__ == "__main__":
-    import sys
     import os
     from PyMca5.PyMcaGui import PyMcaQt as qt
-    from PyMca5.PyMcaGui import PlotWindow
+    from PyMca5.PyMcaGui.pymca import ScanWindow
     # first order, k = 4.820e-04
     x = [0, 600, 1200, 1800, 2400, 3000, 3600]
     y = [0.0365, 0.0274, 0.0206, 0.0157, 0.0117, 0.00860, 0.00640]
@@ -189,10 +188,11 @@ if __name__ == "__main__":
     print("Expected slope: 0.000482")
     sigmay = None
     app = qt.QApplication([])
-    plot = PlotWindow.PlotWindow()
-    plot.setPluginDirectoryList([os.path.dirname(__file__)])
-    plot.getPlugins()
-    plot.addCurve(x, y, "Test Data")
+    plot = ScanWindow.ScanWindow()
+    plot.pluginsToolButton.setPluginDirectoryList([os.path.dirname(__file__)])
+    plot.pluginsToolButton.getPlugins()
+    plot.addCurve(x, y, "Test Data",
+                  resetzoom=True)
     plot.show()
     plugin = getPlugin1DInstance(plot)
     for method in plugin.getMethods():

--- a/PyMca5/PyMcaPlugins/MedianFilterScanDeglitchPlugin.py
+++ b/PyMca5/PyMcaPlugins/MedianFilterScanDeglitchPlugin.py
@@ -184,7 +184,7 @@ class MedianFilterScanDeglitchPlugin(Plugin1DBase.Plugin1DBase):
                 self.addCurve(x,ynew,legend,info, replace=False, replot=True)
             else:
                 self.addCurve(x,ynew,legend,info, replace=False, replot=False)
-        #self._plotWindow.replot()
+
 
 MENU_TEXT = "Remove glitches from curves"
 def getPlugin1DInstance(plotWindow,  **kw):
@@ -192,10 +192,10 @@ def getPlugin1DInstance(plotWindow,  **kw):
     return ob
 
 if __name__ == "__main__":
-    from PyMca5.PyMcaGui import PlotWindow
+    from silx.gui.plot import Plot1D
     app = qt.QApplication([])
 
-    sw = PlotWindow.PlotWindow()
+    sw = Plot1D()
 
     x = numpy.linspace(0, 1999, 2000)
     y0 = x/100. + 100.*numpy.exp(-(x-500)**2/1000.) + 50.*numpy.exp(-(x-1200)**2/5000.) + 100.*numpy.exp(-(x-1700)**2/500.) + 10 * numpy.random.random(2000)
@@ -207,6 +207,7 @@ if __name__ == "__main__":
 
     sw.addCurve(x, y0, legend="Curve0")
     sw.addCurve(x, y1, legend="Curve1")
+    sw.setActiveCurve("Curve0")
 
     plugin = getPlugin1DInstance(sw)
     plugin.configureFilter()

--- a/PyMca5/PyMcaPlugins/StackScanWindowPlugin.py
+++ b/PyMca5/PyMcaPlugins/StackScanWindowPlugin.py
@@ -114,7 +114,7 @@ class StackScanWindowPlugin(StackPluginBase.StackPluginBase):
         x, y, legend, info = self.getActiveCurve()
         if self.widget is None:
             self.widget = ScanWindow.ScanWindow()
-        self.widget.addCurve(x, y, legend=legend, replot=True, replace=replace)
+        self.widget.addCurve(x, y, legend=legend, resetzoom=True, replace=replace)
         self.widget.show()
         self.widget.raise_()
 

--- a/PyMca5/PyMcaPlugins/StackShowSpectra.py
+++ b/PyMca5/PyMcaPlugins/StackShowSpectra.py
@@ -107,7 +107,7 @@ class ShowSpectra(StackPluginBase.StackPluginBase):
         if self.widget is None:
             self.widget = ScanWindow.ScanWindow()
         data = stack.data
-        replot = False
+        resetzoom = False
         if step in [None, 1]:
             for i in range(data.shape[0]):
                 for j in range(data.shape[1]):
@@ -115,7 +115,8 @@ class ShowSpectra(StackPluginBase.StackPluginBase):
                         replace = True
                     else:
                         replace = False
-                    self.widget.addCurve(x, data[i, j], legend="Row %03d Col %03d" % (i, j), replace=replace, replot=replot)
+                    self.widget.addCurve(x, data[i, j], legend="Row %03d Col %03d" % (i, j),
+                                         replace=replace, resetzoom=resetzoom)
         else:
             counter = 0
             for i in range(data.shape[0]):
@@ -125,15 +126,16 @@ class ShowSpectra(StackPluginBase.StackPluginBase):
                             replace = True
                         else:
                             replace = False
-                        self.widget.addCurve(x, data[i, j],
-                                legend="Row %03d Col %03d" % (i, j),
-                                replace=replace, replot=replot)
+                        self.widget.addCurve(
+                            x, data[i, j],
+                            legend="Row %03d Col %03d" % (i, j),
+                            replace=replace, resetzoom=resetzoom)
                     counter += 1
         self.widget.resetZoom()
         self.widget.show()
         self.widget.raise_()
 
-MENU_TEXT="Show Spectra"
+MENU_TEXT = "Show Spectra"
 def getStackPluginInstance(plotWindow, **kw):
     ob = ShowSpectra(plotWindow)
     return ob

--- a/PyMca5/PyMcaPlugins/XASPlugin.py
+++ b/PyMca5/PyMcaPlugins/XASPlugin.py
@@ -377,7 +377,7 @@ if __name__ == "__main__":
     import sys
     import os
     from PyMca5.PyMcaGui import PyMcaQt as qt
-    from PyMca5.PyMcaGui import PlotWindow
+    from PyMca5.PyMcaGui.pymca import ScanWindow
     from PyMca5.PyMcaIO import specfilewrapper as specfile
     from PyMca5.PyMcaDataDir import PYMCA_DATA_DIR
     if len(sys.argv) > 1:
@@ -388,10 +388,11 @@ if __name__ == "__main__":
     energy = data[0, :]
     mu = data[1, :]
     app = qt.QApplication([])
-    plot = PlotWindow.PlotWindow()
-    plot.setPluginDirectoryList([os.path.dirname(__file__)])
-    plot.getPlugins()
-    plot.addCurve(energy, mu, os.path.basename(fileName))
+    plot = ScanWindow.ScanWindow()
+    plot.pluginsToolButton.setPluginDirectoryList([os.path.dirname(__file__)])
+    plot.pluginsToolButton.getPlugins()
+    plot.addCurve(energy, mu, os.path.basename(fileName),
+                  resetzoom=True)
     plot.show()
     plugin = getPlugin1DInstance(plot)
     for method in plugin.getMethods():

--- a/PyMca5/PyMcaPlugins/XMCDPlugin.py
+++ b/PyMca5/PyMcaPlugins/XMCDPlugin.py
@@ -106,9 +106,9 @@ if __name__ == "__main__":
     info2 = {'MotorNames': 'PhaseD oxPS Motor10 Motor8',
              'MotorValues': '2 0.44400576644 0.613870067852 0.901968648111'}
     x = numpy.arange(100.,1100.)
-    y0 =  10*x + 10000.*numpy.exp(-0.5*(x-500)**2/400) + 1500*numpy.random.random(1000.)
-    y1 =  10*x + 10000.*numpy.exp(-0.5*(x-600)**2/400) + 1500*numpy.random.random(1000.)
-    y2 =  10*x + 10000.*numpy.exp(-0.5*(x-400)**2/400) + 1500*numpy.random.random(1000.)
+    y0 =  10*x + 10000.*numpy.exp(-0.5*(x-500)**2/400) + 1500*numpy.random.random(1000)
+    y1 =  10*x + 10000.*numpy.exp(-0.5*(x-600)**2/400) + 1500*numpy.random.random(1000)
+    y2 =  10*x + 10000.*numpy.exp(-0.5*(x-400)**2/400) + 1500*numpy.random.random(1000)
 
     swin.newCurve(x, y2, legend="Curve2", xlabel='ene_st2', ylabel='zratio2', info=info2)
     swin.newCurve(x, y0, legend="Curve0", xlabel='ene_st0', ylabel='zratio0', info=info0)

--- a/PyMca5/PyMcaPlugins/XMCDPlugin.py
+++ b/PyMca5/PyMcaPlugins/XMCDPlugin.py
@@ -110,9 +110,9 @@ if __name__ == "__main__":
     y1 =  10*x + 10000.*numpy.exp(-0.5*(x-600)**2/400) + 1500*numpy.random.random(1000.)
     y2 =  10*x + 10000.*numpy.exp(-0.5*(x-400)**2/400) + 1500*numpy.random.random(1000.)
 
-    swin.newCurve(x, y2, legend="Curve2", xlabel='ene_st2', ylabel='zratio2', info=info2, replot=False, replace=False)
-    swin.newCurve(x, y0, legend="Curve0", xlabel='ene_st0', ylabel='zratio0', info=info0, replot=False, replace=False)
-    swin.newCurve(x, y1, legend="Curve1", xlabel='ene_st1', ylabel='zratio1', info=info1, replot=False, replace=False)
+    swin.newCurve(x, y2, legend="Curve2", xlabel='ene_st2', ylabel='zratio2', info=info2)
+    swin.newCurve(x, y0, legend="Curve0", xlabel='ene_st0', ylabel='zratio0', info=info0)
+    swin.newCurve(x, y1, legend="Curve1", xlabel='ene_st1', ylabel='zratio1', info=info1)
 
     plugin = getPlugin1DInstance(swin)
     plugin.applyMethod(plugin.getMethods()[0])

--- a/PyMca5/PyMcaPlugins/optional/JsonRpc1DPlugin.py
+++ b/PyMca5/PyMcaPlugins/optional/JsonRpc1DPlugin.py
@@ -548,7 +548,7 @@ if __name__ == "__main__":
     import time
     import sys
     import os.path
-    from PyMca5.PyMcaGui.plotting.PlotWindow import PlotWindow
+    from PyMca5.PyMcaGui.pymca.ScanWindow import ScanWindow
 
     if len(sys.argv) == 1 or \
        sys.argv[1] not in ('plugin', 'demoServer', 'demoClient', 'auto'):
@@ -568,17 +568,17 @@ Options: plugin, demoServer demoClient, auto
         app = qt.QApplication([])
 
         # Create plot window
-        plot = PlotWindow(roi=True)
+        plot = ScanWindow(roi=True)
         plot.show()
 
         # Load plugin
         pluginDir = os.path.dirname(os.path.abspath(__file__))
         pluginName = os.path.splitext(os.path.basename(__file__))[0]
 
-        plot.setPluginDirectoryList([pluginDir])
-        nbPlugins = plot.getPlugins()  # Update plug-in list
+        plot.pluginsToolButton.setPluginDirectoryList([pluginDir])
+        nbPlugins = plot.pluginsToolButton.getPlugins()  # Update plug-in list
         assert nbPlugins >= 1
-        plugin = plot.pluginInstanceDict[pluginName]
+        plugin = plot.pluginsToolButton.pluginInstanceDict[pluginName]
 
         if sys.argv[1] == 'auto':
             # Run automated demos

--- a/PyMca5/PyMcaPlugins/optional/TaurusPlugin1D.py
+++ b/PyMca5/PyMcaPlugins/optional/TaurusPlugin1D.py
@@ -160,7 +160,7 @@ if __name__ == "__main__":
     import os
     from PyMca5.PyMcaGui import ScanWindow
     plot = ScanWindow.ScanWindow()
-    plot.setPluginDirectoryList([os.path.dirname(__file__)])
-    plot.getPlugins()
+    plot.pluginsToolButton.setPluginDirectoryList([os.path.dirname(__file__)])
+    plot.pluginsToolButton.getPlugins()
     plot.show()
     app.exec_()

--- a/PyMca5/__init__.py
+++ b/PyMca5/__init__.py
@@ -31,6 +31,10 @@ __version__ = "5.2.1"
 
 import os
 import sys
+
+import logging
+logging.basicConfig()
+
 from PyMca5.PyMcaDataDir import PYMCA_DATA_DIR
 try:
     from fisx.DataDir import FISX_DATA_DIR


### PR DESCRIPTION
This PR implements a ScanWindow based on a silx PlotWindow. Most of the code comes from unmerged PR #49, but there are new updates due to recent deprecations in silx (PlotActions refactoring).

It also replaces the legacy PyMca `PlotWindow` with the silx `PlotWindow` in various plugins accessible from the `ScanWindow`.

PR #91 should be merged first (this branch is based on it, because it implements PluginsToolButton).

To do in separate pull requests:
 - stop using `LegacyScanWindow` (still used in `McaWindow` & `XMCDScanWindow`)
 - test and fix `XMCDWindow` (heavy use of `.dataObjectdict` for accessing curves)
 - add a plugin toolbutton to all new silx  `PlotWindow` instances 
