### PR TITLE
Debian 9 package 5.3.1

### DIFF
--- a/PyMca5/PyMcaCore/NexusTools.py
+++ b/PyMca5/PyMcaCore/NexusTools.py
@@ -426,8 +426,10 @@ def getInstrumentGroup(h5file, path):
 
 def getScannedPositioners(h5file, path):
     """
-    Try to retrieve the positioners (aka. motors) that were moved
+    Try to retrieve the positioners (aka. motors) that were moved.
+
     For that:
+
         - Look for datasets present at measurement and positioners groups
         - Look for positioners with more than one single value
         - Look for datasets present at measurement and title

--- a/PyMca5/PyMcaDataDir.py
+++ b/PyMca5/PyMcaDataDir.py
@@ -36,31 +36,46 @@ PYMCA_DATA_DIR = 'DATA_DIR_FROM_SETUP'
 # This is to be filled by the setup
 PYMCA_DOC_DIR = 'DOC_DIR_FROM_SETUP'
 
+PYMCA_DATA_DIR_ENV = os.getenv("PYMCA_DATA_DIR")
+if PYMCA_DATA_DIR_ENV is not None:
+    PYMCA_DATA_DIR = PYMCA_DATA_DIR_ENV
+    if not os.path.exists(PYMCA_DATA_DIR):
+        raise IOError('%s directory set from environment not found' % \
+                      PYMCA_DATA_DIR)
+    else:
+        txt = "WARNING: Taking PYMCA_DATA_DIR from environment.\n"
+        txt += "Use it at your own risk."
+        print(txt)
+
+
 # this is used in build directory
 if not os.path.exists(PYMCA_DATA_DIR):
     tmp_dir = os.path.dirname(os.path.abspath(__file__))
     old_tmp_dir = tmp_dir + "dummy"
     basename = "PyMcaData"
-    PYMCA_DATA_DIR = os.path.join(tmp_dir, "PyMca5", basename)
-    while (len(PYMCA_DATA_DIR) > 20) and (tmp_dir != old_tmp_dir):
-        if os.path.exists(PYMCA_DATA_DIR):
+    PYMCA_DATA_DIR_BUILD = os.path.join(tmp_dir, "PyMca5", basename)
+    while (len(PYMCA_DATA_DIR_BUILD) > 20) and (tmp_dir != old_tmp_dir):
+        if os.path.exists(PYMCA_DATA_DIR_BUILD):
+            PYMCA_DATA_DIR = PYMCA_DATA_DIR_BUILD
             break
         old_tmp_dir = tmp_dir
         tmp_dir = os.path.dirname(tmp_dir)
-        PYMCA_DATA_DIR = os.path.join(tmp_dir, "PyMca5", basename)
+        PYMCA_DATA_DIR_BUILD = os.path.join(tmp_dir, "PyMca5", basename)
 
 if not os.path.exists(PYMCA_DATA_DIR):
-    PYMCA_DATA_DIR = os.getenv("PYMCA_DATA_DIR")
-    if PYMCA_DATA_DIR is not None:
-        if not os.path.exists(PYMCA_DATA_DIR):
-            raise IOError('%s directory set from environent not found' % \
+    raise IOError('%s directory not found' % PYMCA_DATA_DIR)
+
+
+PYMCA_DOC_DIR_ENV = os.getenv("PYMCA_DOC_DIR")
+if PYMCA_DOC_DIR_ENV is not None:
+    PYMCA_DOC_DIR = PYMCA_DOC_DIR_ENV
+    if not os.path.exists(PYMCA_DOC_DIR):
+        raise IOError('%s directory set from environent not found' % \
                           PYMCA_DATA_DIR)
-        else:
-            txt = "WARNING: Taking PYMCA_DATA_DIR from environement.\n"
-            txt += "Use it at your own risk."
-            print(txt)
     else:
-        raise IOError('%s directory not found' % basename)
+        txt = "WARNING: Taking PYMCA_DOC_DIR from environement.\n"
+        txt += "Use it at your own risk."
+        print(txt)
 
 # do the same for the directory containing HTML files
 if not os.path.exists(PYMCA_DOC_DIR):
@@ -74,21 +89,6 @@ if not os.path.exists(PYMCA_DOC_DIR):
         old_tmp_dir = tmp_dir
         tmp_dir = os.path.dirname(tmp_dir)
         PYMCA_DOC_DIR = os.path.join(tmp_dir, "PyMca5", basename)
-
-if not os.path.exists(PYMCA_DOC_DIR):
-    PYMCA_DOC_DIR = os.getenv("PYMCA_DOC_DIR")
-    if PYMCA_DOC_DIR is not None:
-        if not os.path.exists(PYMCA_DOC_DIR):
-            raise IOError('%s directory set from environent not found' % \
-                          PYMCA_DATA_DIR)
-        else:
-            txt = "WARNING: Taking PYMCA_DOC_DIR from environement.\n"
-            txt += "Use it at your own risk."
-            print(txt)
-    else:
-        # use the data dir as doc dir
+    if not os.path.exists(PYMCA_DOC_DIR):
         print("Setting PYMCA_DOC_DIR equal to PYMCA_DATA_DIR")
         PYMCA_DOC_DIR = PYMCA_DATA_DIR
-
-if not os.path.exists(PYMCA_DOC_DIR):
-    raise IOError('%s documentation directory not found' % basename)

--- a/package/debian9/changelog
+++ b/package/debian9/changelog
@@ -1,3 +1,9 @@
+pymca (5.3.1-1) unstable; urgency=low
+
+  * New release 5.3.1
+
+ -- Pierre Knobel <pierre.knobel@esrf.fr>  Thu, 27 Apr 2018 10:01:17 +0200
+
 pymca (5.3.0-2) unstable; urgency=low
 
   * New release 5.3.0

--- a/package/debian9/rules
+++ b/package/debian9/rules
@@ -25,6 +25,10 @@ override_dh_clean:
 	# remove the build documentation
 	rm -rf doc/build
 
+override_dh_auto_build:
+	dh_auto_build
+	python setup.py build build_doc
+
 override_dh_installchangelogs:
 	dh_installchangelogs changelog.txt
 
@@ -58,10 +62,6 @@ override_dh_auto_test:
 	PYBUILD_SYSTEM=custom \
 	PYBUILD_TEST_ARGS="cd {build_dir} && PYMCA_DATA_DIR=$(PYMCA_DATA_DIR_TEST) {interpreter} PyMca5/tests/TestAll.py" dh_auto_test
 
-override_dh_sphinxdoc:
-ifeq (,$(findstring nodocs, $(DEB_BUILD_OPTIONS)))
-	PYBUILD_SYSTEM=custom \
-	PYBUILD_BUILD_ARGS="cd doc && PYTHONPATH={build_dir} PYMCA_DATA_DIR=$(PYMCA_DATA_DIR_TEST) http_proxy='127.0.0.1:9' {interpreter} -m sphinx -N -bhtml source build/html" dh_auto_build  # HTML generator
-	dh_installdocs "doc/build/html" -p pymca-doc
-	dh_sphinxdoc -O--buildsystem=pybuild
-endif
+override_dh_installdocs:
+	dh_installdocs "build/sphinx/html" -p pymca-doc
+	dh_installdocs


### PR DESCRIPTION
Allows to build debian  package on a machine with a previous version of PyMca already installed.

Changes for debian 9 package 5.3.1