### PR TITLE
Fix signature of weakref callback

### DIFF
--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -88,7 +88,7 @@ class PluginsToolButton(qt.QToolButton, PluginLoader):
 
         self.clicked.connect(self._pluginClicked)
 
-    def _ooPlotDestroyed(self, obj):
+    def _ooPlotDestroyed(self, obj=None):
         self.setEnabled(False)
 
     def __getattr__(self, attr):

--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -88,7 +88,7 @@ class PluginsToolButton(qt.QToolButton, PluginLoader):
 
         self.clicked.connect(self._pluginClicked)
 
-    def _ooPlotDestroyed(self):
+    def _ooPlotDestroyed(self, obj):
         self.setEnabled(False)
 
     def __getattr__(self, attr):


### PR DESCRIPTION
On object destruction, the callback is called with a param.