### PR TITLE
Allow again multiple processes with a single HDF5 input file.

### DIFF
--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -787,10 +787,9 @@ class McaBatchGUI(qt.QWidget):
                     allowSingleFileSplitProcesses = False
                     if HDF5SUPPORT:
                         if h5py.is_hdf5(self.fileList[0]):
-                            _logger.debug("Disallow single HDF5 process split")
-                            _logger.debug("due to problems with concurrent access")
-                            #allowSingleFileSplitProcesses = True
-                            allowSingleFileSplitProcesses = False
+                            _logger.info("Allowing single HDF5 file process split")
+                            _logger.info("In the past it was problematic")
+                            allowSingleFileSplitProcesses = True
                     if not allowSingleFileSplitProcesses:
                         text = "Multiple processes can only be used with multiple input files."
                         qt.QMessageBox.critical(self, "ERROR",text)

--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -221,8 +221,11 @@ class McaAdvancedFitBatch(object):
                 if h5py.is_hdf5(inputfile):
                     self._HDF5 = True
                     try:
+                        # if (len(self._filelist) == 1) && (self.mcaStep > 1)
+                        # it should attempt to avoid loading  many times
+                        # the stack into memory in case of multiple processes
                         return HDF5Stack1D.HDF5Stack1D(self._filelist,
-                                                      self.selection)
+                                                       self.selection)
                     except:
                         raise
             


### PR DESCRIPTION
The crashes due to concurrent access to the same file seem to be gone.

Just enabled the action and added a comment about the fact the stack can be loaded multiple times into memory.