### PR TITLE
[PCA] Allow to use covariance or correlation

### DIFF
--- a/PyMca5/PyMcaGui/math/PCAWindow.py
+++ b/PyMca5/PyMcaGui/math/PCAWindow.py
@@ -63,9 +63,11 @@ class PCAParametersDialog(qt.QDialog):
                         'Cov. Multiple Arrays',
                         'Corr. Multiple Arrays']
         self._multipleIndex = [3, 4]
-        self.functions = [PCAModule.numpyPCA,
+        self.functions = [PCAModule.numpyCovariancePCA,
+                          PCAModule.numpyCorrelationPCA,
                           PCAModule.expectationMaximizationPCA,
-                          PCAModule.multipleArrayPCA]
+                          PCAModule.multipleArrayCovariancePCA,
+                          PCAModule.multipleArrayCorrelationPCA]
         self.methodOptions.mainLayout = qt.QGridLayout(self.methodOptions)
         self.methodOptions.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.methodOptions.mainLayout.setSpacing(2)

--- a/PyMca5/PyMcaGui/math/PCAWindow.py
+++ b/PyMca5/PyMcaGui/math/PCAWindow.py
@@ -71,10 +71,6 @@ class PCAParametersDialog(qt.QDialog):
         self.methodOptions.mainLayout = qt.QGridLayout(self.methodOptions)
         self.methodOptions.mainLayout.setContentsMargins(0, 0, 0, 0)
         self.methodOptions.mainLayout.setSpacing(2)
-        #this does not seem to bring any advantage
-        if 0:
-            self.methods.append("Covariance Numpy")
-            self.functions.append(PCAModule.numpyPCA)
         if MDP and (index != 0):
             #self.methods.append("MDP (PCA + ICA)")
             self.methods.append("MDP (SVD float32)")

--- a/PyMca5/PyMcaGui/math/PCAWindow.py
+++ b/PyMca5/PyMcaGui/math/PCAWindow.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2019 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2020 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -58,8 +58,11 @@ class PCAParametersDialog(qt.QDialog):
 
         self.methodOptions = qt.QGroupBox(self)
         self.methodOptions.setTitle('PCA Method to use')
-        self.methods = ['Covariance', 'Expectation Max.',
-                        'Cov. Multiple Arrays']
+        self.methods = ['Covariance', 'Correlation',
+                        'Expectation Max.',
+                        'Cov. Multiple Arrays',
+                        'Corr. Multiple Arrays']
+        self._multipleIndex = [3, 4]
         self.functions = [PCAModule.numpyPCA,
                           PCAModule.expectationMaximizationPCA,
                           PCAModule.multipleArrayPCA]
@@ -84,7 +87,9 @@ class PCAParametersDialog(qt.QDialog):
         i = 0
         for item in self.methods:
             rButton = qt.QRadioButton(self.methodOptions)
-            self.methodOptions.mainLayout.addWidget(rButton, 0, i)
+            row = int(i / 5)
+            col = i % 5
+            self.methodOptions.mainLayout.addWidget(rButton, row, col)
             #self.l.setAlignment(rButton, qt.Qt.AlignHCenter)
             if i == 1:
                 rButton.setChecked(True)
@@ -204,12 +209,12 @@ class PCAParametersDialog(qt.QDialog):
         button = self.buttonGroup.button(index)
         button.setChecked(True)
         self.binningLabel.setText("Spectral Binning:")
-        if index != 2:
+        if index not in [self._multipleIndex]:
             self.binningCombo.setEnabled(True)
         else:
             self.binningCombo.setEnabled(False)
         if self.__regions:
-            if index != 2:
+            if index not in [self._multipleIndex]:
                 self.regionsWidget.setEnabled(True)
                 self.graph.setEnabled(True)
             else:
@@ -278,7 +283,7 @@ class PCAParametersDialog(qt.QDialog):
             self.nPC.setValue(ddict['npc'])
         if 'method' in ddict:
             self.buttonGroup.buttons()[ddict['method']].setChecked(True)
-            if ddict['method'] != 2:
+            if ddict['method'] not in [self._multipleIndex]:
                 self.binningCombo.setEnabled(True)
             else:
                 self.binningCombo.setEnabled(False)

--- a/PyMca5/PyMcaGui/math/PCAWindow.py
+++ b/PyMca5/PyMcaGui/math/PCAWindow.py
@@ -126,7 +126,6 @@ class PCAParametersDialog(qt.QDialog):
         #self.speedOptions.mainLayout.addWidget(qt.HorizontalSpacer(self), 0, 2)
         self.speedOptions.mainLayout.addWidget(self.binningLabel, 1, 0)
         self.speedOptions.mainLayout.addWidget(self.binningCombo, 1, 1)
