### PR TITLE
Use PyMcaIcons insead of silx icons for some icons

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
@@ -78,6 +78,8 @@ Elements = ElementsInfo.Elements
 from PyMca5.PyMcaCore import PyMcaDirs
 from PyMca5.PyMcaIO import ConfigDict
 from PyMca5.PyMcaGui import CalculationThread
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
+
 _logger = logging.getLogger(__name__)
 
 _logger.debug("############################################\n"
@@ -2916,6 +2918,7 @@ class McaGraphWindow(PlotWindow):
         else:
             self.setGraphXLabel("Channel")
 
+        PyMca_Icons.change_icons(self)
 
     def _energyIconSignal(self):
         self.sigPlotSignal.emit(

--- a/PyMca5/PyMcaGui/plotting/PyMca_Icons.py
+++ b/PyMca5/PyMcaGui/plotting/PyMca_Icons.py
@@ -4177,7 +4177,20 @@ class _PatchedIconDict(MutableMapping):
             # we also need to remove the key from internal translation table
             del self._translation_table[key]
 
+
 IconDict = _PatchedIconDict(IconDict0)
+
+
+def change_icons(plot):
+    """Replace some of the silx icons with PyMca icons.
+
+    :param plot: Silx plot window, or ScanWindow, or McaWindow
+    :return:
+    """
+    from PyMca5.PyMcaGui import PyMcaQt as qt
+    plot.getRoiAction().setIcon(qt.QIcon(qt.QPixmap(IconDict["roi"])))
+    if hasattr(plot, "printPreview"):
+        plot.printPreview.setIcon(qt.QIcon(qt.QPixmap(IconDict["fileprint"])))
 
 
 def showIcons():

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -46,6 +46,7 @@ from PyMca5.PyMcaGui.pymca import ScanFit
 from PyMca5.PyMcaGui.pymca.ScanFitToolButton import ScanFitToolButton
 from PyMca5.PyMcaCore import DataObject
 from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave1D
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import change_icons
 
 if hasattr(qt, 'QString'):
     QString = qt.QString
@@ -200,6 +201,8 @@ class BaseScanWindow(PlotWindow):
             saveAction.setFileFilter(dataKind='curves',
                                      nameFilter=name_filter,
                                      func=self._graphicsSave)
+
+        change_icons(self)
 
     def _customControlButtonMenu(self):
         """Display Options button sub-menu. Overloaded to add


### PR DESCRIPTION
Possible solution for #280. The icon substitution can be done in a single function called by each plot window.