### PR TITLE
Error on concentrations using old configuration files

### DIFF
--- a/PyMca5/PyMcaPhysics/xrf/ConcentrationsTool.py
+++ b/PyMca5/PyMcaPhysics/xrf/ConcentrationsTool.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -262,8 +262,9 @@ class ConcentrationsTool(object):
             elif attenuator.upper() == "DETECTOR":
                 detectoratt = fitresult['result']['config']['attenuators'][attenuator][1:]
             else:
-                if len(fitresult['result']['config']['attenuators'][attenuator][1:]) == 4:
-                   fitresult['result']['config']['attenuators'][attenuator].append(1.0)
+                if len(fitresult['result']['config']['attenuators'][attenuator]) == 4:
+                    # using an old fit configuration file without funny filters
+                    fitresult['result']['config']['attenuators'][attenuator].append(1.0)
                 if abs(fitresult['result']['config']['attenuators'][attenuator][4]-1.0) > 1.0e-10:
                     #funny attenuator
                     funnyfilters.append(fitresult['result']['config']['attenuators']\

--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -671,8 +671,16 @@ class McaAdvancedFitBatch(object):
             if bOutput and result is not None:
                 result['ydata0'] = y
                 if not self.outbuffer.hasAllocatedMemory():
-                    self._allocateMemoryFit(result, concentrations)
-                self._storeFitResult(result, concentrations)
+                    if self._concentrations and (concentrations is None):
+                        # if concentrations were requested but unsuccessful on the first MCA
+                        # the memory allocation crashes the program
+                        _logger.error("Cannot allocate memory due to error on concentrations")
+                    else:
+                        self._allocateMemoryFit(result, concentrations)
+                        self._storeFitResult(result, concentrations)
+                        _logger.info("Memory allocated")
+                else:
+                    self._storeFitResult(result, concentrations)
         self.counter += 1
 
     def __fitOneMca(self,x,y,filename,key,info=None):
@@ -827,6 +835,7 @@ class McaAdvancedFitBatch(object):
         except:
             _logger.error("error in concentrations")
             _logger.error(str(sys.exc_info()[0:-1]))
+            concentrations = None
         return result, concentrations
 
     def _updateFitFile(self, concentrations, outfile):


### PR DESCRIPTION
Error on issue #546 was due to the bad handling of old fit configuration files where attenuators did not have the funny filter information.

Besides that, a batch with concentrations where the first calculation was wrong was crashing the program.