### PR TITLE
[outbuffer] use 'IMAGES' as root directory for legacy formats

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
@@ -76,6 +76,7 @@ class FastXRFLinearFitWindow(qt.QWidget):
         # output root
         outrootLabel = qt.QLabel(self)
         outrootLabel.setText("Output root:")
+        self._outrootLabel = outrootLabel
         self._outrootLine = qt.QLineEdit(self)
         self._outrootLine.setReadOnly(False)
         self._outrootLine.setText("IMAGES")
@@ -89,7 +90,7 @@ class FastXRFLinearFitWindow(qt.QWidget):
 
         # output process
         outnameLabel = qt.QLabel(self)
-        outnameLabel.setText("Output name:")
+        outnameLabel.setText("Output process:")
         self._outnameLabel = outnameLabel
         self._outnameLine = qt.QLineEdit(self)
         self._outnameLine.setText("fast_xrf_fit")
@@ -258,14 +259,16 @@ class FastXRFLinearFitWindow(qt.QWidget):
 
     def toggleH5(self, state):
         h5Out = bool(state)
-        self._outnameLine.setReadOnly(not h5Out)
-        self._outnameLine.setEnabled(h5Out)
+        self._outrootLabel.setEnabled(h5Out)
         self._outnameLabel.setEnabled(h5Out)
         self._diagnosticsBox.setEnabled(h5Out)
-        if h5Out:
-            self._outnameLine.setStyleSheet("")
-        else:
-            self._outnameLine.setStyleSheet("color: gray; background-color: darkGray")
+        for w in [self._outnameLine, self._outrootLine]:
+            w.setReadOnly(not h5Out)
+            w.setEnabled(h5Out)
+            if h5Out:
+                w.setStyleSheet("")
+            else:
+                w.setStyleSheet("color: gray; background-color: darkGray")
 
     def stateMultiPage(self, state=None):
         self._multipageBox.setEnabled(self._edfBox.isChecked() or self._tiffBox.isChecked())

--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -1516,7 +1516,8 @@ class McaBatchGUI(qt.QWidget):
         delete = _logger.getEffectiveLevel() != logging.DEBUG
         basename = McaAdvancedFitBatch.getRootName(self.fileList)
         edfoutlist, datoutlist, h5outlist = work.buildOutput(basename=basename, delete=delete)
-        inputdir = os.path.join(self.outputDir, basename)
+        #inputdir = os.path.join(self.outputDir, basename)
+        inputdir = os.path.join(self.outputDir, 'IMAGES')
         edfoutlist2, datoutlist2, h5outlist2 = work.buildOutput(basename=basename, inputdir=inputdir, delete=delete)
         edfoutlist += edfoutlist2
         datoutlist += datoutlist2

--- a/PyMca5/PyMcaPhysics/xrf/XRFBatchFitOutput.py
+++ b/PyMca5/PyMcaPhysics/xrf/XRFBatchFitOutput.py
@@ -349,8 +349,9 @@ class OutputBuffer(MutableMapping):
             raise RuntimeError('Buffer is locked')
 
     @property
-    def outroot_localfs(self):
-        return os.path.join(self.outputDir, self.outputRoot)
+    def outputDirLegacy(self):
+        #return os.path.join(self.outputDir, self.outputRoot)
+        return os.path.join(self.outputDir, 'IMAGES')
 
     def filename(self, ext, suffix=None):
         if not suffix:
@@ -360,7 +361,7 @@ class OutputBuffer(MutableMapping):
         if ext == '.h5':
             return os.path.join(self.outputDir, self.outputRoot+suffix+ext)
         else:
-            return os.path.join(self.outroot_localfs, self.fileEntry+suffix+ext)
+            return os.path.join(self.outputDirLegacy, self.fileEntry+suffix+ext)
 
     def allocateMemory(self, label, group=None, memtype='ram', **kwargs):
         """
@@ -854,7 +855,7 @@ class OutputBuffer(MutableMapping):
         if not imageFileLabels:
             return
 
-        NexusUtils.mkdir(self.outroot_localfs)
+        NexusUtils.mkdir(self.outputDirLegacy)
         if self.edf:
             if self.multipage:
                 fileName = self.filename('.edf')

--- a/PyMca5/tests/PyMcaBatchTest.py
+++ b/PyMca5/tests/PyMcaBatchTest.py
@@ -374,7 +374,8 @@ class testPyMcaBatch(TestCaseQt):
             if legacy:
                 subdir = 'IMAGES'
             else:
-                subdir = rootname
+                #subdir = rootname
+                subdir = 'IMAGES'
         else:
             # Fast fit
             rootname = 'images'

--- a/PyMca5/tests/XRFBatchFitOutputTest.py
+++ b/PyMca5/tests/XRFBatchFitOutputTest.py
@@ -72,7 +72,8 @@ class testXRFBatchFitOutput(unittest.TestCase):
 
     def testOverwrite(self):
         h5name = os.path.join(self.path, self.saveall['outputRoot']+'.h5')
-        subdir = os.path.join(self.path, self.saveall['outputRoot'])
+        #subdir = os.path.join(self.path, self.saveall['outputRoot'])
+        subdir = os.path.join(self.path, 'IMAGES')
         outbuffer = self._initOutBuffer(**self.saveall)
         outdata, outlabels, outaxes = self._generateData(outbuffer, memtype='mix')
         expected = self._getFiles(self.path)
@@ -110,7 +111,8 @@ class testXRFBatchFitOutput(unittest.TestCase):
 
             # Make sure the expected files are saved
             h5name = os.path.join(outputDir, 'sample.h5')
-            subdir = os.path.join(outputDir, 'sample')
+            #subdir = os.path.join(outputDir, 'sample')
+            subdir = os.path.join(outputDir, 'IMAGES')
             expected = []
             if h5:
                 expected.append(h5name)


### PR DESCRIPTION
Solve issue #490.

Modify batch output from
```
map_xia00_0001_0000_0000_to_0004.h5::/map_xia00_0001_0000_0000_to_0004
map_xia00_0001_0000_0000_to_0004/map_xia00_0001_0000_0000_to_0004.edf
map_xia00_0001_0000_0000_to_0004/map_xia00_0001_0000_0000_to_0004.dat
...
```
to
```
map_xia00_0001_0000_0000_to_0004.h5::/map_xia00_0001_0000_0000_to_0004
IMAGES/map_xia00_0001_0000_0000_to_0004.edf
IMAGES/map_xia00_0001_0000_0000_to_0004.dat
...
```