### PR TITLE
OmnicMap IO: remove windows check for binary file reading

### DIFF
--- a/PyMca5/PyMcaIO/OmnicMap.py
+++ b/PyMca5/PyMcaIO/OmnicMap.py
@@ -62,10 +62,7 @@ class OmnicMap(DataObject.DataObject):
             It is expected to work with OMNIC versions 7.x and 8.x
         '''
         DataObject.DataObject.__init__(self)
-        if sys.platform == 'win32':
-            fid = open(filename, 'rb')
-        else:
-            fid = open(filename, 'r')
+        fid = open(filename, 'rb')
         data = fid.read()
         fid.close()
 


### PR DESCRIPTION
Resolves #447 

Note: I do not have access to a Windows or Mac system to test this change, but the code logic has not changed for Windows, so that case should be fine. The only thing that should probably be tested is MacOS (`darwin`). 