### PR TITLE
[5.3]MaskScatterWidget

### DIFF
--- a/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
@@ -82,7 +82,6 @@ class MaskScatterWidget(PlotWindow):
                                            polygon=polygon)
             self.addToolBar(self.maskToolBar)
 
-        self._buildAdditionalSelectionMenuDict()
         self._selectionCurve = None
         self._selectionMask = None
         self._alphaLevel = None
@@ -627,48 +626,6 @@ class MaskScatterWidget(PlotWindow):
     def emitMaskScatterWidgetSignal(self, ddict):
         self.sigMaskScatterWidgetSignal.emit(ddict)
 
-    def _imageIconSignal(self):
-        self.__resetSelection()
-
-    def _buildAdditionalSelectionMenuDict(self):
-        self._additionalSelectionMenu = {}
-        #scatter view menu
-        menu = qt.QMenu()
-        menu.addAction(QString("Density plot view"), self.__setDensityPlotView)
-        menu.addAction(QString("Reset Selection"), self.__resetSelection)
-        menu.addAction(QString("Invert Selection"), self._invertSelection)
-        self._additionalSelectionMenu["scatter"] = menu
-
-        # density view menu
-        menu = qt.QMenu()
-        menu.addAction(QString("Scatter plot view"), self.__setScatterPlotView)
-        menu.addAction(QString("Reset Selection"), self.__resetSelection)
-        menu.addAction(QString("Invert Selection"), self._invertSelection)
-        menu.addAction(QString("I >= Colormap Max"), self._selectMax)
-        menu.addAction(QString("Colormap Min < I < Colormap Max"),
-                                                self._selectMiddle)
-        menu.addAction(QString("I <= Colormap Min"), self._selectMin)
-        menu.addAction(QString("Increase mask alpha"), self._increaseMaskAlpha)
-        menu.addAction(QString("Decrease mask alpha"), self._decreaseMaskAlpha)
-        self._additionalSelectionMenu["density"] = menu
-
-    def __setScatterPlotView(self):
-        self.setPlotViewMode(mode="scatter")
-
-    def __setDensityPlotView(self):
-        self.setPlotViewMode(mode="density")
-
-    def _additionalIconSignal(self):
-        if self._plotViewMode == "density": # and imageData is not none ...
-            self._additionalSelectionMenu["density"].exec_(self.cursor().pos())
-        else:
-            self._additionalSelectionMenu["scatter"].exec_(self.cursor().pos())
-
-    def __resetSelection(self):
-        # Needed because receiving directly in _resetSelection it was passing
-        # False as argument
-        self._resetSelection(True)
-
     def _resetSelection(self, owncall=True):
         if DEBUG:
             print("_resetSelection")
@@ -852,7 +809,6 @@ class MaskScatterWidget(PlotWindow):
             else:
                 print("OK!!!")
         self.setSelectionMask(view2)
-
 
     def _initializeAlpha(self):
         self._alphaLevel = 128

--- a/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
@@ -72,7 +72,12 @@ class MaskScatterWidget(PlotWindow):
                                                 curveStyle=curveStyle,
                                                 resetzoom=resetzoom,
                                                 aspectRatio=aspectRatio,
-                                                colormap=colormap)
+                                                colormap=colormap,
+                                                mask=False,
+                                                yInverted=False,
+                                                roi=False,
+                                                copy=False,
+                                                print_=False)
 
         self.maskToolBar = None
         if polygon or imageIcons:
@@ -96,7 +101,6 @@ class MaskScatterWidget(PlotWindow):
         self._densityPlotWidget = None
         self._pixmap = None
         self.setPlotViewMode("scatter", bins=bins)
-        self.setDrawModeEnabled(False)
 
     def setPlotViewMode(self, mode="scatter", bins=None):
         if mode.lower() != "density":
@@ -829,6 +833,12 @@ class MaskScatterWidget(PlotWindow):
         if self._alphaLevel < 2:
             self._alphaLevel = 2
         self._updatePlot()
+
+    def setPolygonSelectionMode(self):
+        """
+        Resets zoom mode and enters selection mode with the current active ROI index
+        """
+        self.maskToolBar.setPolygonSelectionMode()
 
 if __name__ == "__main__":
     backend = "matplotlib"

--- a/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
@@ -37,48 +37,45 @@ ___doc__ = """
     - Final layer containing the selected points with the selected colors.
 
 """
-import sys
-import os
 import numpy
 from PyMca5.PyMcaGraph.ctools import pnpoly
 DEBUG = 0
 
-from . import PlotWindow
 from . import MaskImageWidget
 from . import MaskImageTools
-qt = PlotWindow.qt
+from .. import PyMcaQt as qt
+from .PyMca_Icons import IconDict
+
+from silx.gui.plot import PlotWindow
+
 if hasattr(qt, "QString"):
     QString = qt.QString
 else:
     QString = qt.safe_str
