### PR TITLE
[GUI] Crash on exit when using PyQt5

### DIFF
--- a/PyMca5/PyMcaGraph/Plot.py
+++ b/PyMca5/PyMcaGraph/Plot.py
@@ -108,11 +108,7 @@ _COLORLIST = [_COLORDICT['black'],
 #"" 	nothing
 #
 
-try:
-    from .backends.MatplotlibBackend import MatplotlibBackend
-    DEFAULT_BACKEND = "matplotlib"
-except:
-    DEFAULT_BACKEND = PlotBackend.PlotBackend
+DEFAULT_BACKEND = "matplotlib"
 
 class Plot(PlotBase.PlotBase):
     PLUGINS_DIR = None

--- a/PyMca5/PyMcaGraph/Plot.py
+++ b/PyMca5/PyMcaGraph/Plot.py
@@ -126,7 +126,7 @@ class Plot(PlotBase.PlotBase):
     def __init__(self, parent=None, backend=None, callback=None):
         self._parent = parent
         if backend is None:
-            backend = self.defaultBackend
+            backend = Plot.defaultBackend
             self._default = True
         else:
             self._default = False

--- a/PyMca5/PyMcaGraph/backends/MatplotlibBackend.py
+++ b/PyMca5/PyMcaGraph/backends/MatplotlibBackend.py
@@ -101,6 +101,8 @@ if ("PyQt4.QtCore" in sys.modules) or ("PySide.QtCore" in sys.modules):
     TK = False
     QT = True
 elif ("PyQt5.QtCore" in sys.modules) or ("PySide2.QtCore" in sys.modules):
+    from ._patch_matplotlib import patch_backend_qt
+    patch_backend_qt()
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
     TK = False
     QT = True

--- a/PyMca5/PyMcaGraph/backends/_patch_matplotlib.py
+++ b/PyMca5/PyMcaGraph/backends/_patch_matplotlib.py
@@ -1,0 +1,61 @@
+#/*##########################################################################
+#
+# The PyMca X-Ray Fluorescence Toolkit
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF by the Software group.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+__author__ = "V.A. Sole - ESRF Data Analysis"
+__contact__ = "sole@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+
+import sys
+import weakref
+
+if 'PyQt5.QtCore' in sys.modules:
+    from PyQt5 import QtCore
+    from PyQt5.QtWidgets import QApplication
+elif 'PySide2.QtCore' in sys.modules:
+    from PySide2 import QtCore
+    from PySide2.QtWidgets import QApplication
+else:
+    raise ImportError("This module expects PySide2 or PyQt5")
+
+def patch_backend_qt():
+    import matplotlib.backends.backend_qt5
+    def _create_qApp():
+        if QApplication.instance() is None:
+            raise ValueError("A QApplication must be created before")
+        try:
+            QApplication.instance().setAttribute(\
+                        QtCore.Qt.AA_UseHighDpiPixmaps)
+            QApplication.instance().setAttribute(\
+                        QtCore.Qt.AA_EnableHighDpiScaling)
+        except AttributeError:
+            pass
+    matplotlib.backends.backend_qt5._create_qApp = _create_qApp
+    matplotlib.backends.backend_qt5.qApp = weakref.proxy(\
+                                        QApplication.instance())
+

--- a/PyMca5/PyMcaGui/PyMcaQt.py
+++ b/PyMca5/PyMcaGui/PyMcaQt.py
@@ -242,13 +242,15 @@ else:
 # provide a exception handler but not implement it by default
 def exceptionHandler(type_, value, trace):
     print("%s %s %s" % (type_, value, ''.join(traceback.format_tb(trace))))
-    msg = QMessageBox()
-    msg.setWindowTitle("Unhandled exception")
-    msg.setIcon(QMessageBox.Critical)
-    msg.setInformativeText("%s %s\nPlease report details" % (type_, value))
-    msg.setDetailedText(("%s " % value) + ''.join(traceback.format_tb(trace)))
-    msg.raise_()
-    msg.exec_()
+    if QApplication.instance():
+        msg = QMessageBox()
+        msg.setWindowTitle("Unhandled exception")
+        msg.setIcon(QMessageBox.Critical)
+        msg.setInformativeText("%s %s\nPlease report details" % (type_, value))
+        msg.setDetailedText(("%s " % value) + \
+                            ''.join(traceback.format_tb(trace)))
+        msg.raise_()
+        msg.exec_()
 
 # Overwrite the QFileDialog to make sure that by default it
 # returns non-native dialogs as it was the traditional behavior of Qt

--- a/PyMca5/PyMcaGui/physics/xrf/ConcentrationsWidget.py
+++ b/PyMca5/PyMcaGui/physics/xrf/ConcentrationsWidget.py
@@ -950,8 +950,9 @@ if __name__ == "__main__":
                 Elements.Material[material] = copy.deepcopy(d['result']['config']['materials'][material])
             demo.processFitResult(fitresult=d, elementsfrommatrix=False)
         demo.show()
-        app.exec_()
-
+        ret = app.exec_()
+        app = None
+        sys.exit(ret)
     else:
         print("Usage:")
         print("ConcentrationsWidget.py [--flux=xxxx --area=xxxx] fitresultfile")

--- a/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
@@ -308,4 +308,4 @@ if __name__ == "__main__":
     ret = w.exec_()
     if ret:
         print(w.getParameters())
-    #app.exec_()
+    app = None

--- a/PyMca5/PyMcaGui/physics/xrf/FitParam.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FitParam.py
@@ -1363,8 +1363,6 @@ class FitParamDialog(qt.QDialog):
                 self.initDir = os.path.dirname(filename)
 
 def openDialog():
-    app= qt.QApplication(sys.argv)
-    app.lastWindowClosed.connect(app.quit)
     wid= FitParamDialog(modal=1)
     ret = wid.exec_()
     if ret == qt.QDialog.Accepted:
@@ -1376,5 +1374,6 @@ def openDialog():
 if __name__=="__main__":
     logging.basicConfig(level=logging.INFO)
     app = qt.QApplication([])
+    app.lastWindowClosed.connect(app.quit)
     openDialog()
     app = None

--- a/PyMca5/PyMcaGui/physics/xrf/FitParam.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FitParam.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -1362,16 +1362,6 @@ class FitParamDialog(qt.QDialog):
                 self.saveParameters(filename, None)
                 self.initDir = os.path.dirname(filename)
 
-
-def openWidget():
-    app= qt.QApplication(sys.argv)
-    app.lastWindowClosed.connect(app.quit)
-    wid= FitParamWidget()
-    app.setMainWidget(wid)
-    wid.show()
-    app.exec_loop()
-
-
 def openDialog():
     app= qt.QApplication(sys.argv)
     app.lastWindowClosed.connect(app.quit)
@@ -1381,10 +1371,10 @@ def openDialog():
         npar = wid.getParameters()
         print(npar)
         del wid
-    app.quit()
-
+    return ret
 
 if __name__=="__main__":
     logging.basicConfig(level=logging.INFO)
-    #openWidget()
+    app = qt.QApplication([])
     openDialog()
+    app = None

--- a/PyMca5/PyMcaGui/physics/xrf/FitParamForm.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FitParamForm.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2014 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -849,3 +849,4 @@ if __name__ == "__main__":
     w = FitParamForm()
     w.show()
     a.exec_()
+    a = None

--- a/PyMca5/PyMcaGui/physics/xrf/FitPeakSelect.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FitPeakSelect.py
@@ -468,12 +468,12 @@ class MyQLabel(qt.QLabel):
             qt.QLabel.drawContents(self,painter)
             painter.font().setBold(0)
 
-def testwidget():
+if __name__ == "__main__":
     import sys
     def change(ddict):
         print("New selection:",)
         print(ddict)
-    a = qt.QApplication(sys.argv)
+    a = qt.QApplication([])
     a.lastWindowClosed.connect(a.quit)
 
     w = qt.QTabWidget()
@@ -483,6 +483,4 @@ def testwidget():
     f.sigFitPeakSelect.connect(change)
     w.show()
     a.exec_()
-
-if __name__ == "__main__":
-    testwidget()
+    a = None

--- a/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
+++ b/PyMca5/PyMcaGui/physics/xrf/MaterialEditor.py
@@ -951,4 +951,5 @@ if __name__ == "__main__":
     else:
         demo = MaterialEditor(toolmode=False)
     demo.show()
-    app.exec_()
+    ret  = app.exec_()
+    app = None

--- a/PyMca5/PyMcaGui/physics/xrf/MatrixEditor.py
+++ b/PyMca5/PyMcaGui/physics/xrf/MatrixEditor.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2014 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -344,3 +344,4 @@ if __name__ == "__main__":
     demo = MatrixEditor(table=True, orientation="vertical")
     demo.show()
     app.exec_()
+    app = None

--- a/PyMca5/PyMcaGui/physics/xrf/MatrixImage.py
+++ b/PyMca5/PyMcaGui/physics/xrf/MatrixImage.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2014 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -713,3 +713,4 @@ if __name__ == '__main__':
         w=MatrixImage()
     w.show()
     a.exec_()
+    a = None

--- a/PyMca5/PyMcaGui/plotting/PlotWidget.py
+++ b/PyMca5/PyMcaGui/plotting/PlotWidget.py
@@ -355,3 +355,4 @@ if __name__ == "__main__":
         plot.insertYMarker(5., legend="Y", text="Y", draggable=True)
     print("All curves = ", plot.getAllCurves(just_legend=True))
     app.exec_()
+    app = None

--- a/PyMca5/PyMcaGui/plotting/PyMca_Icons.py
+++ b/PyMca5/PyMcaGui/plotting/PyMca_Icons.py
@@ -4291,3 +4291,4 @@ if __name__ == '__main__':
     _logger.setLevel(logging.DEBUG)
     w = showIcons()
     app.exec_()
+    app = None

--- a/PyMca5/PyMcaGui/plotting/Silx_Icons.py
+++ b/PyMca5/PyMcaGui/plotting/Silx_Icons.py
@@ -8615,3 +8615,4 @@ if __name__ == '__main__':
     app.lastWindowClosed.connect(app.quit)
     w = showIcons()
     app.exec_()
+    app = None

--- a/PyMca5/PyMcaGui/pymca/McaWindow.py
+++ b/PyMca5/PyMcaGui/pymca/McaWindow.py
@@ -1728,3 +1728,4 @@ def test():
 
 if __name__ == "__main__":
     test()
+    app = None

--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -1810,5 +1810,7 @@ if __name__ == '__main__':
         p=pstats.Stats("test")
         p.strip_dirs().sort_stats(-1).print_stats()
     else:
-        sys.exit(app.exec_())
+        ret = app.exec_()
+        app = None
+        sys.exit(ret)
 

--- a/PyMca5/PyMcaGui/pymca/QStackWidget.py
+++ b/PyMca5/PyMcaGui/pymca/QStackWidget.py
@@ -1375,4 +1375,5 @@ if __name__ == "__main__":
         widget.setStack(stack)
     widget.show()
     app.exec_()
+    app = None
 

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -1594,3 +1594,4 @@ def test():
 
 if __name__ == "__main__":
     test()
+    app = None


### PR DESCRIPTION
Solves the crash on exit issue in many modules when using PyQt5. The condition to get rid of the crash is
to make sure no reference to a QApplication instance is kept.

A problem is that matplotlib.backends.backend_qt5agg holds a reference to it into a global variable (qApp) instead of using a weakref proxy. This has been reported to matplotlib, but it is not clear at all it will be solved because the crashes are random and not easy to reproduce.
