### PR TITLE
[PyMcaBatch] More robust HTML report generation

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/QtMcaAdvancedFitReport.py
+++ b/PyMca5/PyMcaGui/physics/xrf/QtMcaAdvancedFitReport.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -90,7 +90,7 @@ class QtMcaAdvancedFitReport:
             htmltext={}
         self.otherhtmltext=htmltext
         if plotdict is None:
-            self.plotDict = {'logy':True,
+            self.plotDict = {'logy':None,
                              'xmin':None,
                              'xmax':None,
                              'ymin':None,
@@ -589,6 +589,13 @@ class QtMcaAdvancedFitReport:
             ax = fig.add_axes([.15, .15, .8, .8])
             ax.set_axisbelow(True)
             logplot = self.plotDict.get('logy', True)
+            if logplot is None:
+                if (ddict['result']['ydata'].max() - ddict['result']['ydata'].min()) < 200:
+                    logplot = False
+                elif ddict['result']['yfit'].min() < 0.01:
+                    logplot = False
+                else:
+                    logplot = True
             if logplot:
                 axplot = ax.semilogy
             else:
@@ -612,6 +619,8 @@ class QtMcaAdvancedFitReport:
                 legend = ax.legend(legendlist, loc=0,
                                    prop = fontproperties, labelspacing=0.02)
         except ValueError:
+            # It seems this error is not caught with matplotlib 2.2.4 and the
+            # report crashes instead of switching to a linear plot
             fig = Figure(figsize=(6,3)) # in inches
             canvas = FigureCanvas(fig)
             ax = fig.add_axes([.15, .15, .8, .8])

--- a/PyMca5/__init__.py
+++ b/PyMca5/__init__.py
@@ -27,7 +27,7 @@ __author__ = "V.A. Sole - ESRF Data Analysis"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__version__ = "5.5.0"
+__version__ = "5.5.1"
 
 import os
 import sys

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+VERSION 5.5.1
+-------------
+
+- Qt binding selection tries PyQt5, PySide2, PyQt4 and PySide in that order.
+
+- PyMcaBatch: Correct HTML report generation.
+
 VERSION 5.5.0
 -------------
 


### PR DESCRIPTION
It seems matplotlib errors related to the use of logarithmic y axis are not always caught.

This PR tries to figure out what type of plot is appropriate (log or linear) if nothing has been requested.