### PR TITLE
Resolve issue #418

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
@@ -91,7 +91,7 @@ class FastXRFLinearFitWindow(qt.QWidget):
         outnameLabel.setText("Output name:")
         self._outnameLabel = outnameLabel
         self._outnameLine = qt.QLineEdit(self)
-        self._outnameLine.setText("")
+        self._outnameLine.setText("fast_xrf_fit")
 
         # fit options
         boxLabel1 = qt.QLabel(self)
@@ -147,7 +147,7 @@ class FastXRFLinearFitWindow(qt.QWidget):
         # generate edf file
         self._edfBox = qt.QCheckBox(self._boxContainer2)
         self._edfBox.setText("EDF")
-        self._edfBox.setChecked(not hasH5py)
+        self._edfBox.setChecked(True)
         self._edfBox.setEnabled(True)
         
         # generate hdf5 file

--- a/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
@@ -35,6 +35,11 @@ from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from PyMca5.PyMcaGui import PyMcaFileDialogs
+try:
+    import h5py
+    hasH5py = True
+except ImportError:
+    hasH5py = False
 
 
 class FastXRFLinearFitWindow(qt.QWidget):
@@ -114,7 +119,7 @@ class FastXRFLinearFitWindow(qt.QWidget):
         self._diagnosticsBox = qt.QCheckBox(self._boxContainer1)
         self._diagnosticsBox.setText("calculate diagnostics")
         self._diagnosticsBox.setChecked(False)
-        self._diagnosticsBox.setEnabled(True)
+        self._diagnosticsBox.setEnabled(hasH5py)
 
         # repeat fit on negative contributions
         self._fitAgainBox = qt.QCheckBox(self._boxContainer1)
@@ -142,16 +147,16 @@ class FastXRFLinearFitWindow(qt.QWidget):
         # generate edf file
         self._edfBox = qt.QCheckBox(self._boxContainer2)
         self._edfBox.setText("EDF")
-        self._edfBox.setChecked(False)
+        self._edfBox.setChecked(not hasH5py)
         self._edfBox.setEnabled(True)
         
         # generate hdf5 file
         self._h5Box = qt.QCheckBox(self._boxContainer2)
         self._h5Box.setText("HDF5")
-        self._h5Box.setChecked(True)
-        self._h5Box.setEnabled(True)
-        self.toggleH5(True)
+        self._h5Box.setChecked(hasH5py)
+        self._h5Box.setEnabled(hasH5py)
         self._h5Box.stateChanged.connect(self.toggleH5)
+        self.toggleH5(hasH5py)
 
         # overwrite output
         self._overwriteBox = qt.QCheckBox(self._boxContainer2)

--- a/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
@@ -240,14 +240,15 @@ class FastXRFLinearFitWindow(qt.QWidget):
             self._outdirLine.setText(f)
 
     def toggleH5(self, state):
-        readonly = not state
-        self._outnameLine.setReadOnly(readonly)
-        self._outnameLine.setEnabled(not readonly)
-        self._outnameLabel.setEnabled(not readonly)
-        if readonly:
-            self._outnameLine.setStyleSheet("color: gray; background-color: darkGray")
-        else:
+        h5Out = bool(state)
+        self._outnameLine.setReadOnly(not h5Out)
+        self._outnameLine.setEnabled(h5Out)
+        self._outnameLabel.setEnabled(h5Out)
+        self._diagnosticsBox.setEnabled(h5Out)
+        if h5Out:
             self._outnameLine.setStyleSheet("")
+        else:
+            self._outnameLine.setStyleSheet("color: gray; background-color: darkGray")
 
     def getParameters(self):
         ddict = {}

--- a/PyMca5/PyMcaPhysics/xrf/FastXRFLinearFitOutput.py
+++ b/PyMca5/PyMcaPhysics/xrf/FastXRFLinearFitOutput.py
@@ -126,7 +126,7 @@ class OutputBuffer(object):
         if value:
             self._fileProcess = value
         else:
-            self._fileProcess = self.fileEntry
+            self._fileProcess = 'fast_xrf_fit'
 
     @property
     def edf(self):

--- a/PyMca5/tests/__init__.py
+++ b/PyMca5/tests/__init__.py
@@ -32,12 +32,6 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import os
 
-if os.path.exists('PyMca5'):
-    if os.path.exists('setup.py'):
-        if os.path.exists('py2app_setup.py'):
-            txt = 'Tests cannot be imported from top source directory'
-            raise ImportError(txt)
-
 from PyMca5.tests.TestAll import main as testAll
 from PyMca5.tests.ConfigDictTest import test as testConfigDict
 from PyMca5.tests.EdfFileTest import test as testEdfFile


### PR DESCRIPTION
Disable HDF5 output options when h5py is missing:
![fastfitdialog](https://user-images.githubusercontent.com/7264703/52349396-c4c6d680-2a26-11e9-9d2f-0e28bd418316.png)

However the dependency of the main GUI on silx enforces h5py:

```python
  File "/mntdirect/_data_id21_inhouse/wout/dev/pymca/build/lib.linux-x86_64-2.7/PyMca5/PyMcaGui/pymca/PyMcaMain.py", line 233, in <module>
    from PyMca5.PyMcaGui.pymca import ScanWindow
  File "/data/id21/inhouse/wout/dev/pymca/build/lib.linux-x86_64-2.7/PyMca5/PyMcaGui/pymca/ScanWindow.py", line 39, in <module>
    from silx.gui.plot import PlotWindow
  File "/mntdirect/_data_id21_inhouse/wout/dev/virtualenvs/rnice8/pymca/py27/local/lib/python2.7/site-packages/silx/gui/plot/__init__.py", line 64, in <module>
    from .PlotWindow import PlotWindow, Plot1D, Plot2D  # noqa
  File "/mntdirect/_data_id21_inhouse/wout/dev/virtualenvs/rnice8/pymca/py27/local/lib/python2.7/site-packages/silx/gui/plot/PlotWindow.py", line 43, in <module>
    from . import actions
  File "/mntdirect/_data_id21_inhouse/wout/dev/virtualenvs/rnice8/pymca/py27/local/lib/python2.7/site-packages/silx/gui/plot/actions/__init__.py", line 42, in <module>
    from . import io
  File "/mntdirect/_data_id21_inhouse/wout/dev/virtualenvs/rnice8/pymca/py27/local/lib/python2.7/site-packages/silx/gui/plot/actions/io.py", line 44, in <module>
    from silx.io.nxdata import save_NXdata
  File "/mntdirect/_data_id21_inhouse/wout/dev/virtualenvs/rnice8/pymca/py27/local/lib/python2.7/site-packages/silx/io/nxdata/__init__.py", line 64, in <module>
    from .write import save_NXdata
  File "/mntdirect/_data_id21_inhouse/wout/dev/virtualenvs/rnice8/pymca/py27/local/lib/python2.7/site-packages/silx/io/nxdata/write.py", line 26, in <module>
    import h5py
ImportError: No module named h5py