### PR TITLE
Fix numpy.fromstring deprecation warning

### DIFF
--- a/PyMca5/PyMcaGui/plotting/MaskImageWidget.py
+++ b/PyMca5/PyMcaGui/plotting/MaskImageWidget.py
@@ -1249,23 +1249,25 @@ class MaskImageWidget(qt.QWidget):
             self.__image = qimage
 
         if self.__image.format() == qt.QImage.Format_Indexed8:
-            pixmap0 = numpy.fromstring(qimage.bits().asstring(width * height),
-                                 dtype = numpy.uint8)
+            pixmap0 = numpy.frombuffer(qimage.bits().asstring(width * height),
+                                       dtype=numpy.uint8)
             pixmap = numpy.zeros((height * width, 4), numpy.uint8)
-            pixmap[:,0] = pixmap0[:]
-            pixmap[:,1] = pixmap0[:]
-            pixmap[:,2] = pixmap0[:]
-            pixmap[:,3] = 255
+            pixmap[:, 0] = pixmap0[:]
+            pixmap[:, 1] = pixmap0[:]
+            pixmap[:, 2] = pixmap0[:]
+            pixmap[:, 3] = 255
             pixmap.shape = height, width, 4
         else:
             self.__image = self.__image.convertToFormat(qt.QImage.Format_ARGB32)
-            pixmap = numpy.fromstring(self.__image.bits().asstring(width * height * 4),
-                                 dtype = numpy.uint8)
-            pixmap.shape = height, width,-1
+            pixmap0 = numpy.frombuffer(self.__image.bits().asstring(width * height * 4),
+                                       dtype=numpy.uint8)
+            pixmap = numpy.array(pixmap0, copy=True)
+            pixmap.shape = height, width, -1
             # Qt uses BGRA, convert to RGBA
-            tmpBuffer = numpy.array(pixmap[:,:,0], copy=True, dtype=pixmap.dtype)
-            pixmap[:,:,0] = pixmap[:,:,2]
-            pixmap[:,:,2] = tmpBuffer
+            tmpBuffer = numpy.array(pixmap[:, :, 0],
+                                    copy=True, dtype=pixmap.dtype)
+            pixmap[:, :, 0] = pixmap[:, :, 2]
+            pixmap[:, :, 2] = tmpBuffer
 
         if data is None:
             self.__imageData = numpy.zeros((height, width), numpy.float)

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -896,18 +896,20 @@ class RGBCorrelatorWidget(qt.QWidget):
                     height = qimage.height()
                     width  = qimage.width()
                     if qimage.format() == qt.QImage.Format_Indexed8:
-                        pixmap0 = numpy.fromstring(qimage.bits().asstring(width * height),
-                                             dtype = numpy.uint8)
+                        pixmap0 = numpy.frombuffer(qimage.bits().asstring(width * height),
+                                                   dtype=numpy.uint8)
                         pixmap = numpy.zeros((height * width, 4), numpy.uint8)
-                        pixmap[:,0] = pixmap0[:]
-                        pixmap[:,1] = pixmap0[:]
-                        pixmap[:,2] = pixmap0[:]
-                        pixmap[:,3] = 255
+                        pixmap[:, 0] = pixmap0[:]
+                        pixmap[:, 1] = pixmap0[:]
+                        pixmap[:, 2] = pixmap0[:]
+                        pixmap[:, 3] = 255
                         pixmap.shape = height, width, 4
                     else:
                         image = qimage.convertToFormat(qt.QImage.Format_ARGB32)
-                        pixmap = numpy.fromstring(qimage.bits().asstring(width * height * 4),
-                                             dtype = numpy.uint8)
+                        pixmap0 = numpy.frombuffer(image.bits().asstring(width * height * 4),
+                                                   dtype=numpy.uint8)
+                        pixmap = numpy.array(pixmap0, copy=True)
+
                     pixmap.shape = height, width, -1
                     data = pixmap[:,:,0] * 0.114 +\
                                 pixmap[:,:,1] * 0.587 +\

