### PR TITLE
Remove silx.gui.qt import in Plugin1DBase

### DIFF
--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -124,10 +124,6 @@ try:
     from numpy import argsort, nonzero, take
 except ImportError:
     print("WARNING: numpy not present")
-try:
-    from silx.gui.plot.PlotWidget import PlotWidget as silxPlot
-except ImportError:
-    silxPlot = None
 
 
 def merge_info_params(info, params):
@@ -175,9 +171,8 @@ class Plugin1DBase(object):
         acting as proxy for a *silx* PlotWindow (*legacy=False*).
         """
 
-        if silxPlot is not None:
-            if hasattr(plotWindow, "plot"):  # PluginsToolButton.plot -> silx plot
-                self._legacy = False
+        if hasattr(plotWindow, "plot"):  # PluginsToolButton.plot -> silx plot
+            self._legacy = False
 
     # Window related functions
     def windowTitle(self):

--- a/PyMca5/PyMcaGraph/backends/MatplotlibBackend.py
+++ b/PyMca5/PyMcaGraph/backends/MatplotlibBackend.py
@@ -59,6 +59,50 @@ def nanmin(x):
 
 import sys
 import types
+# This should be independent of Qt
+TK = False
+if "tk" in sys.argv or "Tkinter" in sys.modules or "tkinter" in sys.modules:
+    TK = True
+if TK and "PyQt4.QtCore" not in sys.modules and "PyQt5.QtCore" not in sys.modules and\
+        "PySide.QtCore" not in sys.modules:
+    if sys.version < '3.0':
+        import Tkinter as Tk
+    else:
+        import tkinter as Tk
+elif 'PySide.QtCore' in sys.modules or 'PySide' in sys.argv:
+    matplotlib.rcParams['backend'] = 'Qt4Agg'
+    matplotlib.rcParams['backend.qt4'] = 'PySide'
+    from PySide import QtCore, QtGui
+elif "PyQt4.QtCore" in sys.modules or 'PyQt4' in sys.argv:
+    from PyQt4 import QtCore, QtGui
+    matplotlib.rcParams['backend'] = 'Qt4Agg'
+elif 'PyQt5.QtCore' in sys.modules:
+    matplotlib.rcParams['backend'] = 'Qt5Agg'
+    from PyQt5 import QtCore, QtGui, QtWidgets
+    QtGui.QApplication = QtWidgets.QApplication
+else:
+    try:
+        from PyQt4 import QtCore, QtGui
+        matplotlib.rcParams['backend'] = 'Qt4Agg'
+    except ImportError:
+        try:
+            from PyQt5 import QtCore, QtGui, QtWidgets
+            QtGui.QApplication = QtWidgets.QApplication
+            matplotlib.rcParams['backend']='Qt5Agg'
+        except ImportError:
+            from PySide import QtCore, QtGui
+if ("PyQt4.QtCore" in sys.modules) or ("PySide.QtCore" in sys.modules):
+    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
+    TK = False
+    QT = True
+elif "PyQt5.QtCore" in sys.modules:
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+    TK = False
+    QT = True
+elif ("Tkinter" in sys.modules) or "tkinter" in sys.modules:
+    TK = True
+    QT = False
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg as FigureCanvas
 try:
     from .. import PlotBackend
 except ImportError:
@@ -69,50 +113,6 @@ try:
     from matplotlib.widgets import Cursor
 except:
     print("matplotlib.widgets Cursor not available")
-# This should be independent of Qt
-TK = False
-if ("tk" in sys.argv) or ("Tkinter" in sys.modules) or ("tkinter" in sys.modules):
-    TK = True
-if TK and ("PyQt4" not in sys.modules) and ("PyQt5" not in sys.modules) and\
-    ("PySide" not in sys.modules):
-    if sys.version < '3.0':
-        import Tkinter as Tk
-    else:
-        import tkinter as Tk
-elif ('PySide' in sys.modules) or ('PySide' in sys.argv) :
-    matplotlib.rcParams['backend']='Qt4Agg'
-    matplotlib.rcParams['backend.qt4']='PySide'
-    from PySide import QtCore, QtGui
-elif ("PyQt4" in sys.modules) or ('PyQt4' in sys.argv):
-    from PyQt4 import QtCore, QtGui
-    matplotlib.rcParams['backend']='Qt4Agg'
-elif ('PyQt5' in sys.modules):
-    matplotlib.rcParams['backend']='Qt5Agg'
-    from PyQt5 import QtCore, QtGui, QtWidgets
-    QtGui.QApplication = QtWidgets.QApplication
-else:
-    try:
-        from PyQt4 import QtCore, QtGui
-        matplotlib.rcParams['backend']='Qt4Agg'
-    except ImportError:
-        try:
-            from PyQt5 import QtCore, QtGui, QtWidgets
-            QtGui.QApplication = QtWidgets.QApplication
-            matplotlib.rcParams['backend']='Qt5Agg'
-        except ImportError:
-            from PySide import QtCore, QtGui
-if ("PyQt4" in sys.modules) or ("PySide" in sys.modules):
-    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-    TK = False
-    QT = True
-elif "PyQt5" in sys.modules:
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-    TK = False
-    QT = True
-elif ("Tkinter" in sys.modules) or ("tkinter") in sys.modules:
-    TK = True
-    QT = False
-    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg as FigureCanvas
 
 from matplotlib.figure import Figure
 import matplotlib.patches as patches
@@ -359,7 +359,7 @@ class MatplotlibGraph(FigureCanvas):
         # this respects aspect size
         # self.ax = self.fig.add_subplot(111, aspect='equal')
         # This should be independent of Qt
-        if ("PyQt4" in sys.modules) or ("PySide" in sys.modules):
+        if matplotlib.rcParams['backend'] == "Qt4Agg":
             FigureCanvas.setSizePolicy(self,
                                    QtGui.QSizePolicy.Expanding,
                                    QtGui.QSizePolicy.Expanding)

--- a/PyMca5/PyMcaGraph/backends/MatplotlibBackend.py
+++ b/PyMca5/PyMcaGraph/backends/MatplotlibBackend.py
@@ -61,19 +61,19 @@ import sys
 import types
 # This should be independent of Qt
 TK = False
-if "tk" in sys.argv or "Tkinter" in sys.modules or "tkinter" in sys.modules:
+if ("tk" in sys.argv) or ("Tkinter" in sys.modules) or ("tkinter" in sys.modules):
     TK = True
-if TK and "PyQt4.QtCore" not in sys.modules and "PyQt5.QtCore" not in sys.modules and\
-        "PySide.QtCore" not in sys.modules:
+if TK and ("PyQt4.QtCore" not in sys.modules) and ("PyQt5.QtCore" not in sys.modules) and\
+        ("PySide.QtCore" not in sys.modules):
     if sys.version < '3.0':
         import Tkinter as Tk
     else:
         import tkinter as Tk
-elif 'PySide.QtCore' in sys.modules or 'PySide' in sys.argv:
+elif ('PySide.QtCore' in sys.modules) or ('PySide' in sys.argv):
     matplotlib.rcParams['backend'] = 'Qt4Agg'
     matplotlib.rcParams['backend.qt4'] = 'PySide'
     from PySide import QtCore, QtGui
-elif "PyQt4.QtCore" in sys.modules or 'PyQt4' in sys.argv:
+elif ("PyQt4.QtCore" in sys.modules) or ('PyQt4' in sys.argv):
     from PyQt4 import QtCore, QtGui
     matplotlib.rcParams['backend'] = 'Qt4Agg'
 elif 'PyQt5.QtCore' in sys.modules:
@@ -88,7 +88,7 @@ else:
         try:
             from PyQt5 import QtCore, QtGui, QtWidgets
             QtGui.QApplication = QtWidgets.QApplication
-            matplotlib.rcParams['backend']='Qt5Agg'
+            matplotlib.rcParams['backend'] = 'Qt5Agg'
         except ImportError:
             from PySide import QtCore, QtGui
 if ("PyQt4.QtCore" in sys.modules) or ("PySide.QtCore" in sys.modules):
@@ -99,7 +99,7 @@ elif "PyQt5.QtCore" in sys.modules:
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
     TK = False
     QT = True
-elif ("Tkinter" in sys.modules) or "tkinter" in sys.modules:
+elif ("Tkinter" in sys.modules) or ("tkinter" in sys.modules):
     TK = True
     QT = False
     from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg as FigureCanvas
@@ -747,7 +747,7 @@ class MatplotlibGraph(FigureCanvas):
                         self._mouseData[0,1] = self._ymin
                         self._mouseData[1,0] = self._x0
                         self._mouseData[1,1] = self._ymax
-                    color=self._getDrawingColor()
+                    color = self._getDrawingColor()
                     self._drawingPatch = Polygon(self._mouseData,
                                              closed=True,
                                              fill=False,
@@ -2907,7 +2907,7 @@ def main(parent=None):
     return plot
 
 if __name__ == "__main__":
-    if "tkinter" in sys.modules or "Tkinter" in sys.modules:
+    if ("tkinter" in sys.modules) or ("Tkinter" in sys.modules):
         root = Tk.Tk()
         parent=root
         #w = MatplotlibGraph(root)
@@ -2917,7 +2917,7 @@ if __name__ == "__main__":
         widget = w._plot.graph
     else:
         app = QtGui.QApplication([])
-        parent=None
+        parent = None
         w = main(parent)
         widget = w.getWidgetHandle()
     #w.invertYAxis(True)
@@ -2945,7 +2945,7 @@ if __name__ == "__main__":
     w.resetZoom()
     #print(w.widget.ax.get_images())
     #print(w.widget.ax.get_lines())
-    if "tkinter" in sys.modules or "Tkinter" in sys.modules:
+    if ("tkinter" in sys.modules) or ("Tkinter" in sys.modules):
         tkWidget = w.getWidgetHandle()
         tkWidget.pack(side=Tk.TOP, fill=Tk.BOTH, expand=1)
         Tk.mainloop()


### PR DESCRIPTION
This causes PyQt5 to be imported,  causing a PyQt4 / PyQt5 conflict for a reason yet unknown.