### PR TITLE
Provide signals to plugins

### DIFF
--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -488,7 +488,7 @@ class Plugin1DBase(object):
         print("applyMethod not implemented")
         return
 
-    def activeImageChanged(self, prev, new):
+    def activeCurveChanged(self, prev, new):
         """A plugin may implement this method which is called
         when the active curve changes in the plot.
 

--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -40,7 +40,7 @@ Plugins can be automatically installed provided they are in the appropriate plac
       or *${HOME}/PyMca5/plugins* (older PyMca installation)
     - In *"My Documents\\\\PyMca\\\\plugins"* (Windows)
 
-A plugin inherit the :class:`Plugin1DBase` class and implement the methods:
+Plugins inherit the :class:`Plugin1DBase` class and implement the methods:
 
     - :meth:`Plugin1DBase.getMethods`
     - :meth:`Plugin1DBase.getMethodToolTip` (optional but convenient)
@@ -49,6 +49,9 @@ A plugin inherit the :class:`Plugin1DBase` class and implement the methods:
 
 and modify the static module variable :const:`MENU_TEXT` and the static module function
 :func:`getPlugin1DInstance` according to the defined plugin.
+
+Optionally, plugins may also implement :meth:`Plugin1DBase.activeCurveChanged`
+to react to data selection in the plot.
 
 These plugins will be compatible with any 1D-plot window that implements the Plot1D
 interface. The plot window interface is described in the Plot1DBase class.
@@ -484,6 +487,17 @@ class Plugin1DBase(object):
         """
         print("applyMethod not implemented")
         return
+
+    def activeImageChanged(self, prev, new):
+        """A plugin may implement this method which is called
+        when the active curve changes in the plot.
+
+        :param prev: Legend of the previous active curve,
+            or None if no curve was active.
+        :param new: Legend of the new active curve,
+            or None if no curve is currently active.
+        """
+        pass
 
 
 MENU_TEXT = "Plugin1D Base"

--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -110,8 +110,18 @@ class PluginsToolButton(qt.QToolButton, PluginLoader):
                 # Can we just assume it has the proper signature?
                 self.plot.sigActiveImageChanged.connect(plugin.activeImageChanged)
 
+    def _disconnectPlotSignals(self):
+        for name, plugin in self.pluginInstanceDict.items():
+            if hasattr(plugin, "activeCurveChanged") and callable(plugin.activeCurveChanged):
+                # Can we just assume it has the proper signature?
+                self.plot.sigActiveCurveChanged.disconnect(plugin.activeCurveChanged)
+            if hasattr(plugin, "activeImageChanged") and callable(plugin.activeImageChanged):
+                # Can we just assume it has the proper signature?
+                self.plot.sigActiveImageChanged.disconnect(plugin.activeImageChanged)
+
     def getPlugins(self, method=None, directoryList=None, exceptions=False):
-        """method overloaded to update signal connections when reloading plugins"""
+        """method overloaded to update signal connections when loading plugins"""
+        self._disconnectPlotSignals()
         PluginLoader.getPlugins(self, method, directoryList, exceptions)
         self._connectPlotSignals()
 

--- a/PyMca5/PyMcaGui/PluginsToolButton.py
+++ b/PyMca5/PyMcaGui/PluginsToolButton.py
@@ -101,6 +101,20 @@ class PluginsToolButton(qt.QToolButton, PluginLoader):
             raise AttributeError(
                     self.plot.__class__.__name__ + " has no attribute " + attr)
 
+    def _connectPlotSignals(self):
+        for name, plugin in self.pluginInstanceDict.items():
+            if hasattr(plugin, "activeCurveChanged") and callable(plugin.activeCurveChanged):
+                # Can we just assume it has the proper signature?
+                self.plot.sigActiveCurveChanged.connect(plugin.activeCurveChanged)
+            if hasattr(plugin, "activeImageChanged") and callable(plugin.activeImageChanged):
+                # Can we just assume it has the proper signature?
+                self.plot.sigActiveImageChanged.connect(plugin.activeImageChanged)
+
+    def getPlugins(self, method=None, directoryList=None, exceptions=False):
+        """method overloaded to update signal connections when reloading plugins"""
+        PluginLoader.getPlugins(self, method, directoryList, exceptions)
+        self._connectPlotSignals()
+
     def _pluginClicked(self):
         actionNames = []
         menu = qt.QMenu(self)


### PR DESCRIPTION
If a plugin has a `activeCurveChanged(prev, next)` or a  `activeImageChanged(prev, next)` method, they should be connected with the corresponding plot signal.