### PR TITLE
[ROI Imaging] Use float32 when using a monitor.

### DIFF
--- a/PyMca5/PyMcaCore/StackBase.py
+++ b/PyMca5/PyMcaCore/StackBase.py
@@ -281,11 +281,12 @@ class StackBase(object):
                                                 dtype=numpy.float)
                 mcaData0 = numpy.zeros((shape[2],), numpy.float)
                 step = 1
-                if hasattr(self._stack, "monitor"):
-                    monitor = self._stack.monitor[:]
-                    monitor.shape = shape[2]
-                else:
-                    monitor = numpy.ones((shape[2],), numpy.float)
+                # this is not the meaning of monitor
+                #if hasattr(self._stack, "monitor"):
+                #    monitor = self._stack.monitor[:]
+                #    monitor.shape = shape[2]
+                #else:
+                #    monitor = numpy.ones((shape[2],), numpy.float)
                 for i in range(shape[0]):
                     tmpData = self._stack.data[i:i+step,:,:]
                     numpy.add(self._stackImageData[i:i+step,:],

--- a/PyMca5/PyMcaGui/pymca/StackSelector.py
+++ b/PyMca5/PyMcaGui/pymca/StackSelector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2018 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -279,7 +279,7 @@ class StackSelector(object):
             stack = SupaVisioMap.SupaVisioMap(args[0])
         elif args[0][-3:].upper() in ["RBS"]:
             stack = SupaVisioMap.SupaVisioMap(args[0])
-        elif args[0][-3:].lower() in [".h5", "nxs", "hdf"]:
+        elif args[0][-3:].lower() in [".h5", "nxs", "hdf", "hdf5"]:
             if not HDF5:
                 raise IOError(\
                     "No HDF5 support while trying to read an HDF5 file")

--- a/PyMca5/PyMcaIO/HDF5Stack1D.py
+++ b/PyMca5/PyMcaIO/HDF5Stack1D.py
@@ -256,7 +256,10 @@ class HDF5Stack1D(DataObject.DataObject):
             if self.__dtype in [numpy.int16, numpy.uint16]:
                 self.__dtype = numpy.float32
             elif self.__dtype in [numpy.int32, numpy.uint32]:
-                self.__dtype = numpy.float64
+                if mSelection:
+                    self.__dtype = numpy.float32
+                else:
+                    self.__dtype = numpy.float64
             elif self.__dtype not in [numpy.float16, numpy.float32,
                                       numpy.float64]:
                 # Some datasets form CLS (origin APS?) arrive as data format
@@ -266,7 +269,10 @@ class HDF5Stack1D(DataObject.DataObject):
                 if ("%s" % self.__dtype).endswith("2"):
                     self.__dtype = numpy.float32
                 else:
-                    self.__dtype = numpy.float64
+                    if mSelection:
+                        self.__dtype = numpy.float32
+                    else:
+                        self.__dtype = numpy.float64
 
         # figure out the shape of the stack
         shape = yDataset.shape

--- a/PyMca5/PyMcaIO/HDF5Stack1D.py
+++ b/PyMca5/PyMcaIO/HDF5Stack1D.py
@@ -291,7 +291,7 @@ class HDF5Stack1D(DataObject.DataObject):
             neededMegaBytes = nFiles * dim0 * dim1 * (mcaDim * bytefactor/(1024*1024.))
             physicalMemory = None
             if hasattr(PhysicalMemory, "getAvailablePhysicalMemoryOrNone"):
-                physicalMemory = getAvailablePhysicalMemoryOrNone()
+                physicalMemory = PhysicalMemory.getAvailablePhysicalMemoryOrNone()
             if not physicalMemory:
                 physicalMemory = PhysicalMemory.getPhysicalMemoryOrNone()
             if physicalMemory is None:

--- a/PyMca5/PyMcaMisc/PhysicalMemory.py
+++ b/PyMca5/PyMcaMisc/PhysicalMemory.py
@@ -81,13 +81,33 @@ if sys.platform == 'win32':
             self.dwLength = ctypes.sizeof(self)
             super(MEMORYSTATUSEX, self).__init__()
 
-    #print("MemoryLoad: %d%%" % (stat.dwMemoryLoad))
-    #print("Physical memory = %d" % stat.ullTotalPhys)
-    #print(stat.ullAvailPhys)
     def getPhysicalMemory():
+        #print("MemoryLoad: %d%%" % (stat.dwMemoryLoad))
+        #print("Physical memory = %d" % stat.ullTotalPhys)
+        #print(stat.ullAvailPhys)
         stat = MEMORYSTATUSEX()
         ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
         return stat.ullTotalPhys
+
+    def getAvailablePhysicalMemory():
+        stat = MEMORYSTATUSEX()
+        ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))
+        value = stat.ullAvailPhys
+        return value
+
+    def getAvailablePhysicalMemoryOrNone():
+        try:
+            value = getAvailablePhysicalMemory()
+            if value < 0:
+                # Value makes no sense.
+                # return None as requested in case of failure
+                print("WARNING: Returned physical memory does not make sense %d" % \
+                          value)
+                return None
+            else:
+                return value
+        except:
+            return None
 
 elif sys.platform.startswith('linux'):
     def getPhysicalMemory():

--- a/PyMca5/PyMcaMisc/PhysicalMemory.py
+++ b/PyMca5/PyMcaMisc/PhysicalMemory.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.


### PR DESCRIPTION
To use float64 data to deal with int32 data when a monitor is requested seems overkill.

This PR:

- Uses float32 when using a monitor
- Checks for **available** physical memory instead of installed physical memory under windows.