### PR TITLE
Add silx backend as proof of concept

### DIFF
--- a/PyMca5/PyMcaGraph/Plot.py
+++ b/PyMca5/PyMcaGraph/Plot.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2015 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -142,6 +142,8 @@ class Plot(PlotBase.PlotBase):
                 from .backends.GLUTOpenGLBackend import GLUTOpenGLBackend as be
             elif lowerCaseString in ["osmesa", "mesa"]:
                 from .backends.OSMesaGLBackend import OSMesaGLBackend as be
+            elif lowerCaseString in ["silx"]:
+                from .backends.SilxBackend import SilxBackend as be
             else:
                 raise ValueError("Backend not understood %s" % backend)
             self._plot = be(parent)

--- a/PyMca5/PyMcaGraph/Plot.py
+++ b/PyMca5/PyMcaGraph/Plot.py
@@ -142,9 +142,8 @@ class Plot(PlotBase.PlotBase):
                 from .backends.GLUTOpenGLBackend import GLUTOpenGLBackend as be
             elif lowerCaseString in ["osmesa", "mesa"]:
                 from .backends.OSMesaGLBackend import OSMesaGLBackend as be
-            elif lowerCaseString in ["silx-gl", "silxgl"]:
-                from .backends.SilxBackend import SilxBackend as be
-            elif lowerCaseString in ["silx"]:
+            elif lowerCaseString in ["silx", "silx-mpl", "silxmpl",
+                                     "silx-gl", "silxgl"]:
                 from .backends.SilxBackend import SilxBackend as be
             else:
                 raise ValueError("Backend not understood %s" % backend)

--- a/PyMca5/PyMcaGraph/Plot.py
+++ b/PyMca5/PyMcaGraph/Plot.py
@@ -142,11 +142,18 @@ class Plot(PlotBase.PlotBase):
                 from .backends.GLUTOpenGLBackend import GLUTOpenGLBackend as be
             elif lowerCaseString in ["osmesa", "mesa"]:
                 from .backends.OSMesaGLBackend import OSMesaGLBackend as be
+            elif lowerCaseString in ["silx-gl", "silxgl"]:
+                from .backends.SilxBackend import SilxBackend as be
             elif lowerCaseString in ["silx"]:
                 from .backends.SilxBackend import SilxBackend as be
             else:
                 raise ValueError("Backend not understood %s" % backend)
-            self._plot = be(parent)
+            if lowerCaseString in ["silx-gl", "silxgl"]:
+                self._plot = be(parent, backend="gl")
+            elif lowerCaseString in ["silx-mpl", "silxmpl"]:
+                self._plot = be(parent, backend="mpl")
+            else:
+                self._plot = be(parent)
         super(Plot, self).__init__()
         widget = self._plot.getWidgetHandle()
         if widget is None:

--- a/PyMca5/PyMcaGraph/backends/SilxBackend.py
+++ b/PyMca5/PyMcaGraph/backends/SilxBackend.py
@@ -41,6 +41,7 @@ class SilxBackend(PlotWidget):
     def __init__(self, *var, **kw):
         PlotWidget.__init__(self, *var, **kw)
         # No context menu by default, execute zoomBack on right click
+        print("CALLED!!!!!!!!!")
         plotArea = self.getWidgetHandle()
         plotArea.setContextMenuPolicy(qt.Qt.CustomContextMenu)
         plotArea.customContextMenuRequested.connect(self._zoomBack)