-        self.binningCombo.setEnabled(False)
         self.binningCombo.activated[int].connect( \
                      self._updatePlotFromBinningCombo)
         if regions:
@@ -211,12 +210,12 @@ class PCAParametersDialog(qt.QDialog):
         button = self.buttonGroup.button(index)
         button.setChecked(True)
         self.binningLabel.setText("Spectral Binning:")
-        if index not in [self._multipleIndex]:
+        if index not in self._multipleIndex:
             self.binningCombo.setEnabled(True)
         else:
             self.binningCombo.setEnabled(False)
         if self.__regions:
-            if index not in [self._multipleIndex]:
+            if index not in self._multipleIndex:
                 self.regionsWidget.setEnabled(True)
                 self.graph.setEnabled(True)
             else:
@@ -285,7 +284,7 @@ class PCAParametersDialog(qt.QDialog):
             self.nPC.setValue(ddict['npc'])
         if 'method' in ddict:
             self.buttonGroup.buttons()[ddict['method']].setChecked(True)
-            if ddict['method'] not in [self._multipleIndex]:
+            if ddict['method'] not in self._multipleIndex:
                 self.binningCombo.setEnabled(True)
             else:
                 self.binningCombo.setEnabled(False)

--- a/PyMca5/PyMcaMath/mva/PCAModule.py
+++ b/PyMca5/PyMcaMath/mva/PCAModule.py
@@ -489,7 +489,7 @@ def numpyCorrelationPCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
     spectral_mask = kw.get("spectral_mask", None)
     force = kw.get("force", True)
     return numpyPCA(stack,
-                    ncomponents=10,
+                    ncomponents=ncomponents,
                     binning=binning,
                     legacy=legacy,
                     center=True,

--- a/PyMca5/PyMcaMath/mva/PCAModule.py
+++ b/PyMca5/PyMcaMath/mva/PCAModule.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -245,7 +245,13 @@ def lanczosPCA2(stack, ncomponents=10, binning=None, legacy=True, **kw):
                 #"variance": ???????,
                 }
 
