### PR TITLE
StringIO does not exist under Python 3.

### DIFF
--- a/PyMca5/PyMcaIO/ConfigDict.py
+++ b/PyMca5/PyMcaIO/ConfigDict.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2014 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -31,10 +31,12 @@ __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
-if sys.version < '3.0':
+if sys.version_info < (3,):
     import ConfigParser
+    from StringIO import StringIO
 else:
     import configparser as ConfigParser
+    from io import StringIO
 try:
     import numpy
     USE_NUMPY = True
@@ -170,8 +172,7 @@ class ConfigDict(dict):
                 return sstr
 
     def tostring(self, sections=None):
-        import StringIO
-        tmp = StringIO.StringIO()
+        tmp = StringIO()
         sections = self.__tolist(sections)
         self.__write(tmp, self, sections)
         return tmp.getvalue()


### PR DESCRIPTION
closes #154