### PR TITLE
[rgb] add hdf5 support

### DIFF
--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -1224,11 +1224,7 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
             correlator.raise_()
         self.__correlator[-1].sigRGBCorrelatorSignal.connect( \
                 self._deleteCorrelator)
-
-        if len(filelist) == 1:
-            correlator.addBatchDatFile(filelist[0])
-        else:
-            correlator.addFileList(filelist)
+        correlator.addFileList(filelist)
 
     def __sumRules(self):
         if self.__correlator is None:

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
@@ -46,7 +46,9 @@ if USE_MASK_WIDGET:
 MATPLOTLIB = True
 
 class RGBCorrelator(qt.QWidget):
+
     sigRGBCorrelatorSignal = qt.pyqtSignal(object)
+    
     def __init__(self, parent = None, graph = None, bgrx = True):
         qt.QWidget.__init__(self, parent)
         self.setWindowTitle("PyMca RGB Correlator")

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -1037,6 +1037,7 @@ class RGBCorrelatorWidget(qt.QWidget):
                 msg.setIcon(qt.QMessageBox.Critical)
                 msg.setText("No (valid) datasets were found in '{}::{}'".format(filename, h5path))
                 msg.exec_()
+                self._addHf5File(filename, ignoreStDev=ignoreStDev)
             elif len({dset.size for dset in datasets}) > 1:
                 msg = qt.QMessageBox(self)
                 msg.setIcon(qt.QMessageBox.Critical)

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -1017,13 +1017,13 @@ class RGBCorrelatorWidget(qt.QWidget):
                 h5path = tmp[1]
         if not h5path:
             return
-        # Add images from HDF5 path
+        # Add datasets from HDF5 path
         with HDF5Widget.h5open(filename) as hdf5File:
             datasets = NexusUtils.selectDatasets(hdf5File[h5path])
             if not datasets:
                 msg = qt.QMessageBox(self)
                 msg.setIcon(qt.QMessageBox.Critical)
-                msg.setText("No 2D datasets were found in {}::{}".format(filename, h5path))
+                msg.setText("No datasets were found in {}::{}".format(filename, h5path))
                 msg.exec_()
             elif len({dset.ndim for dset in datasets}) > 1:
                 msg = qt.QMessageBox(self)

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -946,6 +946,12 @@ class RGBCorrelatorWidget(qt.QWidget):
 
     def _addSingleFile(self, uri, filterused=None, ignoreStDev=True):
         filename = uri.split('::')[0]
+        if not os.path.isfile(filename):
+            msg = qt.QMessageBox(self)
+            msg.setIcon(qt.QMessageBox.Critical)
+            msg.setText("%s does not exist" % filename)
+            msg.exec_()
+            return
         if filterused is None:
             filterused = ''
         if isTif(filename):
@@ -1014,6 +1020,12 @@ class RGBCorrelatorWidget(qt.QWidget):
         # Add images from HDF5 path
         with HDF5Widget.h5open(filename) as hdf5File:
             datasets = NexusUtils.getNdimDatasets(hdf5File[h5path], ndim=2)
+            if not datasets:
+                msg = qt.QMessageBox(self)
+                msg.setIcon(qt.QMessageBox.Critical)
+                msg.setText("No 2D datasets were found in {}::{}".format(filename, h5path))
+                msg.exec_()
+                return
             for dset in datasets:
                 label = '/'.join(dset.name.split('/')[-2:])
                 self.addImage(dset[()], label)

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -1030,7 +1030,7 @@ class RGBCorrelatorWidget(qt.QWidget):
                 def match(dset):
                     return dset.ndim == 1 or dset.ndim == 2
             # If `h5path` is an instance of NXdata, only the signals
-            # (including auxilary signals) are concidered for `match`.
+            # (including auxilary signals) are considered for `match`.
             datasets = NexusUtils.selectDatasets(hdf5File[h5path], match=match)
             if not datasets:
                 msg = qt.QMessageBox(self)

--- a/PyMca5/PyMcaIO/NexusUtils.py
+++ b/PyMca5/PyMcaIO/NexusUtils.py
@@ -642,7 +642,7 @@ def getNdimDatasets(root, ndim=2):
             labels = root.keys()
         for label in labels:
             dset = root.get(label, None)
-            if dset is None:
+            if not isinstance(dset, h5py.Dataset):
                 continue
             if dset.ndim == ndim:
                 datasets.append(dset)

