### PR TITLE
[outbuffer] no need for buffercontext when simply asking for filenames

### DIFF
--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -707,7 +707,7 @@ class McaAdvancedFitBatch(object):
 
         # Extract/calculate + save concentrations
         if result:
-            # TODO: 'concentrations' in result, when does this happend and should we pop it????
+            # TODO: 'concentrations' in result, when does this happens and should we pop it????
             concentrationsInResult = 'concentrations' not in result
         else:
             concentrationsInResult = False

--- a/PyMca5/PyMcaPhysics/xrf/XRFBatchFitOutput.py
+++ b/PyMca5/PyMcaPhysics/xrf/XRFBatchFitOutput.py
@@ -822,14 +822,13 @@ class OutputBuffer(MutableMapping):
                 # Stack of datasets
                 mnames = self.labels(group, labeltype='title')
                 for name, mname, bufferi in zip(names, mnames, buffer):
-                    if bufferi.ndim <= 2:
-                        imageFileLabels.append(name)
-                        if not onlylabels:
-                            imageTitleLabels.append(mname)
-                            imageList.append(bufferi[()])
+                    imageFileLabels.append(name)
+                    if not onlylabels:
+                        imageTitleLabels.append(mname)
+                        imageList.append(bufferi[()])
             else:
                 # Single dataset
-                if buffer.ndim <= 2 and group.lower() in self._optionalimage:
+                if group.lower() in self._optionalimage:
                     name = self._labelsToStrings(group, [group], labeltype='filename')[0]
                     mname = self._labelsToStrings(group, [group], labeltype='title')[0]
                     imageFileLabels.append(name)


### PR DESCRIPTION
Solves bug in `McaBatch.onEnd` (make sure opening context is not required for just the filenames).