### PR TITLE
[PeakIdentifier] fix NameError and deprecation warning

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/PeakIdentifier.py
+++ b/PyMca5/PyMcaGui/physics/xrf/PeakIdentifier.py
@@ -159,7 +159,7 @@ class PeakIdentifier(qt.QWidget):
 
     def myslot(self):
         print("PeakIdentifier.py myslot deprecated, use mySlot")
-        return mySlot()
+        return self.mySlot()
 
     def _thresholdSlot(self, value):
         self.mySlot()

--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -1129,7 +1129,7 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
         if self.identifier is None:
             self.identifier=PeakIdentifier.PeakIdentifier(energy=5.9,
                                 useviewer=1)
-            self.identifier.myslot()
+            self.identifier.mySlot()
         if self.identifier.isHidden():
             self.identifier.show()
         self.identifier.raise_()

--- a/PyMca5/PyMcaGui/pymca/QStackWidget.py
+++ b/PyMca5/PyMcaGui/pymca/QStackWidget.py
@@ -239,7 +239,7 @@ class QStackWidget(StackBase.StackBase,
             if 'SourceName' in self._stack.info:
                 if type(self._stack.info['SourceName']) == type([]):
                     if len(self._stack.info['SourceName']) == 1:
-                        title = qt.safe_str(self._stack.info['SourceName'])
+                        title = qt.safe_str(self._stack.info['SourceName'][0])
                     else:
                         f0 = qt.safe_str(self._stack.info['SourceName'][0])
                         f1 = qt.safe_str(self._stack.info['SourceName'][-1])


### PR DESCRIPTION
Closes #97 
Also fixes a typo when setting the ROI imaging window title to the source name.
