### PR TITLE
[GUI] Fix issue with resetzoom in ScanWindow

### DIFF
--- a/PyMca5/PyMcaGui/pymca/ScanFitToolButton.py
+++ b/PyMca5/PyMcaGui/pymca/ScanFitToolButton.py
@@ -146,11 +146,13 @@ class ScanFitToolButton(qt.QToolButton):
             xplot = self.scanFit.specfit.xdata * 1.0
             yplot = self.scanFit.specfit.gendata(parameters=ddict['data'])
 
-            self.plot.addCurve(x=xplot, y=yplot, legend=self._scanFitLegend)
+            self.plot.addCurve(x=xplot, y=yplot, legend=self._scanFitLegend,
+                               resetzoom=False)
 
     def _customFitSignalReceived(self, ddict):
         if ddict['event'] == "FitFinished":
             xplot = ddict['x']
             yplot = ddict['yfit']
 
-            self.plot.addCurve(xplot, yplot, legend=self._customFitLegend)
+            self.plot.addCurve(xplot, yplot, legend=self._customFitLegend,
+                               resetzoom=False)

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -418,7 +418,7 @@ class ScanWindow(BaseScanWindow):
                     newLegend = legend + " " + ylegend
                     self.dataObjectsDict[newLegend] = dataObject
                     self.addCurve(xdata, ydata, legend=newLegend, info=dataObject.info,
-                                  xlabel=xlabel, ylabel=ylabel)
+                                  xlabel=xlabel, ylabel=ylabel, resetzoom=False)
                     if self.scanWindowInfoWidget is not None:
                         if not self.infoDockWidget.isHidden():
                             activeLegend = self.getActiveCurve(just_legend=True)
@@ -513,7 +513,8 @@ class ScanWindow(BaseScanWindow):
                                   symbol=symbol,
                                   yaxis=yaxis,
                                   xlabel=xlabel,
-                                  ylabel=ylabel)
+                                  ylabel=ylabel,
+                                  resetzoom=False)
         try:
             if activeCurve is None and self._curveList:
                 self.setActiveCurve(self._curveList[0])


### PR DESCRIPTION
The resetzoom parameter in ScanWindow.addCurve was ignored.

This PR  closes #249, by not resetting the zoom in scan and MCA windows after a successful fit.