### PR TITLE
Remove "convenience" imports.

### DIFF
--- a/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
@@ -531,7 +531,7 @@ if __name__ == "__main__":
         spectrum = data[1, :]
         w = XASNormalizationDialog(None, spectrum, energy=energy)
     else:
-        from PyMca5 import SpecfitFuns
+        from PyMca5.PyMcaMath.fitting import SpecfitFuns
         noise = numpy.random.randn(1500.)
         x = 8000. + numpy.arange(1500.)
         y = SpecfitFuns.upstep([100, 8500., 50], x)

--- a/PyMca5/PyMcaMath/SNIPModule.py
+++ b/PyMca5/PyMcaMath/SNIPModule.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2014 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -31,7 +31,7 @@ __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import numpy
-from PyMca5 import SpecfitFuns
+from .fitting import SpecfitFuns
 
 snip1d = SpecfitFuns.snip1d
 snip2d = SpecfitFuns.snip2d

--- a/PyMca5/PyMcaMath/fitting/SimpleFitUserEstimatedFunctions.py
+++ b/PyMca5/PyMcaMath/fitting/SimpleFitUserEstimatedFunctions.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -31,7 +31,7 @@ __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import numpy
-from PyMca5 import SpecfitFuns
+from PyMca5.PyMcaMath.fitting import SpecfitFuns
 arctan = numpy.arctan
 exp = numpy.exp
 pi = numpy.pi

--- a/PyMca5/__init__.py
+++ b/PyMca5/__init__.py
@@ -244,18 +244,5 @@ if sys.platform.startswith("win"):
 # mandatory modules for backwards compatibility
 from .PyMcaCore import Plugin1DBase, StackPluginBase, PyMcaDirs, DataObject
 
-#convenience modules that could be directly imported
-# using from PyMca5.PyMca import
-try:
-    from .PyMcaIO import specfilewrapper, EdfFile, specfile, ConfigDict
-except:
-    _logger.info("WARNING importing IO directly")
-    from PyMcaIO import specfilewrapper, EdfFile, specfile, ConfigDict
-
-from .PyMcaMath.fitting import SpecfitFuns, Gefit, Specfit
-from .PyMcaMath.fitting import SpecfitFunctions
-
-from .PyMcaPhysics.xrf import Elements
-
 #all the rest can be imported using from PyMca5.PyMca import ...
 from . import PyMca


### PR DESCRIPTION
They are not used anywhere in PyMca.