--- a/PyMca5/PyMcaIO/NexusUtils.py
+++ b/PyMca5/PyMcaIO/NexusUtils.py
@@ -629,6 +629,10 @@ def nxDataAddErrors(data, errors):
 
 def selectDatasets(root, match=None):
     """
+    Select datasets with given restrictions. In case of `root`
+    is an NXdata instance, an additional restriction is imposed:
+    the dataset must be specified as a signal (including auxilary signals).
+
     :param h5py.Group or h5py.Dataset root:
     :param match: restrict selection (callable, 'max_ndim', 'mostcommon_ndim')
     :returns list(h5py.Dataset):
@@ -654,7 +658,7 @@ def selectDatasets(root, match=None):
             dset = root.get(label, None)
             if not isinstance(dset, h5py.Dataset):
                 continue
-            if match(dset.ndim):
+            if match(dset):
                 datasets.append(dset)
         if post == 'max_ndim':
             ndimref = max(dset.ndim for dset in datasets)

--- a/PyMca5/PyMcaIO/NexusUtils.py
+++ b/PyMca5/PyMcaIO/NexusUtils.py
@@ -37,6 +37,7 @@ import datetime
 import numpy
 import os
 import errno
+from collections import Counter
 from contextlib import contextmanager
 from .. import version
 
@@ -626,15 +627,24 @@ def nxDataAddErrors(data, errors):
             data[name+'_errors'] = h5py.SoftLink(dest.name)
 
 
-def getNdimDatasets(root, ndim=2):
+def selectDatasets(root, match=None):
     """
     :param h5py.Group or h5py.Dataset root:
-    :param int ndim: restrict dimensions
+    :param match: restrict selection (callable, 'max_ndim', 'mostcommon_ndim')
     :returns list(h5py.Dataset):
     """
+    if match == 'max_ndim':
+        match, post = None, match
+    elif match == 'mostcommon_ndim':
+        match, post = None, match
+    else:
+        post = None
+    if not match:
+        def match(dset):
+            return True
     datasets = []
     if isinstance(root, h5py.Dataset):
-        if root.ndim == ndim:
+        if match(root):
             datasets = [root]
     else:
         labels = nxDataGetSignals(root)
@@ -644,8 +654,17 @@ def getNdimDatasets(root, ndim=2):
             dset = root.get(label, None)
             if not isinstance(dset, h5py.Dataset):
                 continue
-            if dset.ndim == ndim:
+            if match(dset.ndim):
                 datasets.append(dset)
+        if post == 'max_ndim':
+            ndimref = max(dset.ndim for dset in datasets)
+        elif post == 'mostcommon_ndim':
+            occurences = Counter(dset.ndim for dset in datasets)
+            ndimref = occurences.most_common(1)[0][0]
+        else:
+            ndimref = None
+        if ndimref is not None:
+            datasets = [dset.ndim == ndimref for dset in datasets]
     return datasets
 
 

--- a/PyMca5/PyMcaIO/NexusUtils.py
+++ b/PyMca5/PyMcaIO/NexusUtils.py
@@ -626,6 +626,29 @@ def nxDataAddErrors(data, errors):
             data[name+'_errors'] = h5py.SoftLink(dest.name)
 
 
+def getNdimDatasets(root, ndim=2):
+    """
+    :param h5py.Group or h5py.Dataset root:
+    :param int ndim: restrict dimensions
+    :returns list(h5py.Dataset):
+    """
+    datasets = []
+    if isinstance(root, h5py.Dataset):
+        if root.ndim == ndim:
+            datasets = [root]
+    else:
+        labels = nxDataGetSignals(root)
+        if not labels:
+            labels = root.keys()
+        for label in labels:
+            dset = root.get(label, None)
+            if dset is None:
+                continue
+            if dset.ndim == ndim:
+                datasets.append(dset)
+    return datasets
+
+
 def markDefault(h5group):
     """
     Mark HDF5 Dataset or Group as default (parents get notified as well)


### PR DESCRIPTION
This PR addresses issue #422 (only the RGB correlator).

I minimized refactoring:
 - `RGBCorrelatorWidget.addFileList` loops and calls `_addSingleFile` which checks file formats and calls `_addEdfFile`, `_addHdf5File`, etc.
 - remove file format checking from `PyMcaPostBatch` (redundant, didn't want to do it for HDF5 as well)
 - deprecation warning for the public `RGBCorrelatorWidget.addBatchDatFile` method (calls `addFileList`)

HDF5 support is added to `RGBCorrelatorWidget`:
 - If the file exists but the uri does not, it will prompt for a uri.
 - I used `HDF5Widget.getUri` and `NexusUtils.getNdimDatasets`.