### PR TITLE
[5.3] PlotWindow

### DIFF
--- a/PyMca5/PyMcaGui/math/StripBackgroundWidget.py
+++ b/PyMca5/PyMcaGui/math/StripBackgroundWidget.py
@@ -255,6 +255,7 @@ class StripBackgroundWidget(qt.QWidget):
         self._x = x
         self._y = y
         self.update()
+        self.graphWidget.resetZoom()
 
     def _slot(self, ddict):
         self.update()
@@ -324,13 +325,14 @@ class StripBackgroundWidget(qt.QWidget):
 
         self.graphWidget.addCurve(x, y,
                                   legend='Input Data',
-                                  color='black')
+                                  resetzoom=False)
         self.graphWidget.addCurve(x, stripBackground,
-                                  legend='Strip Background',
-                                  color='blue')
+                                  resetzoom=False,
+                                  legend='Strip Background')
         self.graphWidget.addCurve(x, snipBackground,
-                                  legend='SNIP Background',
-                                  color='red')
+                                  resetzoom=False,
+                                  legend='SNIP Background')
+        self.graphWidget.setActiveCurve('Input Data')
 
 class StripBackgroundDialog(qt.QDialog):
     def __init__(self, parent=None):

--- a/PyMca5/PyMcaGui/math/StripBackgroundWidget.py
+++ b/PyMca5/PyMcaGui/math/StripBackgroundWidget.py
@@ -30,8 +30,9 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PlotWindow
 from PyMca5.PyMcaMath.fitting import SpecfitFuns
+
+from silx.gui.plot import PlotWindow
 
 
 class StripParametersWidget(qt.QWidget):
@@ -235,10 +236,12 @@ class StripBackgroundWidget(qt.QWidget):
         self.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.mainLayout.setSpacing(2)
         self.parametersWidget = StripParametersWidget(self)
-        self.graphWidget = PlotWindow.PlotWindow(self,
-                                                 newplot=False,
-                                                 plugins=False,
-                                                 fit=False)
+        self.graphWidget = PlotWindow(self, position=False, aspectRatio=False,
+                                      colormap=False, yInverted=False,
+                                      roi=False, mask=False, fit=False)
+        self.graphWidget.zoomModeAction.setVisible(False)
+        self.graphWidget.panModeAction.setVisible(False)
+
         self.mainLayout.addWidget(self.parametersWidget)
         self.mainLayout.addWidget(self.graphWidget)
         self.getParameters = self.parametersWidget.getParameters
@@ -319,16 +322,15 @@ class StripBackgroundWidget(qt.QWidget):
             snipBackground[lastAnchor:] =\
                             SpecfitFuns.snip1d(ysmooth[lastAnchor:], width, 0)
 
-        self.graphWidget.addCurve(x, y, \
-                                  legend='Input Data',\
-                                  replace=True,
-                                  replot=False)
-        self.graphWidget.addCurve(x, stripBackground,\
-                                  legend='Strip Background',\
-                                  replot=False)
-        self.graphWidget.addCurve(x, snipBackground,\
+        self.graphWidget.addCurve(x, y,
+                                  legend='Input Data',
+                                  color='black')
+        self.graphWidget.addCurve(x, stripBackground,
+                                  legend='Strip Background',
+                                  color='blue')
+        self.graphWidget.addCurve(x, snipBackground,
                                   legend='SNIP Background',
-                                  replot=True)
+                                  color='red')
 
 class StripBackgroundDialog(qt.QDialog):
     def __init__(self, parent=None):

--- a/PyMca5/PyMcaGui/math/fitting/SimpleFitGui.py
+++ b/PyMca5/PyMcaGui/math/fitting/SimpleFitGui.py
@@ -298,10 +298,10 @@ class SimpleFitGui(qt.QWidget):
         returnValue = self.fitModule.setData(*var, **kw)
         if self.__useTab:
             if hasattr(self.graph, "addCurve"):
+                self.graph.clear()
                 self.graph.addCurve(self.fitModule._x,
                                     self.fitModule._y,
-                                    legend='Data',
-                                    replace=True)
+                                    legend='Data')
                 self.graph.setActiveCurve('Data')
             elif hasattr(self.graph, "newCurve"):
                 # TODO: remove if not used

