### PR TITLE
Fix bug (qt.Signal does not always exist with PyQt)

### DIFF
--- a/PyMca5/PyMcaGui/pymca/McaWindow.py
+++ b/PyMca5/PyMcaGui/pymca/McaWindow.py
@@ -74,7 +74,7 @@ _logger = logging.getLogger(__name__)
 
 
 class McaWindow(ScanWindow.ScanWindow):
-    sigROISignal = qt.Signal(object)
+    sigROISignal = qt.pyqtSignal(object)
 
     def __init__(self, parent=None, name="Mca Window", fit=True, backend=None,
                  plugins=True, control=True, position=True, roi=True,


### PR DESCRIPTION
This PR is a bug fix for the silx branch. PyMcaQt does not provide `qt.Signal`.