### PR TITLE
[ROI Imaging] Correct error reading stacks of SPE files

### DIFF
--- a/PyMca5/PyMcaCore/NexusTools.py
+++ b/PyMca5/PyMcaCore/NexusTools.py
@@ -483,7 +483,7 @@ if __name__ == "__main__":
     except:
         print("Usage: NexusTools <file> <key>")
         sys.exit()
-    h5 = h5py.File(sourcename)
+    h5 = h5py.File(sourcename, 'r')
     entries = getNXClassGroups(h5, "/", ["NXentry", b"NXentry"], single=False)
     if not len(entries):
         entries = [item for name, item in h5["/"].items() if isGroup(item)]

--- a/PyMca5/PyMcaCore/StackBase.py
+++ b/PyMca5/PyMcaCore/StackBase.py
@@ -323,8 +323,12 @@ class StackBase(object):
                            "SourceName": "Stack",
                            "Key": "SUM"}
         if "McaLiveTime" in self._stack.info:
-            dataObject.info["McaLiveTime"] = \
+            if hasattr(self._stack.info["McaLiveTime"], "sum"):
+                dataObject.info["McaLiveTime"] = \
                                 self._stack.info["McaLiveTime"].sum()
+            else:
+                print("Not an array. Skipping time information")
+                del dataObject.info["McaLiveTime"]
         if not hasattr(self._stack, 'x'):
             self._stack.x = None
         if self._stack.x in [None, []]:


### PR DESCRIPTION
Reading SPE files, the time information is read for the first spectrum and not for the rest, therefore not generating an array. That gives an error when trying to sum all the times.