### PR TITLE
[silx]Use sift from silx

### DIFF
--- a/PyMca5/PyMcaGui/math/SIFTAlignmentWindow.py
+++ b/PyMca5/PyMcaGui/math/SIFTAlignmentWindow.py
@@ -29,20 +29,20 @@ __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import os
-import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import ExternalImagesWindow
 from PyMca5.PyMcaGui import PyMcaFileDialogs
-from PyMca5.PyMcaMath import sift
+import silx.opencl
+from silx.image import sift
 
 DEBUG = 0
 
 if DEBUG:
     print("SIFT coming from %s" % os.path.abspath(sift.__file__))
 
-__doc__ ="""The SIFT algorithm belongs to the University of British Columbia. It is
-protected by patent US6711293. If you are on a country where this pattent
+__doc__ = """The SIFT algorithm belongs to the University of British Columbia. It is
+protected by patent US6711293. If you are in a country where this patent
 applies (like the USA), please check if you are allowed to use it. The
 University of British Columbia does not require a license for its use for
 non-commercial research applications.
@@ -50,7 +50,7 @@ non-commercial research applications.
 This SIFT implementation uses the code developed by Jerome Kieffer and
 Pierre Paleo. The project is hosted at:
 
-https://github.com/kif/sift_pyocl
+https://github.com/silx-kit/silx/tree/master/silx/opencl/sift
 
 This algorithm should provide better results than FFT based algorithms
 provided the images to be aligned provide enough registration points
@@ -72,7 +72,7 @@ Please note that introduces an additional dependency of PyMca on PyOpenCL.
 
 sift_pyocl license follows:
 
-Copyright(C) 2013 European Synchrotron Radiation Facility, Grenoble, France
+Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
 
  Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -146,8 +146,8 @@ class ParametersWidget(qt.QWidget):
 
     def getOpenCLDevices(self):
         devices = []
-        if sift.opencl.ocl is not None:
-            for platformid, platform in enumerate(sift.opencl.ocl.platforms):
+        if silx.opencl.ocl is not None:
+            for platformid, platform in enumerate(silx.opencl.ocl.platforms):
                 for deviceid, dev in enumerate(platform.devices):
                     devices.append((platformid, deviceid, dev.name))
         return devices

--- a/PyMca5/PyMcaMath/sift/__init__.py
+++ b/PyMca5/PyMcaMath/sift/__init__.py
@@ -37,3 +37,7 @@ from .plan import SiftPlan
 from .match import MatchPlan
 from .alignment import LinearAlign
 
+
+_logger = logging.getLogger(__name__)
+_logger.warning("The sift module in PyMca is deprecated. "
+                "You should import sift from the silx library.")

--- a/PyMca5/PyMcaPlugins/ImageAlignmentStackPlugin.py
+++ b/PyMca5/PyMcaPlugins/ImageAlignmentStackPlugin.py
@@ -340,28 +340,13 @@ class ImageAlignmentStackPlugin(StackPluginBase.StackPluginBase):
             if mask.sum() == 0:
                 mask = None
         if device is None:
-            if sys.platform == 'darwin':
-                max_workgroup_size = 1
-                siftInstance = sift.LinearAlign(reference.astype(numpy.float32),
-                                                max_workgroup_size=max_workgroup_size,
-                                                devicetype="cpu",
-                                                init_sigma=sigma)
-            else:
-                siftInstance = sift.LinearAlign(reference.astype(numpy.float32),
-                                                devicetype="cpu",
-                                                init_sigma=sigma)
+            siftInstance = sift.LinearAlign(reference.astype(numpy.float32),
+                                            devicetype="cpu",
+                                            init_sigma=sigma)
         else:
-            deviceType = ocl.platforms[device[0]].devices[device[1]].type
-            if deviceType.lower() == "cpu" and sys.platform == 'darwin':
-                max_workgroup_size = 1
-                siftInstance = sift.LinearAlign(reference.astype(numpy.float32),
-                                                max_workgroup_size=max_workgroup_size,
-                                                device=device,
-                                                init_sigma=sigma)
-            else:
-                siftInstance = sift.LinearAlign(reference.astype(numpy.float32),
-                                                device=device,
-                                                init_sigma=sigma)
+            siftInstance = sift.LinearAlign(reference.astype(numpy.float32),
+                                            deviceid=device,
+                                            init_sigma=sigma)
         data = stack.data
         mcaIndex = stack.info['McaIndex']
         if not (mcaIndex in [0, 2, -1]):

--- a/PyMca5/PyMcaPlugins/ImageAlignmentStackPlugin.py
+++ b/PyMca5/PyMcaPlugins/ImageAlignmentStackPlugin.py
@@ -77,6 +77,7 @@ _logger = logging.getLogger(__name__)
 try:
     from PyMca5.PyMcaGui import SIFTAlignmentWindow
     sift = SIFTAlignmentWindow.sift
+    ocl = SIFTAlignmentWindow.silx.opencl.ocl
     SIFT = True
 except:
     _logger.warning("SIFTAlignmentWindow not successful")
@@ -291,14 +292,14 @@ class ImageAlignmentStackPlugin(StackPluginBase.StackPluginBase):
                 import pyopencl
             except:
                 raise ImportError("PyOpenCL does not seem to be installed on your system")
-        if sift.opencl.ocl is None:
+        if ocl is None:
             raise ImportError("PyOpenCL does not seem to be installed on your system")
         stack = self.getStackDataObject()
         if stack is None:
             return
         mcaIndex = stack.info.get('McaIndex')
         if not (mcaIndex in [0, 2, -1]):
-             raise IndexError("Unsupported 1D index %d" % mcaIndex)
+            raise IndexError("Unsupported 1D index %d" % mcaIndex)
         widget = SIFTAlignmentWindow.SIFTAlignmentDialog()
         widget.setStack(stack)
         mask = self.getStackSelectionMask()
@@ -350,7 +351,7 @@ class ImageAlignmentStackPlugin(StackPluginBase.StackPluginBase):
                                                 devicetype="cpu",
                                                 init_sigma=sigma)
         else:
-            deviceType = sift.opencl.ocl.platforms[device[0]].devices[device[1]].type
+            deviceType = ocl.platforms[device[0]].devices[device[1]].type
             if deviceType.lower() == "cpu" and sys.platform == 'darwin':
                 max_workgroup_size = 1
                 siftInstance = sift.LinearAlign(reference.astype(numpy.float32),


### PR DESCRIPTION
Closes #122 

On my machine it works fine with PY3, and shows correct results on PY2 but segfaults on exiting the demo code in `SIFTAlignmentWindow`. 
The segfault is most likely unrelated to sift, I believe I messed up my system when I uninstalled a lot of packages to do debian packaging (It also segfaults on PY2 when I run the demo code in `McaWindow`).

I will do a few more tests to try to solve the issue on my machine, before removing the WIP tag.
