### PR TITLE
[gui] Remove numpy boolean subtraction from image mask.

### DIFF
--- a/PyMca5/PyMcaGui/plotting/MaskImageWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskImageWidget.py
@@ -1123,7 +1123,7 @@ class MaskImageWidget(qt.QWidget):
                                              numpy.uint8)
         minValue, maxValue = self._getSelectionMinMax()
         tmpData = numpy.array(self.__imageData, copy=True)
-        tmpData[True - numpy.isfinite(self.__imageData)] = minValue
+        tmpData[~numpy.isfinite(self.__imageData)] = minValue
         selectionMask[tmpData >= maxValue] = 1
         self.setSelectionMask(selectionMask, plot=False)
         self.plotImage(update=False)
@@ -1134,7 +1134,7 @@ class MaskImageWidget(qt.QWidget):
                                              numpy.uint8)
         minValue, maxValue = self._getSelectionMinMax()
         tmpData = numpy.array(self.__imageData, copy=True)
-        tmpData[True - numpy.isfinite(self.__imageData)] = maxValue
+        tmpData[~numpy.isfinite(self.__imageData)] = maxValue
         selectionMask[tmpData >= maxValue] = 0
         selectionMask[tmpData <= minValue] = 0
         self.setSelectionMask(selectionMask, plot=False)
@@ -1146,7 +1146,7 @@ class MaskImageWidget(qt.QWidget):
                                              numpy.uint8)
         minValue, maxValue = self._getSelectionMinMax()
         tmpData = numpy.array(self.__imageData, copy=True)
-        tmpData[True - numpy.isfinite(self.__imageData)] = maxValue
+        tmpData[~numpy.isfinite(self.__imageData)] = maxValue
         selectionMask[tmpData <= minValue] = 1
         self.setSelectionMask(selectionMask, plot=False)
         self.plotImage(update=False)


### PR DESCRIPTION
This breaks image masking based on intensities (raises a TypeError):
https://github.com/numpy/numpy/commit/58e9e27c0c110f9be1558a53fb547dc1abc76fa4#diff-a42b7545751437baeae8a6e2dfaacd98