### PR TITLE
Hdf5 string

### DIFF
--- a/PyMca5/PyMcaIO/NexusUtils.py
+++ b/PyMca5/PyMcaIO/NexusUtils.py
@@ -67,7 +67,7 @@ def asNxChar(s, raiseExtended=True):
         # dtype=nxcharUnicode will not attempt decoding bytes
         # so readers will get UnicodeDecodeError when bytes
         # are extended ASCII encoded. So do this instead:
-        arr = numpy.array(s, dtype=unicode)
+        numpy.array(s, dtype=unicode)
     except UnicodeDecodeError:
         # Reason: byte-string with extended ASCII encoding (e.g. Latin-1)
         # Solution: save as byte-string or raise exception
@@ -78,7 +78,7 @@ def asNxChar(s, raiseExtended=True):
             raise
         return numpy.array(s, dtype=nxcharBytes)
     else:
-        return arr.astype(nxcharUnicode)
+        return numpy.array(s, dtype=nxcharUnicode)
 
 
 PROGRAM_NAME = asNxChar('pymca')

--- a/PyMca5/tests/NexusUtilsTest.py
+++ b/PyMca5/tests/NexusUtilsTest.py
@@ -198,6 +198,8 @@ class testNexusUtils(unittest.TestCase):
         sLatinUnicode = u'\xe423'  # not used
         sUTF8Unicode = u'\u0101bc'
         sUTF8Bytes = b'\xc4\x81bc'
+        sUTF8AsciiUnicode = u'abc'
+        sUTF8AsciiBytes = b'abc'
         # Expected conversion after HDF5 write/read
         strmap = {}
         strmap['ascii(scalar)'] = sAsciiBytes,\
@@ -206,28 +208,38 @@ class testNexusUtils(unittest.TestCase):
                                 sLatinBytes
         strmap['unicode(scalar)'] = sUTF8Unicode,\
                                     sUTF8Unicode
+        strmap['unicode2(scalar)'] = sUTF8AsciiUnicode,\
+                                     sUTF8AsciiUnicode
         strmap['ascii(list)'] = [sAsciiBytes, sAsciiBytes],\
                                 [sAsciiUnicode, sAsciiUnicode]
         strmap['ext(list)'] = [sLatinBytes, sLatinBytes],\
                               [sLatinBytes, sLatinBytes]
         strmap['unicode(list)'] = [sUTF8Unicode, sUTF8Unicode],\
                                   [sUTF8Unicode, sUTF8Unicode]
-        strmap['mixed(list)'] = [sUTF8Unicode, sAsciiBytes, sLatinBytes],\
-                                [sUTF8Bytes, sAsciiBytes, sLatinBytes]
+        strmap['unicode2(list)'] = [sUTF8AsciiUnicode, sUTF8AsciiUnicode],\
+                                   [sUTF8AsciiUnicode, sUTF8AsciiUnicode]
+        strmap['mixed(list)'] = [sUTF8Unicode, sUTF8AsciiUnicode, sAsciiBytes, sLatinBytes],\
+                                [sUTF8Bytes, sUTF8AsciiBytes, sAsciiBytes, sLatinBytes]
         strmap['ascii(0d-array)'] = numpy.array(sAsciiBytes),\
                                     sAsciiUnicode
         strmap['ext(0d-array)'] = numpy.array(sLatinBytes),\
                                   sLatinBytes
         strmap['unicode(0d-array)'] = numpy.array(sUTF8Unicode),\
                                       sUTF8Unicode
+        strmap['unicode2(0d-array)'] = numpy.array(sUTF8AsciiUnicode),\
+                                       sUTF8AsciiUnicode
         strmap['ascii(1d-array)'] = numpy.array([sAsciiBytes, sAsciiBytes]),\
                                     [sAsciiUnicode, sAsciiUnicode]
         strmap['ext(1d-array)'] = numpy.array([sLatinBytes, sLatinBytes]),\
                                   [sLatinBytes, sLatinBytes]
         strmap['unicode(1d-array)'] = numpy.array([sUTF8Unicode, sUTF8Unicode]),\
                                       [sUTF8Unicode, sUTF8Unicode]