-def multipleArrayPCA(stackList0, ncomponents=10, binning=None, legacy=True, **kw):
+def multipleArrayCovariancePCA(stackList0, **kw):
+    return multipleArrayPCA(stackList0, scale=False, **kw)
+
+def multipleArrayCorrelationPCA(stackList0, **kw):
+    return multipleArrayPCA(stackList0, scale=True, **kw)
+
+def multipleArrayPCA(stackList0, ncomponents=10, binning=None, legacy=True, scale=False, **kw):
     """
     Given a list of arrays, calculate the requested principal components from
     the matrix resulting from their column concatenation. Therefore, all the
@@ -464,7 +470,36 @@ def expectationMaximizationPCA(stack, ncomponents=10, binning=None, legacy=True,
                 }
 
 
-def numpyPCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
+def numpyCovariancePCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
+    mask = kw.get("mask", None)
+    spectral_mask = kw.get("spectral_mask", None)
+    force = kw.get("force", True)
+    return numpyPCA(stack,
+                    ncomponents=10,
+                    binning=binning,
+                    legacy=legacy,
+                    center=True,
+                    scale=False,
+                    mask=mask,
+                    spectral_mask=spectral_mask,
+                    force=force)
+
+def numpyCorrelationPCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
+    mask = kw.get("mask", None)
+    spectral_mask = kw.get("spectral_mask", None)
+    force = kw.get("force", True)
+    return numpyPCA(stack,
+                    ncomponents=10,
+                    binning=binning,
+                    legacy=legacy,
+                    center=True,
+                    scale=True,
+                    mask=mask,
+                    spectral_mask=spectral_mask,
+                    force=force)
+
+def numpyPCA(stack, ncomponents=10, binning=None, legacy=True,
+                     center=True, scale=False, mask=None, spectral_mask=None, force=True):
     """
     This is a covariance method using numpy
     """
@@ -481,7 +516,11 @@ def numpyPCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
                              ncomponents=ncomponents,
                              binning=binning,
                              legacy=legacy,
-                             **kw)
+                             center=center,
+                             scale=scale,
+                             mask=mask,
+                             spectral_mask=spectral_mask,
+                             force=force)
 
 def mdpPCASVDFloat32(stack, ncomponents=10, binning=None,
                      mask=None, spectral_mask=None, legacy=True, **kw):

--- a/PyMca5/PyMcaMath/mva/PCAModule.py
+++ b/PyMca5/PyMcaMath/mva/PCAModule.py
@@ -475,7 +475,7 @@ def numpyCovariancePCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
     spectral_mask = kw.get("spectral_mask", None)
     force = kw.get("force", True)
     return numpyPCA(stack,
-                    ncomponents=10,
+                    ncomponents=ncomponents,
                     binning=binning,
                     legacy=legacy,
                     center=True,

--- a/PyMca5/PyMcaMath/mva/PCAModule.py
+++ b/PyMca5/PyMcaMath/mva/PCAModule.py
@@ -312,7 +312,7 @@ def multipleArrayPCA(stackList0, ncomponents=10, binning=None, legacy=True, scal
             if i <= j:
                 covMatrix[rowOffset:(rowOffset + iVectorLength),
                           colOffset:(colOffset + jVectorLength)] =\
-                          dotblas.dot(stackList[i].T, stackList[j])
+                          dotblas.dot(stackList[i].T, stackList[j])/(npixels-1)
                 if i < j:
                     key = "%02d%02d" % (i, j)
                     indexDict[key] = (rowOffset, rowOffset + iVectorLength,
@@ -328,10 +328,28 @@ def multipleArrayPCA(stackList0, ncomponents=10, binning=None, legacy=True, scal
     indexDict = None
 
     #I have the covariance matrix, calculate the eigenvectors and eigenvalues
+    totalVariance = numpy.array(numpy.diag(covMatrix), copy=True)
+    # use the correlation matrix if required
+    normalizeToUnitStandardDeviation = scale
+    #option to normalize to unit standard deviation
+    if normalizeToUnitStandardDeviation:
+        for i in range(covMatrix.shape[0]):
+            if totalVariance[i] > 0:
+                covMatrix[i, :] /= numpy.sqrt(totalVariance[i])
+                covMatrix[:, i] /= numpy.sqrt(totalVariance[i])
     totalVariance = numpy.diag(covMatrix).sum()
     evalues, evectors = numpy.linalg.eigh(covMatrix)
     covMatrix = None
-    _logger.info("Total Variance = %s", totalVariance.sum())
+    _logger.info("Total Variance = %s", totalVariance)
+    # The total variance should also be the sum of all the eigenvalues
+    calculatedTotalVariance = evalues.sum()
+    if abs(totalVariance - calculatedTotalVariance) > \
+           (0.0001 * calculatedTotalVariance):
+        _logger.warning("Discrepancy on total variance")
+        _logger.warning("Variance from matrix = %s",
+                     totalVariance)
+        _logger.warning("Variance from sum of eigenvalues = %s",
+                     calculatedTotalVariance)
 
     images = numpy.zeros((ncomponents, npixels), numpy.float32)
     eigenvectors = numpy.zeros((ncomponents, eigenvectorLength), numpy.float32)
@@ -345,13 +363,19 @@ def multipleArrayPCA(stackList0, ncomponents=10, binning=None, legacy=True, scal
         i = a[i0][1]
         eigenvalues[i0] = evalues[i]
         partialExplainedVariance = 100. * evalues[i] / \
-                                   totalVariance
-        print("PC%02d  Explained variance %.5f %% " %\
+                                   calculatedTotalVariance
+        _logger.info("PC%02d  Explained variance %.5f %% " %\
                                     (i0 + 1, partialExplainedVariance))
         totalExplainedVariance += partialExplainedVariance
         eigenvectors[i0, :] = evectors[:, i]
         #print("NORMA = ", numpy.dot(evectors[:, i].T, evectors[:, i]))
-    print("Total explained variance = %.2f %% " % totalExplainedVariance)
+    _logger.info("Total explained variance = %.2f %% " % totalExplainedVariance)
+
+    # figure out if eigenvectors are to be multiplied by -1
+    for i0 in range(ncomponents):
+        if eigenvectors[i0].sum() < 0.0:
+            _logger.info("PC%02d multiplied by -1" % i0)
+            eigenvectors[i0] *= -1
 
     for i in range(ncomponents):
         colOffset = 0
@@ -380,7 +404,7 @@ def multipleArrayPCA(stackList0, ncomponents=10, binning=None, legacy=True, scal
                 "eigenvectors": eigenvectors,
                 "average": avgList,
                 "pixels": npixels,
-                "variance": totalVariance}
+                "variance": calculatedTotalVariance}
 
 def expectationMaximizationPCA(stack, ncomponents=10, binning=None, legacy=True, **kw):
     """