--- a/PyMca5/PyMcaIO/EdfFile.py
+++ b/PyMca5/PyMcaIO/EdfFile.py
@@ -443,7 +443,7 @@ class  EdfFile(object):
             self.Images[Index].DataType = 'UnsignedShort'
             try:
                 self.__data = numpy.reshape(
-                    numpy.fromstring(binary, numpy.uint16),
+                    numpy.copy(numpy.frombuffer(binary, numpy.uint16)),
                     (self.Images[Index].Dim2, self.Images[Index].Dim1))
             except ValueError:
                 raise IOError('Size spec in ADSC-header does not match ' + \
@@ -636,14 +636,14 @@ class  EdfFile(object):
                     sizeToRead = self.Images[Index].Dim1 * \
                                  self.Images[Index].Dim2 * \
                                  self.Images[Index].Dim3 * datasize
-                    Data = numpy.fromstring(self.File.read(sizeToRead),
-                                datatype)
+                    Data = numpy.copy(numpy.frombuffer(self.File.read(sizeToRead),
+                                                       datatype))
                     Data = numpy.reshape(Data, (self.Images[Index].Dim3, self.Images[Index].Dim2, self.Images[Index].Dim1))
                 elif self.Images[Index].NumDim == 2:
                     sizeToRead = self.Images[Index].Dim1 * \
                                  self.Images[Index].Dim2 * datasize
-                    Data = numpy.fromstring(self.File.read(sizeToRead),
-                                datatype)
+                    Data = numpy.copy(numpy.frombuffer(self.File.read(sizeToRead),
+                                                       datatype))
                     #print "datatype = ",datatype
                     #print "Data.type = ", Data.dtype.char
                     #print "self.Images[Index].DataType ", self.Images[Index].DataType
@@ -654,8 +654,8 @@ class  EdfFile(object):
                     Data = numpy.reshape(Data, (self.Images[Index].Dim2, self.Images[Index].Dim1))
                 elif self.Images[Index].NumDim == 1:
                     sizeToRead = self.Images[Index].Dim1 * datasize
-                    Data = numpy.fromstring(self.File.read(sizeToRead),
-                                datatype)
+                    Data = numpy.copy(numpy.frombuffer(self.File.read(sizeToRead),
+                                                       datatype))
         elif self.ADSC or self.MARCCD or self.PILATUS_CBF or self.SPE:
             return self.__data[Pos[1]:(Pos[1] + Size[1]),
                                Pos[0]:(Pos[0] + Size[0])]
@@ -664,9 +664,9 @@ class  EdfFile(object):
             return data[Pos[1]:(Pos[1] + Size[1]),
                                Pos[0]:(Pos[0] + Size[0])]
         elif fastedf and CAN_USE_FASTEDF:
-            type = self.__GetDefaultNumpyType__(self.Images[Index].DataType, index=Index)
-            size_pixel = self.__GetSizeNumpyType__(type)
-            Data = numpy.array([], type)
+            type_ = self.__GetDefaultNumpyType__(self.Images[Index].DataType, index=Index)
+            size_pixel = self.__GetSizeNumpyType__(type_)
+            Data = numpy.array([], type_)
             if self.Images[Index].NumDim == 1:
                 if Pos == None: Pos = (0,)
                 if Size == None: Size = (0,)
@@ -674,7 +674,7 @@ class  EdfFile(object):
                 Size = list(Size)
                 if Size[0] == 0:Size[0] = sizex - Pos[0]
                 self.File.seek((Pos[0] * size_pixel) + self.Images[Index].DataPosition, 0)
-                Data = numpy.fromstring(self.File.read(Size[0] * size_pixel), type)
+                Data = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
             elif self.Images[Index].NumDim == 2:
                 if Pos == None: Pos = (0, 0)
                 if Size == None: Size = (0, 0)
@@ -682,7 +682,7 @@ class  EdfFile(object):
                 sizex, sizey = self.Images[Index].Dim1, self.Images[Index].Dim2
                 if Size[0] == 0:Size[0] = sizex - Pos[0]
                 if Size[1] == 0:Size[1] = sizey - Pos[1]
-                Data = numpy.zeros([Size[1], Size[0]], type)
+                Data = numpy.zeros([Size[1], Size[0]], type_)
                 self.File.seek((((Pos[1] * sizex) + Pos[0]) * size_pixel) + self.Images[Index].DataPosition, 0)
                 extended_fread(Data, Size[0] * size_pixel , numpy.array([Size[1]]),
                                numpy.array([sizex * size_pixel]) , self.File)
@@ -695,7 +695,7 @@ class  EdfFile(object):
                 if Size[0] == 0:Size[0] = sizex - Pos[0]
                 if Size[1] == 0:Size[1] = sizey - Pos[1]
                 if Size[2] == 0:Size[2] = sizez - Pos[2]
-                Data = numpy.zeros([Size[2], Size[1], Size[0]], type)
+                Data = numpy.zeros([Size[2], Size[1], Size[0]], type_)
                 self.File.seek(((((Pos[2] * sizey + Pos[1]) * sizex) + Pos[0]) * size_pixel) + self.Images[Index].DataPosition, 0)
                 extended_fread(Data, Size[0] * size_pixel , numpy.array([Size[2], Size[1]]),
                         numpy.array([ sizey * sizex * size_pixel , sizex * size_pixel]) , self.File)
@@ -703,9 +703,9 @@ class  EdfFile(object):
         else:
             if fastedf:
                 print("I could not use fast routines")
-            type = self.__GetDefaultNumpyType__(self.Images[Index].DataType, index=Index)
-            size_pixel = self.__GetSizeNumpyType__(type)
-            Data = numpy.array([], type)
+            type_ = self.__GetDefaultNumpyType__(self.Images[Index].DataType, index=Index)
+            size_pixel = self.__GetSizeNumpyType__(type_)
+            Data = numpy.array([], type_)
             if self.Images[Index].NumDim == 1:
                 if Pos == None: Pos = (0,)
                 if Size == None: Size = (0,)
@@ -713,7 +713,7 @@ class  EdfFile(object):
                 Size = list(Size)
                 if Size[0] == 0:Size[0] = sizex - Pos[0]
                 self.File.seek((Pos[0] * size_pixel) + self.Images[Index].DataPosition, 0)
-                Data = numpy.fromstring(self.File.read(Size[0] * size_pixel), type)
+                Data = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
             elif self.Images[Index].NumDim == 2:
                 if Pos == None: Pos = (0, 0)
                 if Size == None: Size = (0, 0)
@@ -723,11 +723,11 @@ class  EdfFile(object):
                 if Size[1] == 0:Size[1] = sizey - Pos[1]
                 #print len(range(Pos[1],Pos[1]+Size[1])), "LECTURES OF ", Size[0], "POINTS"
                 #print "sizex = ", sizex, "sizey = ", sizey
-                Data = numpy.zeros((Size[1], Size[0]), type)
+                Data = numpy.zeros((Size[1], Size[0]), type_)
                 dataindex = 0
                 for y in range(Pos[1], Pos[1] + Size[1]):
                     self.File.seek((((y * sizex) + Pos[0]) * size_pixel) + self.Images[Index].DataPosition, 0)
-                    line = numpy.fromstring(self.File.read(Size[0] * size_pixel), type)
+                    line = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
                     Data[dataindex, :] = line[:]
                     #Data=numpy.concatenate((Data,line))
                     dataindex += 1
@@ -745,7 +745,7 @@ class  EdfFile(object):
                 for z in range(Pos[2], Pos[2] + Size[2]):
                     for y in range(Pos[1], Pos[1] + Size[1]):
                         self.File.seek(((((z * sizey + y) * sizex) + Pos[0]) * size_pixel) + self.Images[Index].DataPosition, 0)
-                        line = numpy.fromstring(self.File.read(Size[0] * size_pixel), type)
+                        line = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
                         Data = numpy.concatenate((Data, line))
                 Data = numpy.reshape(Data, (Size[2], Size[1], Size[0]))
 
@@ -776,9 +776,10 @@ class  EdfFile(object):
                 size_img = size_row * self.Images[Index].Dim2
                 offset = offset + (Position[2] * size_img)
         self.File.seek(self.Images[Index].DataPosition + offset, 0)
-        Data = numpy.fromstring(self.File.read(size_pixel),
-                                self.__GetDefaultNumpyType__(self.Images[Index].DataType,
-                                                             index=Index))
+        Data = numpy.copy(numpy.frombuffer(
+                self.File.read(size_pixel),
+                self.__GetDefaultNumpyType__(self.Images[Index].DataType,
+                                             index=Index)))
         if self.SysByteOrder.upper() != self.Images[Index].ByteOrder.upper():
             Data = Data.byteswap()
         Data = self.__SetDataType__ (Data, "DoubleValue")

--- a/PyMca5/PyMcaIO/EdfFile.py
+++ b/PyMca5/PyMcaIO/EdfFile.py
@@ -443,7 +443,7 @@ class  EdfFile(object):
             self.Images[Index].DataType = 'UnsignedShort'
             try:
                 self.__data = numpy.reshape(
-                    numpy.copy(numpy.frombuffer(binary, numpy.uint16)),
+                    numpy.array(numpy.frombuffer(binary, numpy.uint16)),
                     (self.Images[Index].Dim2, self.Images[Index].Dim1))
             except ValueError:
                 raise IOError('Size spec in ADSC-header does not match ' + \
@@ -636,14 +636,14 @@ class  EdfFile(object):
                     sizeToRead = self.Images[Index].Dim1 * \
                                  self.Images[Index].Dim2 * \
                                  self.Images[Index].Dim3 * datasize
-                    Data = numpy.copy(numpy.frombuffer(self.File.read(sizeToRead),
-                                                       datatype))
+                    Data = numpy.array(numpy.frombuffer(self.File.read(sizeToRead),
+                                                        datatype))
                     Data = numpy.reshape(Data, (self.Images[Index].Dim3, self.Images[Index].Dim2, self.Images[Index].Dim1))
                 elif self.Images[Index].NumDim == 2:
                     sizeToRead = self.Images[Index].Dim1 * \
                                  self.Images[Index].Dim2 * datasize
-                    Data = numpy.copy(numpy.frombuffer(self.File.read(sizeToRead),
-                                                       datatype))
+                    Data = numpy.array(numpy.frombuffer(self.File.read(sizeToRead),
+                                                        datatype))
                     #print "datatype = ",datatype
                     #print "Data.type = ", Data.dtype.char
                     #print "self.Images[Index].DataType ", self.Images[Index].DataType
@@ -654,8 +654,8 @@ class  EdfFile(object):
                     Data = numpy.reshape(Data, (self.Images[Index].Dim2, self.Images[Index].Dim1))
                 elif self.Images[Index].NumDim == 1:
                     sizeToRead = self.Images[Index].Dim1 * datasize
-                    Data = numpy.copy(numpy.frombuffer(self.File.read(sizeToRead),
-                                                       datatype))
+                    Data = numpy.array(numpy.frombuffer(self.File.read(sizeToRead),
+                                                        datatype))
         elif self.ADSC or self.MARCCD or self.PILATUS_CBF or self.SPE:
             return self.__data[Pos[1]:(Pos[1] + Size[1]),
                                Pos[0]:(Pos[0] + Size[0])]
@@ -674,7 +674,7 @@ class  EdfFile(object):
                 Size = list(Size)
                 if Size[0] == 0:Size[0] = sizex - Pos[0]
                 self.File.seek((Pos[0] * size_pixel) + self.Images[Index].DataPosition, 0)
-                Data = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
+                Data = numpy.array(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
             elif self.Images[Index].NumDim == 2:
                 if Pos == None: Pos = (0, 0)
                 if Size == None: Size = (0, 0)
@@ -713,7 +713,7 @@ class  EdfFile(object):
                 Size = list(Size)
                 if Size[0] == 0:Size[0] = sizex - Pos[0]
                 self.File.seek((Pos[0] * size_pixel) + self.Images[Index].DataPosition, 0)
-                Data = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
+                Data = numpy.array(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
             elif self.Images[Index].NumDim == 2:
                 if Pos == None: Pos = (0, 0)
                 if Size == None: Size = (0, 0)
@@ -727,7 +727,7 @@ class  EdfFile(object):
                 dataindex = 0
                 for y in range(Pos[1], Pos[1] + Size[1]):
                     self.File.seek((((y * sizex) + Pos[0]) * size_pixel) + self.Images[Index].DataPosition, 0)
-                    line = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
+                    line = numpy.array(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
                     Data[dataindex, :] = line[:]
                     #Data=numpy.concatenate((Data,line))
                     dataindex += 1
@@ -745,7 +745,7 @@ class  EdfFile(object):
                 for z in range(Pos[2], Pos[2] + Size[2]):
                     for y in range(Pos[1], Pos[1] + Size[1]):
                         self.File.seek(((((z * sizey + y) * sizex) + Pos[0]) * size_pixel) + self.Images[Index].DataPosition, 0)
-                        line = numpy.copy(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
+                        line = numpy.array(numpy.frombuffer(self.File.read(Size[0] * size_pixel), type_))
                         Data = numpy.concatenate((Data, line))
                 Data = numpy.reshape(Data, (Size[2], Size[1], Size[0]))
 
@@ -776,7 +776,7 @@ class  EdfFile(object):
                 size_img = size_row * self.Images[Index].Dim2
                 offset = offset + (Position[2] * size_img)
         self.File.seek(self.Images[Index].DataPosition + offset, 0)
-        Data = numpy.copy(numpy.frombuffer(
+        Data = numpy.array(numpy.frombuffer(
                 self.File.read(size_pixel),
                 self.__GetDefaultNumpyType__(self.Images[Index].DataType,
                                              index=Index)))

--- a/PyMca5/PyMcaIO/MarCCD.py
+++ b/PyMca5/PyMcaIO/MarCCD.py
@@ -64,11 +64,11 @@ class MarCCD(object):
         depth  = info["depth"]
         fd.seek(4096)
         if depth == 1:
-            data = numpy.fromstring(fd.read(nbytes), numpy.uint8)
+            data = numpy.array(numpy.frombuffer(fd.read(nbytes), numpy.uint8))
         elif depth == 2:
-            data = numpy.fromstring(fd.read(nbytes), numpy.uint16)
+            data = numpy.array(numpy.frombuffer(fd.read(nbytes), numpy.uint16))
         elif depth == 4:
-            data = numpy.fromstring(fd.read(nbytes), numpy.uint32)
+            data = numpy.array(numpy.frombuffer(fd.read(nbytes), numpy.uint32))
         if swap:
             data = data.byteswap()
         data.shape = info["nfast"], info["nslow"]
@@ -155,7 +155,7 @@ class MccdHeader(object):
         if 0:
             self.__format = struct.unpack("256I", self.raw[0:256*4])
         else:
-            self.__format = numpy.fromstring(self.raw[0:256*4], numpy.uint32)
+            self.__format = numpy.array(numpy.frombuffer(self.raw[0:256*4], numpy.uint32))
 
     def __unpack_gonio(self):
         idx= 640

--- a/PyMca5/PyMcaIO/PilatusCBF.py
+++ b/PyMca5/PyMcaIO/PilatusCBF.py
@@ -173,24 +173,27 @@ class PilatusCBF(object):
 #                lns = len(stream)
                 idx = stream.find(key16)
                 if idx == -1:
-                    listnpa.append(np.fromstring(stream, dtype="int8"))
+                    listnpa.append(np.array(np.frombuffer(stream, dtype="int8")))
                     break
-                listnpa.append(np.fromstring(stream[:idx], dtype="int8"))
+                listnpa.append(np.array(np.frombuffer(stream[:idx], dtype="int8")))
 #                position += listnpa[-1].size
 
                 if stream[idx + 1:idx + 3] == key32:
                     if stream[idx + 3:idx + 7] == key64:
-                        listnpa.append(np.fromstring(stream[idx + 7:idx + 15], dtype="int64"))
+                        listnpa.append(np.array(np.frombuffer(stream[idx + 7:idx + 15],
+                                                              dtype="int64")))
 #                        position += 1
 #                        print "loop64 x=%4i y=%4i in idx %4i lns %4i value=%s" % ((position % 2463), (position // 2463), idx, lns, listnpa[-1])
                         shift = 15
                     else: #32 bit int
-                        listnpa.append(np.fromstring(stream[idx + 3:idx + 7], dtype="int32"))
+                        listnpa.append(np.array(np.frombuffer(stream[idx + 3:idx + 7],
+                                                              dtype="int32")))
 #                        position += 1
 #                        print "loop32 x=%4i y=%4i in idx %4i lns %4i value=%s" % ((position % 2463), (position // 2463), idx, lns, listnpa[-1])
                         shift = 7
                 else: #int16
-                    listnpa.append(np.fromstring(stream[idx + 1:idx + 3], dtype="int16"))
+                    listnpa.append(np.array(np.frombuffer(stream[idx + 1:idx + 3],
+                                                          dtype="int16")))
 #                    position += 1
 #                    print "loop16 x=%4i y=%4i in idx %4i lns %4i value=%s" % ((position % 2463), (position // 2463), idx, lns, listnpa[-1])
                     shift = 3

--- a/PyMca5/PyMcaIO/TiffIO.py
+++ b/PyMca5/PyMcaIO/TiffIO.py
@@ -672,9 +672,9 @@ class TiffIO(object):
             fd.seek(stripOffsets[0] + rowMin * bytesPerRow)
             nBytes = (rowMax-rowMin+1) * bytesPerRow
             if self._swap:
-                readout = numpy.fromstring(fd.read(nBytes), dtype).byteswap()
+                readout = numpy.array(numpy.frombuffer(fd.read(nBytes), dtype)).byteswap()
             else:
-                readout = numpy.fromstring(fd.read(nBytes), dtype)
+                readout = numpy.array(numpy.frombuffer(fd.read(nBytes), dtype))
             if hasattr(nBits, 'index'):
                 readout.shape = -1, nColumns, len(nBits)
             elif info['colormap'] is not None:
@@ -723,9 +723,9 @@ class TiffIO(object):
                             # if read -128 ignore the byte
                             continue
                     if self._swap:
-                        readout = numpy.fromstring(bufferBytes, dtype).byteswap()
+                        readout = numpy.array(numpy.frombuffer(bufferBytes, dtype)).byteswap()
                     else:
-                        readout = numpy.fromstring(bufferBytes, dtype)
+                        readout = numpy.array(numpy.frombuffer(bufferBytes, dtype))
                     if hasattr(nBits, 'index'):
                         readout.shape = -1, nColumns, len(nBits)
                     elif info['colormap'] is not None:
@@ -738,9 +738,9 @@ class TiffIO(object):
                     if 1:
                         # use numpy
                         if self._swap:
-                            readout = numpy.fromstring(fd.read(nBytes), dtype).byteswap()
+                            readout = numpy.array(numpy.frombuffer(fd.read(nBytes), dtype)).byteswap()
                         else:
-                            readout = numpy.fromstring(fd.read(nBytes), dtype)
+                            readout = numpy.array(numpy.frombuffer(fd.read(nBytes), dtype))
                         if hasattr(nBits, 'index'):
                             readout.shape = -1, nColumns, len(nBits)
                         elif colormap is not None:

--- a/PyMca5/PyMcaPlugins/SilxExternalImagesStackPlugin.py
+++ b/PyMca5/PyMcaPlugins/SilxExternalImagesStackPlugin.py
@@ -351,7 +351,7 @@ class SilxExternalImagesStackPlugin(StackPluginBase.StackPluginBase):
         width = qimage.width()
         height = qimage.height()
         if qimage.format() == qt.QImage.Format_Indexed8:
-            pixmap0 = numpy.fromstring(qimage.bits().asstring(width * height),
+            pixmap0 = numpy.frombuffer(qimage.bits().asstring(width * height),
                                        dtype=numpy.uint8)
             pixmap = numpy.zeros((height * width, 4), numpy.uint8)
             pixmap[:, 0] = pixmap0[:]
@@ -361,10 +361,11 @@ class SilxExternalImagesStackPlugin(StackPluginBase.StackPluginBase):
             pixmap.shape = height, width, 4
         else:
             qimage = qimage.convertToFormat(qt.QImage.Format_ARGB32)
-            pixmap = numpy.fromstring(qimage.bits().asstring(width * height * 4),
-                                      dtype=numpy.uint8)
+            pixmap0 = numpy.frombuffer(qimage.bits().asstring(width * height * 4),
+                                       dtype=numpy.uint8)
+            pixmap = numpy.array(pixmap0)  # copy
             pixmap.shape = height, width, -1
-            # Qt uses BGRA, convert to RGBA   # TODO: check this (qt doc says 0xAARRGGBB)
+            # Qt uses BGRA, convert to RGBA
             tmpBuffer = numpy.array(pixmap[:, :, 0], copy=True, dtype=pixmap.dtype)
             pixmap[:, :, 0] = pixmap[:, :, 2]
             pixmap[:, :, 2] = tmpBuffer


### PR DESCRIPTION
In numpy 1.14, `fromstring` prints a deprecation warning when it is given binary data to process.

This PR uses `numpy.frombuffer` instead. Both functions have the same API in our use case, but `frombuffer` does not copy the data and returns a read-only array, so we need an additional copy.

The `numpy.frombuffer` function is available since at least numpy version 1.3.