### PR TITLE
Make the matplotlib patch compatible with the QApplication not being instantiated yet

### DIFF
--- a/PyMca5/PyMcaGraph/backends/_patch_matplotlib.py
+++ b/PyMca5/PyMcaGraph/backends/_patch_matplotlib.py
@@ -55,7 +55,6 @@ def patch_backend_qt():
                         QtCore.Qt.AA_EnableHighDpiScaling)
         except AttributeError:
             pass
-    matplotlib.backends.backend_qt5._create_qApp = _create_qApp
-    matplotlib.backends.backend_qt5.qApp = weakref.proxy(\
+        matplotlib.backends.backend_qt5.qApp = weakref.proxy(\
                                         QApplication.instance())
-
+    matplotlib.backends.backend_qt5._create_qApp = _create_qApp


### PR DESCRIPTION
It was forcing to create a QApplication prior to import graphics related widget.