### PR TITLE
[h5py] always specify file mode

### DIFF
--- a/PyMca5/Object3D/Object3DPlugins/ChimeraStack.py
+++ b/PyMca5/Object3D/Object3DPlugins/ChimeraStack.py
@@ -69,9 +69,8 @@ def getObject3DInstance(config=None):
     #file index is irrelevant in case of an actual 3D stack.
     filename = fileList[0]
     legend = os.path.basename(filename)
-    f = h5py.File(filename)
-    stack = f['Image']['data'].value
-    f = None
+    with h5py.File(filename, mode='r') as f
+        stack = f['Image']['data'][()]
     if stack is None:
         raise IOError("Problem reading stack.")
     object3D = ChimeraStack(name=legend)
@@ -121,8 +120,8 @@ if __name__ == "__main__":
         if not os.path.exists(filename):
             print("File does not exists")
             sys.exit(1)
-        f = h5py.File(filename)
-        stack = f['Image']['data'].value
+        with h5py.File(filename, mode='r') as f
+            stack = f['Image']['data'][()]
         if stack is None:
             raise IOError("Problem reading stack.")
         object3D = ChimeraStack(name=os.path.basename(filename))

--- a/PyMca5/PyMcaCore/PyMcaBatchBuildOutput.py
+++ b/PyMca5/PyMcaCore/PyMcaBatchBuildOutput.py
@@ -131,13 +131,13 @@ class PyMcaBatchBuildOutput(object):
 
     def _mergeH5(self, parts, outfilename):
         shutil.copy(parts[0], outfilename)
-        with h5py.File(outfilename) as fout:
+        with h5py.File(outfilename, mode='a') as fout:
             for entry in NexusTools.getNXClassGroups(fout, '/', [u'NXentry']):
                 for process in NexusTools.getNXClassGroups(fout, entry.name, [u'NXprocess']):
                     for results in NexusTools.getNXClassGroups(fout, process.name, [u'NXcollection']):
                         for dataout in NexusTools.getNXClassGroups(fout, results.name, [u'NXdata']):
                             for part in parts[1:]:
-                                with h5py.File(part) as fin:
+                                with h5py.File(part, mode='r') as fin:
                                     try:
                                         datain = fin[dataout.name]
                                     except KeyError:

--- a/PyMca5/PyMcaGui/pymca/SilxGLWindow.py
+++ b/PyMca5/PyMcaGui/pymca/SilxGLWindow.py
@@ -153,7 +153,7 @@ def getChimeraStack():
     if not fileList:
         return None, None
     filename = fileList[0]
-    with h5py.File(filename) as f:
+    with h5py.File(filename, mode='r') as f:
         stack = f['Image/data'][...]
     if not isinstance(stack, numpy.ndarray) or stack.ndim != 3:
         raise IOError("Problem reading stack.")

--- a/PyMca5/tests/XRFBatchFitOutputTest.py
+++ b/PyMca5/tests/XRFBatchFitOutputTest.py
@@ -166,7 +166,7 @@ class testXRFBatchFitOutput(unittest.TestCase):
 
     def _verifyHdf5(self, filename, outdata, outlabels, outaxes):
         outlabels = outlabels['h5']
-        with h5py.File(filename) as f:
+        with h5py.File(filename, mode='a') as f:
             nxprocess = f['sample_dataset']['test']
             self.assertEqual(set(nxprocess.keys()),
                              {'configuration', 'date', 'program', 'version', 'results'})


### PR DESCRIPTION
Closes #586.

Issue: Default h5py file mode will change from 'a' to 'r'.

Solution: Add `mode='a'` to all `h5py.File` calls which do not specify a mode (unless it can be read-only).