### PR TITLE
[save action] Restore original save method in McaAdvancedFit

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
@@ -1313,7 +1313,7 @@ class McaAdvancedFit(qt.QWidget):
         fileNamesDict = XRFMCHelper.getOutputFileNames(newFile,
                                                        outputDir=self.__tmpMatrixSpectrumDir)
         if newFile != fileNamesDict['fit']:
-            removeDirectory(self.__tmpMatrixSpectrumDir)
+            self.removeDirectory(self.__tmpMatrixSpectrumDir)
             raise ValueError("Inconsistent internal behaviour!")
 
         self._xrfmcFileNamesDict = fileNamesDict
@@ -2861,7 +2861,8 @@ class McaGraphWindow(PlotWindow):
                                              roi=True, aspectRatio=False,
                                              print_=False, colormap=False,
                                              yInverted=False, mask=False,
-                                             fit=False, **kw)
+                                             fit=False, save=False,
+                                             **kw)
         self.setDataMargins(0, 0, 0.025, 0.025)
         self.setPanWithArrowKeys(True)
 
@@ -2896,18 +2897,26 @@ class McaGraphWindow(PlotWindow):
         self.energyButton.setToolTip('Toggle Energy Axis (On/Off)')
         self.energyButton.clicked.connect(self._energyIconSignal)
 
+        self.saveButton = qt.QToolButton(self.toolBar())
+        self.saveButton.setIcon(qt.QIcon(qt.QPixmap(IconDict["filesave"])))
+        self.saveButton.setToolTip('Save plot snapshot or curves data')
+        self.saveButton.clicked.connect(self._saveIconSignal)
+
         self.fitAction = self.toolBar().insertWidget(self.getCopyAction(),
                                                      self.fitButton)
         self.energyAction = self.toolBar().insertWidget(self.getRoiAction(),
                                                         self.energyButton)
-        self.toolBar().addWidget(qt.HorizontalSpacer(self.toolBar()))
-        self.printAction = self.toolBar().addWidget(self.printPreviewTB)
+
+        self.saveAction = self.getOutputToolBar().addWidget(self.saveButton)
+        self.getOutputToolBar().addWidget(qt.HorizontalSpacer(self.toolBar()))
+        self.printAction = self.getOutputToolBar().addWidget(self.printPreviewTB)
 
         self.setGraphYLabel("Counts")
         if self.energyButton.isChecked():
             self.setGraphXLabel("Energy")
         else:
             self.setGraphXLabel("Channel")
+
 
     def _energyIconSignal(self):
         self.sigPlotSignal.emit(

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -193,10 +193,10 @@ class BaseScanWindow(PlotWindow):
         saveAction = self.getOutputToolBar().getSaveAction()
         # if silx-kit/silx#2013 is merged, the following line can be removed for silx 0.9
         saveAction.setFileFilter(dataKind='curve',  # single curve case
-                                 nameFilter='Curves as graphics (*.png *.eps *.png)',
+                                 nameFilter='Customized graphics (*.png *.eps *.png)',
                                  func=self._graphicsSave)
         saveAction.setFileFilter(dataKind='curves',
-                                 nameFilter='Curves as graphics (*.png *.eps *.png)',
+                                 nameFilter='Customized graphics (*.png *.eps *.png)',
                                  func=self._graphicsSave)
 
     def _customControlButtonMenu(self):

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -191,13 +191,15 @@ class BaseScanWindow(PlotWindow):
         self.matplotlibDialog = None
 
         saveAction = self.getOutputToolBar().getSaveAction()
-        # if silx-kit/silx#2013 is merged, the following line can be removed for silx 0.9
-        saveAction.setFileFilter(dataKind='curve',  # single curve case
-                                 nameFilter='Customized graphics (*.png *.eps *.png)',
-                                 func=self._graphicsSave)
-        saveAction.setFileFilter(dataKind='curves',
-                                 nameFilter='Customized graphics (*.png *.eps *.png)',
-                                 func=self._graphicsSave)
+        for ext in ["png", "eps", "svg"]:
+            name_filter = 'Customized graphics (*.%s)' % ext
+            # if silx-kit/silx#2013 is merged, the following line can be removed for silx 0.9
+            saveAction.setFileFilter(dataKind='curve',  # single curve case
+                                     nameFilter=name_filter,
+                                     func=self._graphicsSave)
+            saveAction.setFileFilter(dataKind='curves',
+                                     nameFilter=name_filter,
+                                     func=self._graphicsSave)
 
     def _customControlButtonMenu(self):
         """Display Options button sub-menu. Overloaded to add


### PR DESCRIPTION
This PR restores original save method in `McaAdvancedFit` instead of the using the silx save action. Closes #285.

It also renames the file filter in the `ScanWindow` save file dialog.

