### PR TITLE
don't unselect curve in McaAdvancedFit when clicking in the plot

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
@@ -2936,7 +2936,9 @@ class McaGraphWindow(PlotWindow):
              'active': self.getActiveCurve(just_legend=True)})
 
     def setActiveCurve(self, legend, replot=None):
-        super(McaGraphWindow, self).setActiveCurve(legend, replot)
+        if legend is not None:
+            # see vasole/pymca#314
+            super(McaGraphWindow, self).setActiveCurve(legend, replot)
         self.setGraphYLabel("Counts")
         if self.energyButton.isChecked():
             self.setGraphXLabel("Energy")


### PR DESCRIPTION
Closes #314  by redefining `McaAdvancedFit.setActiveCurve`. 