-IconDict = PlotWindow.IconDict
 
-class MaskScatterWidget(PlotWindow.PlotWindow):
+
+class MaskScatterWidget(PlotWindow):
     sigMaskScatterWidgetSignal = qt.pyqtSignal(object)
     DEFAULT_COLORMAP_INDEX = 2
     DEFAULT_COLORMAP_LOG_FLAG = True
 
-    def __init__(self, parent=None, backend=None, plugins=False, newplot=False,
-                 control=False, position=False, maxNRois=1, grid=False,
-                 logx=False, logy=False, togglePoints=False, normal=True,
-                 polygon=True, colormap=True, aspect=True,
-                 imageIcons=True, bins=None, **kw):
+    def __init__(self, parent=None, backend=None, control=False,
+                 position=False, maxNRois=1, grid=False, logScale=False,
+                 curveStyle=False, resetzoom=True, colormap=True,
+                 aspectRatio=True, imageIcons=True, bins=None):
         super(MaskScatterWidget, self).__init__(parent=parent,
                                                 backend=backend,
-                                                plugins=plugins,
-                                                newplot=newplot,
                                                 control=control,
                                                 position=position,
                                                 grid=grid,
-                                                logx=logx,
-                                                logy=logy,
-                                                togglePoints=togglePoints,
-                                                normal=normal,
-                                                aspect=aspect,
+                                                logScale=logScale,
+                                                curveStyle=curveStyle,
+                                                resetzoom=resetzoom,
+                                                aspectRatio=aspectRatio,
                                                 colormap=colormap,
-                                                imageIcons=imageIcons,
-                                                polygon=polygon,
-                                                **kw)
+                                                imageIcons=imageIcons)
+                                                # polygon=polygon,     # TODO: polygon/mask toolbutton
+
         self._buildAdditionalSelectionMenuDict()
         self._selectionCurve = None
         self._selectionMask = None

--- a/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
@@ -141,7 +141,7 @@ class MaskScatterWidget(PlotWindow):
         self._plotViewMode = "scatter"
         self.colormapAction.setVisible(False)
         self._brushMode = False
-        self.setInteractiveMode("zoom")
+        self.setInteractiveMode("select")
 
         if hasattr(self, "maskToolBar"):
             self.maskToolBar.activateScatterPlotView()
