### PR TITLE
[GUI] conserve plot lines and colors in McaAdvancedFit

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
@@ -2046,10 +2046,7 @@ class McaAdvancedFit(qt.QWidget):
         self.plot()
 
     def plot(self, ddict=None):
-        if self.graph.isYAxisLogarithmic():
-            logfilter = 1
-        else:
-            logfilter = 0
+        self.graph.clearCurves()
         config = self.mcafit.configure()
         if ddict is None:
             if not self.__fitdone:


### PR DESCRIPTION
Closes  #283

All curves are replotted every time, so the easy way to fix this was to clear the plot before plotting again, which resets colors and style.