### PR TITLE
Correct old default directory name

### DIFF
--- a/PyMca5/PyMcaCore/Plugin1DBase.py
+++ b/PyMca5/PyMcaCore/Plugin1DBase.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -37,7 +37,7 @@ perform user defined operations of the plotted 1D data.
 Plugins can be automatically installed provided they are in the appropriate place:
 
     - In the user home directory (POSIX systems): *${HOME}/.pymca/plugins* 
-      or *${HOME}/PyMca5/plugins* (older PyMca installation)
+      or *${HOME}/PyMca/plugins* (older PyMca installation)
     - In *"My Documents\\\\PyMca\\\\plugins"* (Windows)
 
 Plugins inherit the :class:`Plugin1DBase` class and implement the methods:

--- a/PyMca5/PyMcaCore/Plugin2DBase.py
+++ b/PyMca5/PyMcaCore/Plugin2DBase.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -33,7 +33,7 @@ perform user defined operations of the plotted 2D data.
 Plugins can be automatically installed provided they are in the appropriate place:
 
     - In the user home directory (POSIX systems): *${HOME}/.pymca/plugins*
-      or *${HOME}/PyMca5/plugins* (older PyMca installation)
+      or *${HOME}/PyMca/plugins* (older PyMca installation)
     - In *"My Documents\\\\PyMca\\\\plugins"* (Windows)
 
 A plugin inherits the :class:`Plugin2DBase` class and implements the methods:

--- a/PyMca5/PyMcaCore/StackPluginBase.py
+++ b/PyMca5/PyMcaCore/StackPluginBase.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -38,7 +38,7 @@ in order to perform user defined operations on the data stack.
 Plugins can be automatically installed provided they are in the appropriate place:
 
     - In the user home directory (POSIX systems): *${HOME}/.pymca/plugins* 
-      or *${HOME}/PyMca5/plugins* (older PyMca installation)
+      or *${HOME}/PyMca/plugins* (older PyMca installation)
     - In *"My Documents\\\\PyMca\\\\plugins"* (Windows)
 
 It has to inherit the :class:`StackPluginBase` class and implement the following methods:


### PR DESCRIPTION
It was named PyMca and not PyMca5