--- a/PyMca5/PyMcaGui/math/fitting/SimpleFitGui.py
+++ b/PyMca5/PyMcaGui/math/fitting/SimpleFitGui.py
@@ -34,7 +34,7 @@ from PyMca5.PyMcaMath.fitting import SimpleFitModule
 from . import SimpleFitConfigurationGui
 from PyMca5.PyMcaMath.fitting import SimpleFitUserEstimatedFunctions
 from . import Parameters
-from PyMca5.PyMcaGui import PlotWindow
+from silx.gui.plot import PlotWindow
 
 DEBUG = 0
 
@@ -140,11 +140,12 @@ class SimpleFitGui(qt.QWidget):
             self.fitModule = fit
         if graph is None:
             self.__useTab = True
-            self.graph = PlotWindow.PlotWindow(newplot=False,
-                                               plugins=False,
-                                               fit=False,
-                                               control=True,
-                                               position=True)
+            self.graph = PlotWindow(self,
+                                    aspectRatio=False, colormap=False,
+                                    yInverted=False, roi=False, mask=False,
+                                    fit=False, control=True, position=True)
+            self.graph.zoomModeAction.setVisible(False)
+            self.graph.panModeAction.setVisible(False)
         else:
             self.__useTab = False
             self.graph = graph
@@ -301,12 +302,14 @@ class SimpleFitGui(qt.QWidget):
                                     self.fitModule._y,
                                     legend='Data',
                                     replace=True)
+                self.graph.setActiveCurve('Data')
             elif hasattr(self.graph, "newCurve"):
+                # TODO: remove if not used
                 self.graph.clearCurves()
                 self.graph.newCurve('Data',
                                     self.fitModule._x,
                                     self.fitModule._y)
-            self.graph.replot()
+                self.graph.replot()
         return returnValue
 
     def estimate(self):
@@ -375,10 +378,9 @@ class SimpleFitGui(qt.QWidget):
         #ddict['yfit'] = self.evaluateDefinedFunction()
         #ddict['background'] = self.fitModule._evaluateBackground()
         self.graph.clear()
-        self.graph.addCurve(ddict['x'], ddict['y'], 'Data', replot=False)
-        self.graph.addCurve(ddict['x'], ddict['yfit'], 'Fit', replot=False)
-        self.graph.addCurve(ddict['x'], ddict['background'], 'Background',
-                                                replot=False)
+        self.graph.addCurve(ddict['x'], ddict['y'], 'Data')
+        self.graph.addCurve(ddict['x'], ddict['yfit'], 'Fit')
+        self.graph.addCurve(ddict['x'], ddict['background'], 'Background')
         contributions = ddict['contributions']
         if len(contributions) > 1:
             background = ddict['background']
@@ -386,9 +388,7 @@ class SimpleFitGui(qt.QWidget):
             for contribution in contributions:
                 i += 1
                 self.graph.addCurve(ddict['x'], background + contribution,
-                                    legend='Contribution %d' % i,
-                                    replot=False)
-        self.graph.replot()
+                                    legend='Contribution %d' % i)
         self.graph.show()
 
     def dismiss(self):

--- a/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
@@ -285,7 +285,7 @@ class XASNormalizationWindow(qt.QWidget):
         self.__lastDict = {}
         self.graph.sigPlotSignal.connect(self._handleGraphSignal)
         self.graph.addCurve(self.energy,
-                            spectrum, legend="Spectrum", replace=True)
+                            spectrum, legend="Spectrum")
         self.graph.setActiveCurve("Spectrum")
         self.mainLayout.addWidget(self.parametersWidget)
         self.mainLayout.addWidget(self.graph)
@@ -310,10 +310,10 @@ class XASNormalizationWindow(qt.QWidget):
         else:
             self.energy = energy
         self.graph.clearMarkers()
+        self.graph.clearCurves()
         self.graph.addCurve(self.energy,
                             self.spectrum,
-                            legend="Spectrum",
-                            replace=True)
+                            legend="Spectrum")
         edgeEnergy = XASNormalization.estimateXANESEdge(self.spectrum,
                                                         energy=self.energy,
                                                         full=False)