--- a/PyMca5/PyMcaMath/mva/PCATools.py
+++ b/PyMca5/PyMcaMath/mva/PCATools.py
@@ -534,7 +534,7 @@ def getCovarianceMatrix(stack,
 
 
 def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
-                center=True, scale=True, mask=None, spectral_mask=None, legacy=True, **kw):
+                center=True, scale=True, mask=None, spectral_mask=None, legacy=True, force=True):
     _logger.debug("PCATools.numpyPCA")
     _logger.debug("index = %d", index)
     _logger.debug("center = %s", center)
@@ -546,7 +546,6 @@ def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
     else:
         data = stack
 
-    force = kw.get("force", True)
     oldShape = data.shape
     if index not in [0, -1, len(oldShape) - 1]:
         data = None
@@ -608,13 +607,12 @@ def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
     _logger.info("Total Variance = %s", totalVariance.sum())
 
     normalizeToUnitStandardDeviation = scale
-    if 0:
-        #option to normalize to unit standard deviation
-        if normalizeToUnitStandardDeviation:
-            for i in range(cov.shape[0]):
-                if totalVariance[i] > 0:
-                    cov[i, :] /= numpy.sqrt(totalVariance[i])
-                    cov[:, i] /= numpy.sqrt(totalVariance[i])
+    #option to normalize to unit standard deviation
+    if normalizeToUnitStandardDeviation:
+        for i in range(cov.shape[0]):
+            if totalVariance[i] > 0:
+                cov[i, :] /= numpy.sqrt(totalVariance[i])
+                cov[:, i] /= numpy.sqrt(totalVariance[i])
 
     t0 = time.time()
 
@@ -671,7 +669,7 @@ def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
     # the Ca signal.
     # Clearly the user should have control about subtracting the average or not and
     # normalizing to the standard deviation or not.
-    subtractAndNormalize = False
+    subtractAndNormalize = scale
     if actualIndex in [0]:
         for i in range(oldShape[actualIndex]):
             if subtractAndNormalize:

--- a/PyMca5/PyMcaMath/mva/PCATools.py
+++ b/PyMca5/PyMcaMath/mva/PCATools.py
@@ -601,7 +601,7 @@ def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
                                                              weights=spectral_mask)
 
     # the total variance is the sum of the elements of the diagonal
-    totalVariance = numpy.diag(cov)
+    totalVariance = numpy.array(numpy.diag(cov), copy=True)
     standardDeviation = numpy.sqrt(totalVariance)
     standardDeviation = standardDeviation + (standardDeviation == 0)
     _logger.info("Total Variance = %s", totalVariance.sum())
@@ -615,14 +615,15 @@ def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
                 cov[:, i] /= numpy.sqrt(totalVariance[i])
 
     t0 = time.time()
-
+    totalVariance = numpy.diag(cov).sum()
     evalues, evectors = numpy.linalg.eigh(cov)
     # The total variance should also be the sum of all the eigenvalues
     calculatedTotalVariance = evalues.sum()
-    if abs(totalVariance.sum() - evalues.sum()) > 0.0001:
+    if abs(totalVariance - calculatedTotalVariance) > \
+           (0.0001 * calculatedTotalVariance):
         _logger.info("WARNING: Discrepancy on total variance")
         _logger.info("Variance from covariance matrix = %s",
-                     totalVariance.sum())
+                     totalVariance)
         _logger.info("Variance from sum of eigenvalues = %s",
                      calculatedTotalVariance)
     _logger.debug("Eig elapsed = %s", time.time() - t0)

--- a/PyMca5/PyMcaMath/mva/PCATools.py
+++ b/PyMca5/PyMcaMath/mva/PCATools.py
@@ -669,7 +669,7 @@ def numpyPCA(stack, index=-1, ncomponents=10, binning=None,
     # the Ca signal.
     # Clearly the user should have control about subtracting the average or not and
     # normalizing to the standard deviation or not.
-    subtractAndNormalize = scale
+    subtractAndNormalize = False
     if actualIndex in [0]:
         for i in range(oldShape[actualIndex]):
             if subtractAndNormalize:

--- a/PyMca5/PyMcaMath/mva/PCATools.py
+++ b/PyMca5/PyMcaMath/mva/PCATools.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.


### PR DESCRIPTION
Give the user the choice to perform the PCA on the covariance matrix or the correlation matrix, the later being the covariance matrix scaled to the diagonal elements in order to have unit standard deviation.