### PR TITLE
[IO] In case of error reading the file it is clear it is not a SPEC file.

### DIFF
--- a/PyMca5/PyMcaIO/specfilewrapper.py
+++ b/PyMca5/PyMcaIO/specfilewrapper.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2015 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -103,7 +103,11 @@ def Specfile(filename):
                    ('#SPECTRUM' in line):
                     line = ""
                 break
-        line = f.readline()
+        try:
+            line = f.readline()
+        except:
+            line = ""
+            break
     f.close()
     amptek = False
     qxas   = False


### PR DESCRIPTION
Sometimes there are errors related to the encodings. If that happens it is clear we are not dealing with a SPEC file.