--- a/PyMca5/PyMcaGui/physics/xas/XASWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASWindow.py
@@ -203,15 +203,13 @@ class XASMdiArea(qt.QMdiArea):
         plot = self._windowDict["Spectrum"]
         e0 = ddict["Edge"]
         plot.addCurve(ddict["Energy"] - e0, ddict["Mu"], legend="Spectrum",
-                      xlabel="Energy (eV)", ylabel="Absorption (a.u.)",
-                      resetzoom=False)
+                      xlabel="Energy (eV)", ylabel="Absorption (a.u.)")
         plot.addCurve(ddict["NormalizedEnergy"][idx] - e0,
                       ddict["NormalizedMu"][idx],
                       legend="Normalized",
                       xlabel="Energy (eV)",
                       ylabel="Absorption (a.u.)",
-                      yaxis="right",
-                      resetzoom=False)
+                      yaxis="right")
         plot.addCurve(ddict["NormalizedEnergy"] - e0,
                ddict["NormalizedSignal"], legend="Post", resetzoom=False)
         plot.addCurve(ddict["NormalizedEnergy"] - e0,
@@ -225,16 +223,14 @@ class XASMdiArea(qt.QMdiArea):
                       ddict["EXAFSSignal"][idx],
                       legend="EXAFSSignal",
                       xlabel="K",
-                      ylabel="Normalized Units",
-                      resetzoom=False)
+                      ylabel="Normalized Units")
         plot.setActiveCurve("EXAFSSignal")
         plot.addCurve(ddict["EXAFSKValues"][idx],
                       ddict["PostEdgeB"][idx],
                       legend="PostEdge",
                       xlabel="K",
                       ylabel="Normalized Units",
-                      color="blue",
-                      resetzoom=False)
+                      color="blue")
         if 0:
             plot.clearMarkers()
             for i in range(len(ddict["KnotsX"])):
@@ -249,7 +245,6 @@ class XASMdiArea(qt.QMdiArea):
             plot.addCurve(ddict["KnotsX"],
                           ddict["KnotsY"],
                           legend="Knots",
-                          resetzoom=False,
                           linestyle="",
                           symbol="o",
                           color="orange")
@@ -266,8 +261,7 @@ class XASMdiArea(qt.QMdiArea):
                       ddict["EXAFSNormalized"][idx],
                       legend="Normalized EXAFS",
                       xlabel="K",
-                      ylabel=ylabel,
-                      resetzoom=False)
+                      ylabel=ylabel)
         plot.setActiveCurve("Normalized EXAFS")
         plot.addCurve(ddict["FT"]["K"],
                       ddict["FT"]["WindowWeight"],
@@ -275,16 +269,14 @@ class XASMdiArea(qt.QMdiArea):
                       xlabel="K",
                       ylabel="Weight",
                       yaxis="right",
-                      color="red",
-                      resetzoom=False)
+                      color="red")
         plot.resetZoom()
         plot = self._windowDict["FT"]
         plot.addCurve(ddict["FT"]["FTRadius"],
                       ddict["FT"]["FTIntensity"],
                       legend="FT Intensity",
                       xlabel="R (Angstrom)",
-                      ylabel="Arbitrary Units",
-                      resetzoom=False)
+                      ylabel="Arbitrary Units")
         plot.setActiveCurve("FT Intensity")
         """
         plot.addCurve(ddict["FT"]["FTRadius"],
@@ -292,17 +284,14 @@ class XASMdiArea(qt.QMdiArea):
                       legend="FT Real",
                       xlabel="R (Angstrom)",
                       ylabel="Arbitrary Units",
-                      color="green",
-                      resetzoom=False)
+                      color="green")
         """
         plot.addCurve(ddict["FT"]["FTRadius"],
                       ddict["FT"]["FTImaginary"],
                       legend="FT Imaginary",
                       xlabel="R (Angstrom)",
                       ylabel="Arbitrary Units",
-                      color="red",
-                      resetzoom=False)
-        plot.resetZoom()
+                      color="red")
         self.sigXASMdiAreaSignal.emit(ddict)
 
 if __name__ == "__main__":