-        strmap['mixed(1d-array)'] = numpy.array([sUTF8Unicode, sAsciiBytes]),\
-                                    [sUTF8Unicode, sAsciiUnicode]
+        strmap['unicode2(1d-array)'] = numpy.array([sUTF8AsciiUnicode, sUTF8AsciiUnicode]),\
+                                       [sUTF8AsciiUnicode, sUTF8AsciiUnicode]
+        strmap['mixed(1d-array)'] = numpy.array([sUTF8Unicode, sUTF8AsciiUnicode, sAsciiBytes]),\
+                                    [sUTF8Unicode, sUTF8AsciiUnicode, sAsciiUnicode]
+        strmap['mixed2(1d-array)'] = numpy.array([sUTF8AsciiUnicode, sAsciiBytes]),\
+                                    [sUTF8AsciiUnicode, sAsciiUnicode]
             
         with self.h5open('testNxString{:d}'.format(attribute)) as h5group:
             h5group = h5group.create_group('test')

--- a/PyMca5/tests/NexusUtilsTest.py
+++ b/PyMca5/tests/NexusUtilsTest.py
@@ -177,14 +177,24 @@ class testNexusUtils(unittest.TestCase):
     @unittest.skipIf(NexusUtils is None,
                      'PyMca5.PyMcaIO.NexusUtils cannot be imported')
     def testNxStringAttribute(self):
-        self._checkStringTypes(attribute=True)
+        self._checkStringTypes(attribute=True, raiseExtended=True)
 
     @unittest.skipIf(NexusUtils is None,
                      'PyMca5.PyMcaIO.NexusUtils cannot be imported')
     def testNxStringDataset(self):
-        self._checkStringTypes(attribute=False)
+        self._checkStringTypes(attribute=False, raiseExtended=True)
 
-    def _checkStringTypes(self, attribute=True):
+    @unittest.skipIf(NexusUtils is None,
+                     'PyMca5.PyMcaIO.NexusUtils cannot be imported')
+    def testNxExtStringAttribute(self):
+        self._checkStringTypes(attribute=True, raiseExtended=False)
+
+    @unittest.skipIf(NexusUtils is None,
+                     'PyMca5.PyMcaIO.NexusUtils cannot be imported')
+    def testNxExtStringDataset(self):
+        self._checkStringTypes(attribute=False, raiseExtended=False)
+
+    def _checkStringTypes(self, attribute=True, raiseExtended=True):
         # Test following string literals
         sAsciiBytes = b'abc'
         sAsciiUnicode = u'abc'
@@ -230,8 +240,17 @@ class testNexusUtils(unittest.TestCase):
             else:
                 out = h5group
             for name, (value, expectedValue) in strmap.items():
+                decodingError = 'ext' in name or name == 'mixed(list)'
+                if raiseExtended and decodingError:
+                    with self.assertRaises(UnicodeDecodeError):
+                        ovalue = NexusUtils.asNxChar(value,
+                            raiseExtended=raiseExtended)
+                    continue
+                else:
+                    ovalue = NexusUtils.asNxChar(value,
+                        raiseExtended=raiseExtended)
                 # Write/read
-                out[name] = NexusUtils.asNxChar(value)
+                out[name] = ovalue
                 if attribute:
                     value = out[name]
                 else:
@@ -270,6 +289,8 @@ def getSuite(auto=True):
         # use a predefined order
         testSuite.addTest(testNexusUtils('testNxStringAttribute'))
         testSuite.addTest(testNexusUtils('testNxStringDataset'))
+        testSuite.addTest(testNexusUtils('testNxExtStringAttribute'))
+        testSuite.addTest(testNexusUtils('testNxExtStringDataset'))
         testSuite.addTest(testNexusUtils('testNxRoot'))
         testSuite.addTest(testNexusUtils('testNxEntry'))
         testSuite.addTest(testNexusUtils('testNxProcess'))

--- a/PyMca5/tests/NexusUtilsTest.py
+++ b/PyMca5/tests/NexusUtilsTest.py
@@ -50,10 +50,6 @@ try:
     from PyMca5.PyMcaIO import ConfigDict
 except ImportError:
     ConfigDict = None
-try:
-    unicode
-except NameError:
-    unicode = str
 
 
 class testNexusUtils(unittest.TestCase):


### PR DESCRIPTION
Function asNxChar to create variable-length UTF-8 string:
 - handles scalars and arrays
 - handles ASCII byte-strings, extended ASCII byte-strings, unicode-strings, fixed-length numpy strings
 - checks UTF-8 encoding (wasn't doing that before with custom dtype)
 - extended ASCII bytes: either raise UnicodeDecodeError (default) or save as bytes (abuse HDF5 ASCII character set)
 - behaves the same in python 2 and 3 (see tests)

Note: numpy 0d-array is saved as an HDF5 scalar.