--- a/PyMca5/PyMcaGraph/backends/SilxBackend.py
+++ b/PyMca5/PyMcaGraph/backends/SilxBackend.py
@@ -1,0 +1,173 @@
+#/*##########################################################################
+#
+# The PyMca X-Ray Fluorescence Toolkit
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+__author__ = "V.A. Sole - ESRF Data Analysis"
+__contact__ = "sole@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__doc__ = """
+Silx Plot Backend.
+"""
+
+from silx.gui import qt
+from silx.gui.plot import PlotWidget
+
+class SilxBackend(PlotWidget):
+    def __init__(self, *var, **kw):
+        PlotWidget.__init__(self, *var, **kw)
+        # No context menu by default, execute zoomBack on right click
+        plotArea = self.getWidgetHandle()
+        plotArea.setContextMenuPolicy(qt.Qt.CustomContextMenu)
+        plotArea.customContextMenuRequested.connect(self._zoomBack)
+
+    def _zoomBack(self, pos):
+        self.getLimitsHistory().pop()
+
+    def addCurve(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.addCurve(self, *var, **kw)
+
+    def addImage(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        if "xScale" in kw:
+            xScale = kw["xScale"]
+            del kw["xScale"]
+        if "yScale" in kw:
+            yScale = kw["yScale"]
+            del kw["yScale"]
+        if xScale is not None or yScale is not None:
+            origin = kw.get("origin", None)
+            scale = kw.get("scale", None)
+            if origin is None and scale is None:
+                kw["origin"] = xScale[0], yScale[0]
+                kw["scale"] = xScale[1], yScale[1]
+        return PlotWidget.addImage(self, *var, **kw)
+
+    def setActiveCurve(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.setActiveCurve(self, *var, **kw)
+
+    def setActiveImage(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.setActiveImage(self, *var, **kw)
+
+    def insertXMarker(self, *var, **kw):
+        return self.addXMarker(*var, **kw)
+
+    def insertYMarker(self, *var, **kw):
+        return self.addYMarker(*var, **kw)
+
+    def insertMarker(self, *var, **kw):
+        return self.addMarker(*var, **kw)
+
+    def removeCurve(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.removeCurve(self, *var, **kw)
+
+    def isActiveCurveHandlingEnabled(self):
+        return self.isActiveCurveHandling()
+
+    def enableActiveCurveHandling(self, *args, **kwargs):
+        return self.setActiveCurveHandling(*args, **kwargs)
+
+    def invertYAxis(self, *args, **kwargs):
+        return self.getYAxis().setInverted(*args, **kwargs)
+
+    def showGrid(self, flag=True):
+        if flag in (0, False):
+            flag = None
+        elif flag in (1, True):
+            flag = 'major'
+        else:
+            flag = 'both'
+        return self.setGraphGrid(flag)
+
+    def keepDataAspectRatio(self, *args, **kwargs):
+        return self.setKeepDataAspectRatio(*args, **kwargs)
+
+    def hideCurve(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.hideCurve(self, *var, **kw)
+
+    def setGraphXLimits(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.setGraphXLimits(self, *var, **kw)
+
+    def setGraphYLimits(self, *var, **kw):
+        if "replot" in kw:
+            del kw["replot"]
+        return PlotWidget.setGraphYLimits(self, *var, **kw)
+
+    def isDrawModeEnabled(self):
+        return self.getInteractiveMode()['mode'] == 'draw'
+
+
+    def setDrawModeEnabled(self, flag=True, shape='polygon', label=None,
+                           color=None, **kwargs):
+        if color is None:
+            color = 'black'
+
+        if flag:
+            self.setInteractiveMode('draw', shape=shape,
+                                    label=label, color=color)
+        elif self.getInteractiveMode()['mode'] == 'draw':
+            self.setInteractiveMode('select')
+
+    def getDrawMode(self):
+        mode = self.getInteractiveMode()
+        return mode if mode['mode'] == 'draw' else None
+
+    def isZoomModeEnabled(self):
+        return self.getInteractiveMode()['mode'] == 'zoom'
+
+    def setZoomModeEnabled(self, flag=True, color=None):
+        if color is None:
+            color = 'black'
+        if flag:
+            self.setInteractiveMode('zoom', color=color)
+        elif self.getInteractiveMode()['mode'] == 'zoom':
+            self.setInteractiveMode('select')
+
+if __name__ == "__main__":
+    def callback(ddict):
+        print("RECEIVED = ", ddict)
+    from silx.gui import qt
+    app = qt.QApplication([])
+    w = SilxBackend()
+    w.setCallback(callback)
+    w.addCurve([1, 2, 3], [4, 5, 6], legend="My Curve")
+    w.insertXMarker(1.5, draggable=True)
+    w.show()
+    app.exec_()

--- a/PyMca5/PyMcaGraph/backends/SilxBackend.py
+++ b/PyMca5/PyMcaGraph/backends/SilxBackend.py
@@ -160,6 +160,9 @@ class SilxBackend(PlotWidget):
         elif self.getInteractiveMode()['mode'] == 'zoom':
             self.setInteractiveMode('select')
 
+    def setActiveCurveColor(self, *var, **kw):
+        return PlotWidget.setActiveCurveStyle(self, *var, **kw)
+
 if __name__ == "__main__":
     def callback(ddict):
         print("RECEIVED = ", ddict)

--- a/PyMca5/PyMcaGui/plotting/PlotWidget.py
+++ b/PyMca5/PyMcaGui/plotting/PlotWidget.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2018 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2019 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -93,7 +93,7 @@ class PlotWidget(QtGui.QMainWindow, Plot.Plot):
                          legends=False, callback=None, **kw):
         self._panWithArrowKeys = False
         QtGui.QMainWindow.__init__(self, parent)
-        Plot.Plot.__init__(self, parent, backend=backend)
+        Plot.Plot.__init__(self, parent=self, backend=backend)
         if parent is not None:
             # behave as a widget
             self.setWindowFlags(QtCore.Qt.Widget)
@@ -321,6 +321,10 @@ if __name__ == "__main__":
     if ("matplotlib" in sys.argv) or ("mpl" in sys.argv):
         backend = "matplotlib"
         print("USING matplotlib")
+        time.sleep(1)
+    elif ("silx" in sys.argv):
+        backend = "silx"
+        print("USING silx")
         time.sleep(1)
     elif ("pyqtgraph" in sys.argv):
         backend = "pyqtgraph"

--- a/PyMca5/PyMcaGui/plotting/PlotWindow.py
+++ b/PyMca5/PyMcaGui/plotting/PlotWindow.py
@@ -1642,6 +1642,10 @@ if __name__ == "__main__":
         backend = "opengl"
     elif "pyqtgraph" in sys.argv:
         backend = "pyqtgraph"
+    elif "silx" in sys.argv:
+        backend = "silx"
+    else:
+        backend = "matplotlib"
     plot = PlotWindow(backend=backend, roi=True, control=True,
                           position=True, colormap=True)#uselegendmenu=True)
     plot.setPanWithArrowKeys(True)


### PR DESCRIPTION
This shows an alternative way to use silx within PyMca.

It works, but it seems more efficient to directly use the silx PlotWidget replacing the PlotWidget of PyMca. 