--- a/PyMca5/PyMcaGui/physics/xrf/FitParam.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FitParam.py
@@ -56,8 +56,8 @@ except ImportError:
     # no XRFMC support
     pass
 from PyMca5.PyMcaGui.math import StripBackgroundWidget
-from PyMca5.PyMcaGui import PlotWindow
 from PyMca5.PyMcaGui.physics.xrf import StrategyHandler
+from silx.gui.plot import PlotWindow
 import numpy
 
 DEBUG = 0
@@ -84,11 +84,14 @@ class FitParamWidget(FitParamForm):
         self.graphDialog.mainLayout = qt.QVBoxLayout(self.graphDialog)
         self.graphDialog.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.graphDialog.mainLayout.setSpacing(0)
-        self.graphDialog.graph = PlotWindow.PlotWindow(self.graphDialog,
-                                                       newplot=False,
-                                                       plugins=False, fit=False)
+        self.graphDialog.graph = PlotWindow(self.graphDialog,
+                                            position=False, colormap=False,
+                                            aspectRatio=False, yInverted=False,
+                                            roi=False, mask=False, fit=False)
         self.graph = self.graphDialog.graph
-        self.graph._togglePointsSignal()
+        self.graph.zoomModeAction.setVisible(False)
+        self.graph.panModeAction.setVisible(False)
+        self.graph.setDefaultPlotPoints(True)
         self.tabAttenuators   = AttenuatorsTable.AttenuatorsTab(self.tabAtt,
                                                 graph=self.graphDialog)
         self.graphDialog.mainLayout.addWidget(self.graph)
@@ -315,11 +318,11 @@ class FitParamWidget(FitParamForm):
                 efficiency *= (1.0 - numpy.exp(-coeffs))
 
         self.graph.setGraphTitle('Filter (not beam filter) and detector correction')
-        self.graph.addCurve(energies, efficiency,
-                            legend='Ta * (1.0 - Td)',
+        legend = 'Ta * (1.0 - Td)'
+        self.graph.addCurve(energies, efficiency, legend,
                             xlabel='Energy (keV)',
-                            ylabel='Efficiency Term',
-                            replace=True)
+                            ylabel='Efficiency Term')
+        self.graph.setActiveCurve(legend)
         self.graphDialog.exec_()
 
     def __contComboActivated(self, idx):

--- a/PyMca5/PyMcaGui/physics/xrf/QXTube.py
+++ b/PyMca5/PyMcaGui/physics/xrf/QXTube.py
@@ -33,8 +33,9 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 from PyMca5.PyMcaPhysics import Elements
 from PyMca5.PyMcaPhysics import XRayTubeEbel
 import numpy
-from PyMca5.PyMcaGui import PlotWindow
 from PyMca5.PyMcaGui import PyMcaQt as qt
+from PyMca5.PyMcaGui.PluginsToolButton import PluginsToolButton
+from silx.gui.plot import PlotWindow
 
 
 DEBUG = 0
@@ -86,8 +87,14 @@ class QXTube(qt.QWidget):
         self.l.addWidget(label)
 
         self.l.addWidget(hbox)
-        self.graph = PlotWindow.PlotWindow(self,
-                                               backend=None)
+        self.graph = PlotWindow(self, colormap=False, yInverted=False,
+                                aspectRatio=False, control=False,
+                                position=False, roi=False, mask=False,
+                                fit=False)
+        self.pluginsToolButton = PluginsToolButton(plot=self.graph)
+        self.graph.toolBar().addWidget(self.pluginsToolButton)
+        self.graph.zoomModeAction.setVisible(False)
+        self.graph.panModeAction.setVisible(False)
         self.l.addWidget(self.graph)
         self.graph.setGraphXLabel("Energy (keV)")
         self.graph.setGraphYLabel("photons/sr/mA/keV/s")
@@ -133,11 +140,8 @@ class QXTube(qt.QWidget):
                                              targetthickness=anodethickness,
                                              filterlist=filterlist)
 
-
-
-
-            self.graph.addCurve(e, continuumR, "continuumR", replot=False)
-            self.graph.addCurve(e, continuumT, "continuumT", replot=False)
+            self.graph.addCurve(e, continuumR, "continuumR")
+            self.graph.addCurve(e, continuumT, "continuumT")
         else:
             continuum = XRayTubeEbel.continuumEbel([anode, anodedensity, anodethickness],
                                              voltage, e,
@@ -146,10 +150,10 @@ class QXTube(qt.QWidget):
                                              transmission=transmission,
                                              targetthickness=anodethickness,
                                              filterlist=filterlist)
