### PR TITLE
[batchfit] force save FOMs (chisq only for non-hdf5 formats)

### DIFF
--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -212,6 +212,8 @@ class McaAdvancedFitBatch(object):
                                           nosave=self.nosave,
                                           suffix=self._outputSuffix(),
                                           **self.outbufferkwargs)
+        # Always save figures-of-merit (HDF5: all, EDF/CSV: chisq only)
+        self.outbuffer.saveFOM = True
         self.outbuffer['configuration'] = self.mcafit.getConfiguration()
 
     def _outputSuffix(self):

--- a/PyMca5/PyMcaPhysics/xrf/XRFBatchFitOutput.py
+++ b/PyMca5/PyMcaPhysics/xrf/XRFBatchFitOutput.py
@@ -118,7 +118,10 @@ class OutputBuffer(MutableMapping):
         self.saveFit = saveFit
         self.saveData = saveData
         self.saveFOM = saveFOM
-        self.diagnostics = diagnostics
+        if not self.diagnostics:
+            # None of the above diagnostics
+            # are enabled specifically
+            self.diagnostics = diagnostics
         self.overwrite = overwrite
         self.nosave = nosave
         self.suffix = suffix
@@ -272,6 +275,8 @@ class OutputBuffer(MutableMapping):
 
     @property
     def saveFOM(self):
+        # For all non-hdf5 formats: FOM needs to be in
+        # self._optionalimage to be saved
         return self._saveFOM
     
     @saveFOM.setter


### PR DESCRIPTION
Solve issue #489. The FOMs will always be saved. HDF5 will contain all of them, the other formats only the chisq. Note that this only goes for slow fitting, fast fitting does not produce the chisq.