@@ -365,7 +365,7 @@ class MaskScatterWidget(PlotWindow):
         pixmap = MaskImageTools.getPixmapFromData(image.getData(), colormap)
         self.addImage(image.getData(), legend=image.getLegend(),
                       info=image.getInfo(),
-                      pixmap=pixmap.getRgbaImageData())
+                      pixmap=pixmap)
 
     def setSelectionCurveData(self, x, y, legend=None, info=None,
                               replace=True, linestyle=" ", resetzoom=True,
@@ -493,7 +493,7 @@ class MaskScatterWidget(PlotWindow):
                 self._selectionMask = numpy.zeros(x.shape, numpy.uint8)
         return self._selectionMask
 
-    def _updatePlot(self, resetzoom=True, replace=True):
+    def _updatePlot(self, resetzoom=False, replace=True):
         if self._selectionCurve is None:
             return
         x0, y0, legend, info = self.getCurve(self._selectionCurve)[0:4]
@@ -554,25 +554,6 @@ class MaskScatterWidget(PlotWindow):
         if (intValue < 0) or (intValue > self._maxNRois):
             raise ValueError("Value %d outside the interval [0, %d]" % (intValue, self._maxNRois))
         self._nRoi = intValue
-
-    # TODO
-
-    def setZoomModeEnabled(self, flag, color=None):
-        if color is None:
-            if hasattr(self, "colormapDialog"):
-                if self.colormapDialog is None:
-                    color = "#00FFFF"
-                else:
-                    cmap = self.colormapDialog.getColormap()
-                    if cmap[0] < 2:
-                        color = "#00FFFF"
-                    else:
-                        color = "black"
-        self.setInteractiveMode('zoom', color=color)
-        if flag:
-            if self.maskToolBar is not None:      # TODO: refactor --> MaskToolBar
-                self.maskToolBar.polygonSelectionAction.setChecked(False)
-                self.maskToolBar.brushSelectionAction.setChecked(False)
 
     def _handlePolygonMask(self, points):
         if DEBUG:

--- a/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
@@ -43,7 +43,7 @@ DEBUG = 0
 
 from . import MaskImageWidget
 from . import MaskImageTools
-from .. import PyMcaQt as qt
+from PyMca5.PyMcaGui import PyMcaQt as qt
 from .MaskToolBar import MaskToolBar
 
 from silx.gui.plot import PlotWindow
@@ -146,7 +146,7 @@ class MaskScatterWidget(PlotWindow):
         curve = self.getCurve(self._selectionCurve)
         if curve is None:
             return
-        x, y, legend, info = curve[0:4]
+        x, y, = curve[0:2]
         if bins is not None:
             if type(bins) == type(1):
                 bins = (bins, bins)
@@ -387,14 +387,14 @@ class MaskScatterWidget(PlotWindow):
     def getSelectionMask(self):
         if self._selectionMask is None:
             if self._selectionCurve is not None:
-                x, y, legend, info = self.getCurve(self._selectionCurve)
+                x, y = self.getCurve(self._selectionCurve)[0:2]
                 self._selectionMask = numpy.zeros(x.shape, numpy.uint8)
         return self._selectionMask
 
     def _updatePlot(self, resetzoom=True, replace=True):
         if self._selectionCurve is None:
             return
-        x0, y0, legend, info = self.getCurve(self._selectionCurve)
+        x0, y0, legend, info = self.getCurve(self._selectionCurve)[0:4]
         # make sure we work with views
         x = x0[:]
         y = y0[:]
@@ -478,7 +478,7 @@ class MaskScatterWidget(PlotWindow):
             value = 0
         else:
             value = self._nRoi
-        x, y, legend, info = self.getCurve(self._selectionCurve)
+        x, y = self.getCurve(self._selectionCurve)[0:2]
         x.shape = -1
         y.shape = -1
         currentMask = self.getSelectionMask()
@@ -751,14 +751,14 @@ class MaskScatterWidget(PlotWindow):
         curve = self.getCurve(self._selectionCurve)
         if curve is None:
             return
-        x, y, legend, info = curve[0:4]
+        x, y = curve[0:2]
         bins = self._bins
         x0 = x.min()
         y0 = y.min()
         deltaX = (x.max() - x0)/float(bins[0])
         deltaY = (y.max() - y0)/float(bins[1])
         columns = numpy.digitize(x, self._binsX, right=True)
-        columns[columns>=densityPlotMask.shape[1]] = \
+        columns[columns >= densityPlotMask.shape[1]] = \
                                                    densityPlotMask.shape[1] - 1
         rows = numpy.digitize(y, self._binsY, right=True)
         rows[rows>=densityPlotMask.shape[0]] = densityPlotMask.shape[0] - 1
@@ -794,7 +794,7 @@ class MaskScatterWidget(PlotWindow):
         curve = self.getCurve(self._selectionCurve)
         if curve is None:
             return
-        x, y, legend, info = curve[0:4]
+        x, y = curve[0:2]
         bins = self._bins
         x0 = x.min()
         y0 = y.min()

--- a/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskScatterWidget.py
@@ -407,7 +407,7 @@ class MaskScatterWidget(PlotWindow):
                 tmpMask = self._selectionMask[:]
                 tmpMask.shape = -1
                 for i in range(0, self._maxNRois + 1):
-                    colors[tmpMask == i, :] = self._selectionColors[i]
+                    colors[tmpMask == i, :] = self.maskToolBar._selectionColors[i]
                 self.setSelectionCurveData(x, y, legend=legend, info=info,
                                            #color=colors,
                                            color="k",
@@ -432,7 +432,7 @@ class MaskScatterWidget(PlotWindow):
                     if xMask.size < 1:
                         self.removeCurve(legend=legend + " %02d" % i)
                         continue
-                    color = self._selectionColors[i].copy()
+                    color = self.maskToolBar._selectionColors[i].copy()
                     if useAlpha:
                         if len(color) == 4:
                             if type(color[3]) in [numpy.uint8, numpy.int]:

--- a/PyMca5/PyMcaGui/plotting/MaskToolBar.py
+++ b/PyMca5/PyMcaGui/plotting/MaskToolBar.py
@@ -66,7 +66,10 @@ _COLORLIST = [_COLORDICT['black'],
 
 
 class MaskToolBar(qt.QToolBar):
-    sigIconSignal = qt.pyqtSignal(object)
+    """Toolbar with buttons controlling the mask drawing and erasing
+    interactions on a :class:`MaskScatterWidget`, to select or deselect
+    data."""
+    # sigIconSignal = qt.pyqtSignal(object)
     colorList = _COLORLIST
 
     def __init__(self, parent=None, plot=None, title="Mask tools",
@@ -296,9 +299,9 @@ class MaskToolBar(qt.QToolBar):
         else:
             self._additionalSelectionMenu["scatter"].exec_(self.cursor().pos())
 
-    def emitIconSignal(self, key, event="iconClicked"):
-        ddict = {"key": key,
-                 "event": event}
-        self.sigIconSignal.emit(ddict)
+    # def emitIconSignal(self, key, event="iconClicked"):
+    #     ddict = {"key": key,
+    #              "event": event}
+    #     self.sigIconSignal.emit(ddict)
 
 

--- a/PyMca5/PyMcaGui/plotting/MaskToolBar.py
+++ b/PyMca5/PyMcaGui/plotting/MaskToolBar.py
@@ -32,7 +32,7 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 import numpy
 
-from .. import PyMcaQt as qt
+from PyMca5.PyMcaGui import PyMcaQt as qt
 from .PyMca_Icons import IconDict
 from PyMca5.PyMcaGraph import Colors
 

--- a/PyMca5/PyMcaGui/plotting/MaskToolBar.py
+++ b/PyMca5/PyMcaGui/plotting/MaskToolBar.py
@@ -145,7 +145,7 @@ class MaskToolBar(qt.QToolBar):
         self.eraseSelectionAction.setToolTip("Set erase mode if checked")
         self.eraseSelectionAction.setCheckable(True)
 
-        self.eraseSelectionAction.setChecked(self._eraseMode)
+        self.eraseSelectionAction.setChecked(self.plot._eraseMode)
 
         self.polygonSelectionAction.setCheckable(True)
         self.rectSelectionAction.setCheckable(True)

--- a/PyMca5/PyMcaGui/plotting/MaskToolBar.py
+++ b/PyMca5/PyMcaGui/plotting/MaskToolBar.py
@@ -114,6 +114,9 @@ class MaskToolBar(qt.QToolBar):
         self.additionalSelectionToolButton.setToolTip('Additional Selections Menu')
 
         self.eraseSelectionToolButton.setCheckable(True)
+        self.polygonSelectionToolButton.setCheckable(True)
+        self.rectSelectionToolButton.setCheckable(True)
+
 
         self.imageAction = self.addWidget(self.imageToolButton)
         self.eraseSelectionAction = self.addWidget(self.eraseSelectionToolButton)
@@ -122,6 +125,14 @@ class MaskToolBar(qt.QToolBar):
         self.brushAction = self.addWidget(self.brushToolButton)
         self.polygonSelectionAction = self.addWidget(self.polygonSelectionToolButton)
         self.additionalSelectionAction = self.addWidget(self.additionalSelectionToolButton)
+
+        self.imageToolButton.clicked.connect(self._imageIconSignal)
+        self.eraseSelectionToolButton.clicked.connect(self._eraseSelectionIconSignal)
+        self.rectSelectionToolButton.clicked.connect(self._rectSelectionIconSignal)
+        self.brushSelectionToolButton.clicked.connect(self._brushSelectionIconSignal)
+        self.brushToolButton.clicked.connect(self._brushIconSignal)
+        self.polygonSelectionToolButton.clicked.connect(self._polygonIconSignal)
+        self.additionalSelectionToolButton.clicked.connect(self._additionalIconSignal)
 
         if not imageIcons:
             self.imageAction.setVisible(False)
@@ -148,30 +159,30 @@ class MaskToolBar(qt.QToolBar):
         self.brushSelectionAction.setVisible(False)
         self.brushAction.setVisible(False)
         self.eraseSelectionAction.setToolTip("Set erase mode if checked")
-        self.eraseSelectionAction.setCheckable(True)
+        self.eraseSelectionToolButton.setCheckable(True)
 
-        self.eraseSelectionAction.setChecked(self.plot._eraseMode)
+        self.eraseSelectionToolButton.setChecked(self.plot._eraseMode)
 
-        self.polygonSelectionAction.setCheckable(True)
-        self.rectSelectionAction.setCheckable(True)
+        self.polygonSelectionToolButton.setCheckable(True)
+        self.rectSelectionToolButton.setCheckable(True)
 
-        self.brushSelectionAction.setChecked(False)
+        self.brushSelectionToolButton.setChecked(False)
 
     def activateDensityPlotView(self):
         self.brushSelectionAction.setVisible(True)
         self.brushAction.setVisible(True)
         self.rectSelectionAction.setVisible(True)
 
-        self.eraseSelectionAction.setCheckable(True)
-        self.brushSelectionAction.setCheckable(True)
-        self.polygonSelectionAction.setCheckable(True)
-        self.rectSelectionAction.setCheckable(True)
+        self.eraseSelectionToolButton.setCheckable(True)
+        self.brushSelectionToolButton.setCheckable(True)
+        self.polygonSelectionToolButton.setCheckable(True)
+        self.rectSelectionToolButton.setCheckable(True)
 
-    def _imageIconSignal(self):
+    def _imageIconSignal(self, checked=False):
         self.plot._resetSelection(owncall=True)
 
-    def _eraseSelectionIconSignal(self):
-        self.plot._eraseMode = self.eraseSelectionAction.isChecked()
+    def _eraseSelectionIconSignal(self, checked=False):
+        self.plot._eraseMode = checked
 
     def _getSelectionColor(self):
         color = self._selectionColors[self.plot._nRoi]
@@ -181,52 +192,58 @@ class MaskToolBar(qt.QToolBar):
                 color = color.copy()
                 color[-1] = 255
 
-    def _polygonIconSignal(self):
-        if self.polygonSelectionAction.isChecked():
+    def _polygonIconSignal(self, checked=False):
+        if checked:
             self.plot.setInteractiveMode("draw", shape="polygon",
                                          label="mask",
                                          color=self._getSelectionColor())
-            self.plot.setPolygonSelectionMode()
             self.plot._zoomMode = False
             self.plot._brushMode = False
 
-            self.brushSelectionAction.setChecked(False)
-            self.rectSelectionAction.setChecked(False)
-            self.polygonSelectionAction.setChecked(True)
+            self.brushSelectionToolButton.setChecked(False)
+            self.rectSelectionToolButton.setChecked(False)
+            self.polygonSelectionToolButton.setChecked(True)
         else:
             self.plot.setZoomModeEnabled(True)
-            self.polygonSelectionAction.setChecked(False)
-            self.brushSelectionAction.setChecked(False)
+            self.polygonSelectionToolButton.setChecked(False)
+            self.brushSelectionToolButton.setChecked(False)
 
-    def _rectSelectionIconSignal(self):
-        if self.rectSelectionAction.isChecked():
+    def setPolygonSelectionMode(self):
+        """
+        Resets zoom mode and enters selection mode with the current active ROI index
+        """
+        self.polygonSelectionToolButton.setChecked(True)
+        self.polygonSelectionAction.trigger()    # calls _polygonIconSignal
+
+    def _rectSelectionIconSignal(self, checked=False):
+        if checked:
             self.plot.setInteractiveMode("draw", shape="rectangle",
                                          label="mask")
             self.plot._zoomMode = False
             self.plot._brushMode = False
-            self.brushSelectionAction.setChecked(False)
-            self.polygonSelectionAction.setChecked(False)
-            self.rectSelectionAction.setChecked(True)
+            self.brushSelectionToolButton.setChecked(False)
+            self.polygonSelectionToolButton.setChecked(False)
+            self.rectSelectionToolButton.setChecked(True)
 
-            self.setInteractiveMode("draw",
-                                    shape="rectangle",
-                                    label="mask",
-                                    color=self._getSelectionColor())
+            self.plot.setInteractiveMode("draw",
+                                        shape="rectangle",
+                                        label="mask",
+                                        color=self._getSelectionColor())
         else:
             self.plot.setZoomModeEnabled(True)
-            self.polygonSelectionAction.setChecked(False)
-            self.brushSelectionAction.setChecked(False)
+            self.polygonSelectionToolButton.setChecked(False)
+            self.brushSelectionToolButton.setChecked(False)
 
-    def _brushSelectionIconSignal(self):
-        self.polygonSelectionAction.setChecked(False)
-        if self.brushSelectionAction.isChecked():
+    def _brushSelectionIconSignal(self, checked=False):
+        self.polygonSelectionToolButton.setChecked(False)
+        if checked:
             self.plot._brushMode = True
             self.plot.setInteractiveMode('select')
         else:
             self._brushMode = False
             self.plot.setInteractiveMode('zoom')
 
-    def _brushIconSignal(self):
+    def _brushIconSignal(self, checked=False):
         if self._brushMenu is None:
             self._brushMenu = qt.QMenu()
             self._brushMenu.addAction(QString(" 1 Image Pixel Width"),
@@ -293,7 +310,7 @@ class MaskToolBar(qt.QToolBar):
     def __resetSelection(self):
         self.plot._resetSelection(owncall=True)
 
-    def _additionalIconSignal(self):
+    def _additionalIconSignal(self, checked=False):
         if self.plot._plotViewMode == "density":   # and imageData is not none ...
             self._additionalSelectionMenu["density"].exec_(self.cursor().pos())
         else:

--- a/PyMca5/PyMcaGui/plotting/MaskToolBar.py
+++ b/PyMca5/PyMcaGui/plotting/MaskToolBar.py
@@ -1,0 +1,268 @@
+#/*##########################################################################
+# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""This module implements a plot toolbar with buttons to draw and erase masks.
+"""
+
+__author__ = "P. Knobel"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+
+import numpy
+
+from .. import PyMcaQt as qt
+from .PyMca_Icons import IconDict
+from PyMca5.PyMcaGraph import Colors
+
+if hasattr(qt, "QString"):
+    QString = qt.QString
+else:
+    QString = qt.safe_str
+
+
+_COLORDICT = Colors.COLORDICT
+_COLORLIST = [_COLORDICT['black'],
+              _COLORDICT['blue'],
+              _COLORDICT['red'],
+              _COLORDICT['green'],
+              _COLORDICT['pink'],
+              _COLORDICT['yellow'],
+              _COLORDICT['brown'],
+              _COLORDICT['cyan'],
+              _COLORDICT['magenta'],
+              _COLORDICT['orange'],
+              _COLORDICT['violet'],
+              #_COLORDICT['bluegreen'],
+              _COLORDICT['grey'],
+              _COLORDICT['darkBlue'],
+              _COLORDICT['darkRed'],
+              _COLORDICT['darkGreen'],
+              _COLORDICT['darkCyan'],
+              _COLORDICT['darkMagenta'],
+              _COLORDICT['darkYellow'],
+              _COLORDICT['darkBrown']]
+
+
+class MaskToolBar(qt.QToolBar):
+    sigIconSignal = qt.pyqtSignal(object)
+    colorList = _COLORLIST
+
+    def __init__(self, parent=None, plot=None, title="Mask tools",
+                 imageIcons=True, polygon=True):
+        super(MaskToolBar, self).__init__(title, parent)
+        assert plot is not None
+        assert imageIcons or polygon,\
+            "It makes no sense to build an empty mask toolbar"
+        self.plot = plot
+
+        self.polygonSelectionToolButton = qt.QToolButton(self)
+        self.polygonSelectionToolButton.setIcon(self.polygonIcon)
+        self.polygonIcon = qt.QIcon(qt.QPixmap(IconDict["polygon"]))
+        self.polygonSelectionToolButton.setToolTip('Polygon selection\n'
+                                                   'Right click to finish')
+        self.imageIcon = qt.QIcon(qt.QPixmap(IconDict["image"]))
+        self.eraseSelectionIcon = qt.QIcon(qt.QPixmap(IconDict["eraseselect"]))
+        self.rectSelectionIcon = qt.QIcon(qt.QPixmap(IconDict["boxselect"]))
+        self.brushSelectionIcon = qt.QIcon(qt.QPixmap(IconDict["brushselect"]))
+        self.brushIcon = qt.QIcon(qt.QPixmap(IconDict["brush"]))
+        self.additionalIcon = qt.QIcon(qt.QPixmap(IconDict["additionalselect"]))
+
+        self.imageToolButton = qt.QToolButton(self)
+        self.eraseSelectionToolButton = qt.QToolButton(self)
+        self.rectSelectionToolButton = qt.QToolButton(self)
+        self.brushSelectionToolButton = qt.QToolButton(self)
+        self.brushToolButton = qt.QToolButton(self)
+        self.additionalSelectionToolButton = qt.QToolButton(self)
+
+        self.imageToolButton.setIcon(self.imageIcon)
+        self.eraseSelectionToolButton.setIcon(self.eraseSelectionIcon)
+        self.rectSelectionToolButton.setIcon(self.rectSelectionIcon)
+        self.brushSelectionToolButton.setIcon(self.brushSelectionIcon)
+        self.brushToolButton.setIcon(self.brushIcon)
+        self.additionalSelectionToolButton.setIcon(self.additionalIcon)
+
+        self.imageToolButton.setToolTip('Reset')
+        self.eraseSelectionToolButton.setToolTip('Erase Selection')
+        self.rectSelectionToolButton.setToolTip('Rectangular Selection')
+        self.brushSelectionToolButton.setToolTip('Brush Selection')
+        self.brushToolButton.setToolTip('Select Brush')
+        self.additionalSelectionToolButton.setToolTip('Additional Selections Menu')
+
+        self.eraseSelectionToolButton.setCheckable(True)
+
+        self.imageAction = self.addWidget(self.imageToolButton)
+        self.eraseSelectionAction = self.addWidget(self.eraseSelectionToolButton)
+        self.rectSelectionAction = self.addWidget(self.rectSelectionToolButton)
+        self.brushSelectionAction = self.addWidget(self.brushSelectionToolButton)
+        self.brushAction = self.addWidget(self.brushToolButton)
+        self.polygonSelectionAction = self.addWidget(self.polygonSelectionToolButton)
+        self.additionalSelectionAction = self.addWidget(self.additionalSelectionToolButton)
+
+        if not imageIcons:
+            self.imageAction.setVisible(False)
+            self.eraseSelectionAction.setVisible(False)
+            self.rectSelectionAction.setVisible(False)
+            self.brushSelectionAction.setVisible(False)
+            self.brushAction.setVisible(False)
+            self.polygonSelectionAction.setVisible(False)
+            self.additionalSelectionAction.setVisible(False)
+
+        if not polygon:
+            self.polygonSelectionAction.setVisible(False)
+
+        self._selectionColors = numpy.zeros((len(self.colorList), 4), numpy.uint8)
+        for i in range(len(self.colorList)):
+            self._selectionColors[i, 0] = eval("0x" + self.colorList[i][-2:])
+            self._selectionColors[i, 1] = eval("0x" + self.colorList[i][3:-2])
+            self._selectionColors[i, 2] = eval("0x" + self.colorList[i][1:3])
+            self._selectionColors[i, 3] = 0xff
+
+    def activateScatterPlotView(self):
+        self.brushSelectionAction.setVisible(False)
+        self.brushAction.setVisible(False)
+        self.eraseSelectionAction.setToolTip("Set erase mode if checked")
+        self.eraseSelectionAction.setCheckable(True)
+
+        self.eraseSelectionAction.setChecked(self._eraseMode)
+
+        self.polygonSelectionAction.setCheckable(True)
+        self.rectSelectionAction.setCheckable(True)
+
+        self.brushSelectionAction.setChecked(False)
+
+    def activateDensityPlotView(self):
+        self.brushSelectionAction.setVisible(True)
+        self.brushAction.setVisible(True)
+        self.rectSelectionAction.setVisible(True)
+
+        self.eraseSelectionAction.setCheckable(True)
+        self.brushSelectionAction.setCheckable(True)
+        self.polygonSelectionAction.setCheckable(True)
+        self.rectSelectionAction.setCheckable(True)
+
+    def _imageIconSignal(self):
+        self.emitIconSignal("image")
+
+    def _eraseSelectionIconSignal(self):
+        self.plot._eraseMode = self.eraseSelectionAction.isChecked()
+
+    def _getSelectionColor(self):
+        color = self._selectionColors[self.plot._nRoi]
+        # make sure the selection is made with a non transparent color
+        if len(color) == 4:
+            if type(color[-1]) in [numpy.uint8, numpy.int8]:
+                color = color.copy()
+                color[-1] = 255
+
+    def _polygonIconSignal(self):
+        if self.polygonSelectionAction.isChecked():
+            self.plot.setInteractiveMode("draw", shape="polygon",
+                                         label="mask",
+                                         color=self._getSelectionColor())
+            self.plot.setPolygonSelectionMode()
+            self.plot._zoomMode = False
+            self.plot._brushMode = False
+
+            self.brushSelectionAction.setChecked(False)
+            self.rectSelectionAction.setChecked(False)
+            self.polygonSelectionAction.setChecked(True)
+        else:
+            self.plot.setZoomModeEnabled(True)
+            self.polygonSelectionAction.setChecked(False)
+            self.brushSelectionAction.setChecked(False)
+
+    def _rectSelectionIconSignal(self):
+        if self.rectSelectionAction.isChecked():
+            self.plot.setInteractiveMode("draw", shape="rectangle",
+                                         label="mask")
+            self.plot._zoomMode = False
+            self.plot._brushMode = False
+            self.brushSelectionAction.setChecked(False)
+            self.polygonSelectionAction.setChecked(False)
+            self.rectSelectionAction.setChecked(True)
+
+            self.setInteractiveMode("draw",
+                                    shape="rectangle",
+                                    label="mask",
+                                    color=self._getSelectionColor())
+        else:
+            self.plot.setZoomModeEnabled(True)
+            self.polygonSelectionAction.setChecked(False)
+            self.brushSelectionAction.setChecked(False)
+
+    def _brushSelectionIconSignal(self):
+        self.polygonSelectionAction.setChecked(False)
+        if self.brushSelectionAction.isChecked():
+            self.plot._brushMode = True
+            self.plot.setInteractiveMode('select')
+        else:
+            self._brushMode = False
+            self.plot.setInteractiveMode('zoom')
+
+    def _brushIconSignal(self):
+        if self._brushMenu is None:
+            self._brushMenu = qt.QMenu()
+            self._brushMenu.addAction(QString(" 1 Image Pixel Width"),
+                                      self._setBrush1)
+            self._brushMenu.addAction(QString(" 2 Image Pixel Width"),
+                                      self._setBrush2)
+            self._brushMenu.addAction(QString(" 3 Image Pixel Width"),
+                                      self._setBrush3)
+            self._brushMenu.addAction(QString(" 5 Image Pixel Width"),
+                                      self._setBrush4)
+            self._brushMenu.addAction(QString("10 Image Pixel Width"),
+                                      self._setBrush5)
+            self._brushMenu.addAction(QString("20 Image Pixel Width"),
+                                      self._setBrush6)
+        self._brushMenu.exec_(self.cursor().pos())
+
+    def _setBrush1(self):
+        self.plot._brushWidth = 1
+
+    def _setBrush2(self):
+        self.plot._brushWidth = 2
+
+    def _setBrush3(self):
+        self.plot._brushWidth = 3
+
+    def _setBrush4(self):
+        self.plot._brushWidth = 5
+
+    def _setBrush5(self):
+        self.plot._brushWidth = 10
+
+    def _setBrush6(self):
+        self.plot._brushWidth = 20
+
+
+    def _additionalIconSignal(self):
+        self.emitIconSignal("additional")
+
+    def emitIconSignal(self, key, event="iconClicked"):
+        ddict = {"key": key,
+                 "event": event}
+        self.sigIconSignal.emit(ddict)
+
+

--- a/PyMca5/PyMcaGui/plotting/MaskToolBar.py
+++ b/PyMca5/PyMcaGui/plotting/MaskToolBar.py
@@ -77,11 +77,7 @@ class MaskToolBar(qt.QToolBar):
             "It makes no sense to build an empty mask toolbar"
         self.plot = plot
 
-        self.polygonSelectionToolButton = qt.QToolButton(self)
-        self.polygonSelectionToolButton.setIcon(self.polygonIcon)
         self.polygonIcon = qt.QIcon(qt.QPixmap(IconDict["polygon"]))
-        self.polygonSelectionToolButton.setToolTip('Polygon selection\n'
-                                                   'Right click to finish')
         self.imageIcon = qt.QIcon(qt.QPixmap(IconDict["image"]))
         self.eraseSelectionIcon = qt.QIcon(qt.QPixmap(IconDict["eraseselect"]))
         self.rectSelectionIcon = qt.QIcon(qt.QPixmap(IconDict["boxselect"]))
@@ -89,6 +85,7 @@ class MaskToolBar(qt.QToolBar):
         self.brushIcon = qt.QIcon(qt.QPixmap(IconDict["brush"]))
         self.additionalIcon = qt.QIcon(qt.QPixmap(IconDict["additionalselect"]))
 
+        self.polygonSelectionToolButton = qt.QToolButton(self)
         self.imageToolButton = qt.QToolButton(self)
         self.eraseSelectionToolButton = qt.QToolButton(self)
         self.rectSelectionToolButton = qt.QToolButton(self)
@@ -96,6 +93,7 @@ class MaskToolBar(qt.QToolBar):
         self.brushToolButton = qt.QToolButton(self)
         self.additionalSelectionToolButton = qt.QToolButton(self)
 
+        self.polygonSelectionToolButton.setIcon(self.polygonIcon)
         self.imageToolButton.setIcon(self.imageIcon)
         self.eraseSelectionToolButton.setIcon(self.eraseSelectionIcon)
         self.rectSelectionToolButton.setIcon(self.rectSelectionIcon)
@@ -103,6 +101,8 @@ class MaskToolBar(qt.QToolBar):
         self.brushToolButton.setIcon(self.brushIcon)
         self.additionalSelectionToolButton.setIcon(self.additionalIcon)
 
+        self.polygonSelectionToolButton.setToolTip('Polygon selection\n'
+                                                   'Right click to finish')
         self.imageToolButton.setToolTip('Reset')
         self.eraseSelectionToolButton.setToolTip('Erase Selection')
         self.rectSelectionToolButton.setToolTip('Rectangular Selection')

--- a/PyMca5/PyMcaGui/plotting/RGBCorrelatorGraph.py
+++ b/PyMca5/PyMcaGui/plotting/RGBCorrelatorGraph.py
@@ -448,7 +448,7 @@ class RGBCorrelatorGraph(qt.QWidget):
             button.hide()
         self._pickerSelectionWidthLabel.hide()
         self._pickerSelectionWidthValue.hide()
-        if self.graph.getInteractiveMode()['draw']:
+        if self.graph.getInteractiveMode()['mode'] == 'draw':
             self.graph.setInteractiveMode('select')
 
     def showProfileSelectionIcons(self):

--- a/PyMca5/PyMcaGui/plotting/ScatterPlotCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/plotting/ScatterPlotCorrelatorWidget.py
@@ -141,12 +141,12 @@ class ScatterPlotCorrelatorWidget(MaskScatterWidget.MaskScatterWidget):
         self.setSelectionCurveData(x, y, legend=None,
                                    color="k",
                                    symbol=".",
-                                   replot=False,
+                                   resetzoom=False,
                                    replace=True,
                                    xlabel=xLabel,
                                    ylabel=yLabel,
                                    selectable=False)
-        self._updatePlot(replot=False, replace=True)
+        self._updatePlot(resetzoom=False, replace=True)
         #matplotlib needs a zoom reset to update the scales
         # that problem does not seem to be present with OpenGL
         self.resetZoom()


### PR DESCRIPTION
Make the MaskScatterWidget use a silx plot. Closes #105.

This solution uses the current pymca interaction, with buttons in a small toolbar, instead of using the silx mask widget.