-            self.graph.addCurve(e, continuum, "continuum", replot=False)
+            self.graph.addCurve(e, continuum, "continuum")
+            self.graph.setActiveCurve("continuum")
 
         self.graph.resetZoom()
-        self.graph.replot()
 
     def _export(self):
         d = self.tubeWidget.getParameters()

--- a/PyMca5/PyMcaGui/plotting/ProfileScanWidget.py
+++ b/PyMca5/PyMcaGui/plotting/ProfileScanWidget.py
@@ -34,7 +34,7 @@ if 1:
     # if not, we miss profile fitting ...
     from PyMca5.PyMcaGui.pymca.ScanWindow import ScanWindow as Window
 else:
-    from .PlotWindow import PlotWindow as Window
+    from silx.gui.plot import PlotWindow as Window
 DEBUG = 0
 
 class ProfileScanWidget(Window):
@@ -118,7 +118,7 @@ class ProfileScanWidget(Window):
         elif action == 'REMOVE':
             self.sigRemoveClicked.emit(ddict)
         else:
-            self.replaceAddClicked.emit(ddict)
+            self.sigReplaceClicked.emit(ddict)
 
 def test():
     app = qt.QApplication([])

--- a/PyMca5/PyMcaPhysics/xas/XASClass.py
+++ b/PyMca5/PyMcaPhysics/xas/XASClass.py
@@ -35,8 +35,6 @@ __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import copy
-import os
-import sys
 import numpy
 import time
 from PyMca5.PyMca import XASNormalization
@@ -1487,25 +1485,25 @@ if __name__ == "__main__":
     #sys.exit()
     from PyMca5.PyMca import PyMcaQt as qt
     app = qt.QApplication([])
-    from PyMca5.PyMca import PlotWindow
-    w = PlotWindow.PlotWindow()
-    w.addCurve(energy, mu, legend="original", replot=False)
+    from silx.gui.plot import Plot1D
+    w = Plot1D()
+    w.addCurve(energy, mu, legend="original")
     w.addCurve(ddict["NormalizedEnergy"],
-               ddict["NormalizedMu"], legend="Mu", yaxis="right", replot=False)
+               ddict["NormalizedMu"], legend="Mu", yaxis="right")
     w.addCurve(ddict["NormalizedEnergy"],
-               ddict["NormalizedSignal"], legend="Post", replot=False)
+               ddict["NormalizedSignal"], legend="Post")
     w.addCurve(ddict["NormalizedEnergy"],
-               ddict["NormalizedBackground"], legend="Pre",replot=False)
+               ddict["NormalizedBackground"], legend="Pre")
     w.resetZoom()
     w.show()
-    exafs = PlotWindow.PlotWindow()
+    exafs = Plot1D()
     idx = (ddict["EXAFSKValues"] >= ddict["KMin"]) & \
           (ddict["EXAFSKValues"] <= ddict["KMax"])
     exafs.addCurve(ddict["EXAFSKValues"][idx], ddict["EXAFSNormalized"][idx],
                    legend="Normalized EXAFS")
     exafs.show()
     #"""
-    ft = PlotWindow.PlotWindow()
+    ft = Plot1D()
     ft.addCurve(ddict["FT"]["FTRadius"], ddict["FT"]["FTIntensity"])
     ft.resetZoom()
     ft.show()


### PR DESCRIPTION
Use a silx PlotWindow instead of a PyMca PlotWindow.

Some PlotWindow directly related to ScanWindow have already been converted in #96.

TODO in separate PRs:

 - deal with `McaAdvancedFit` (more complicated than all the other widgets)
 - `ImageView`: use the silx one or keep this one? Not used in PyMca but in external plugins. One notable change: signature of `__init__`
 - add a `PrintPreview` toolbutton to all these `PlotWindow`s (currently the print icon is the *silx* one)
 - `MaskScatterWidget`: depends on `MaskImageWidget`. Should we try to use `SilxMaskImageWidget` (different API)