### PR TITLE
sift: do not use variadic macro in preprocess.cl

### DIFF
--- a/PyMca5/PyMcaMath/sift/preprocess.cl
+++ b/PyMca5/PyMcaMath/sift/preprocess.cl
@@ -36,13 +36,14 @@
 
 
 //OpenCL extensions are silently defined by opencl compiler at compile-time:
-#ifdef cl_amd_printf
-  #pragma OPENCL EXTENSION cl_amd_printf : enable
-  //#define printf(...)
-#elif defined(cl_intel_printf)
-  #pragma OPENCL EXTENSION cl_intel_printf : enable
-#else
-  #define printf(...)
+#ifdef DEBUG
+  #ifdef cl_amd_printf
+    #pragma OPENCL EXTENSION cl_amd_printf : enable
+  #elif defined(cl_intel_printf)
+    #pragma OPENCL EXTENSION cl_intel_printf : enable
+  #else
+    #define printf(...)
+  #endif
 #endif
 
 #ifndef WORKGROUP_SIZE


### PR DESCRIPTION
Variadic macros are not supported by all OpenCL compilers and may therefore generate compile-time errors.

Closes #133