### PR TITLE
[DataViewer] fix ColormapAction patch

### DIFF
--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5NodeView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5NodeView.py
@@ -60,7 +60,7 @@ if silx.version == '0.7.0':
         dialog.setModal(False)
         return dialog
 
-    ColormapAction._createDialog = _ColormapAction_createDialog
+    ColormapAction._createDialog = staticmethod(_ColormapAction_createDialog)
 
 
 PLUGINS_DIR = []


### PR DESCRIPTION
The patched method must be static.

Related to #173, #175 and silx-kit/silx#1726, 