### PR TITLE
Default scatter backend should be OpenGL

### DIFF
--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -555,9 +555,9 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
             legend = ddict['legend']
             if legend not in self.imageWindowDict.keys():
                 if OPENGL_DRIVERS_OK:
-                    scatter_backend = "gl"
+                    backend = "gl"
                 else:
-                    scatter_backend = "mpl"
+                    backend = "mpl"
                 imageWindow = SilxScatterWindow.SilxScatterWindow(backend=backend)
                 self.imageWindowDict[legend] = imageWindow
                 self.imageWindowDict[legend].setPlotEnabled(True)


### PR DESCRIPTION
The default was matplotlib due to an error on the name of the passed variable.