### PR TITLE
[RGB Correlator] Cannot handle "," or ";" in label names

### DIFF
--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -1078,7 +1078,8 @@ class RGBCorrelatorWidget(qt.QWidget):
         labels = []
         for label in imageList:
             datalist.append(self._imageDict[label]['image'])
-            labels.append(label.replace(" ","_"))
+            # prevent problems when reading back the saved data
+            labels.append(label.replace(" ","_").replace(",", "_").replace(";","_"))
 
         fileRoot = os.path.splitext(filename)[0]
         fileExtension = os.path.splitext(filename)[-1].lower()


### PR DESCRIPTION
Prevent the generation of files that cannot be read back.