### PR TITLE
[ROI Imaging] Handle axes as dimensions

### DIFF
--- a/PyMca5/PyMcaIO/HDF5Stack1D.py
+++ b/PyMca5/PyMcaIO/HDF5Stack1D.py
@@ -797,7 +797,7 @@ class HDF5Stack1D(DataObject.DataObject):
                                                    dtype=numpy.float32)
                             else:
                                 delta = 1.0
-                            scaleList.append([origin. delta])
+                            scaleList.append([origin, delta])
                     if goodScale == 3:
                         xScale = scaleList[1] 
                         yScale = scaleList[0]
@@ -819,7 +819,7 @@ class HDF5Stack1D(DataObject.DataObject):
                                                dtype=numpy.float32)
                         else:
                             delta = 1.0
-                        scaleList.append([origin. delta])
+                        scaleList.append([origin, delta])
                     else:
                         _logger.warning("Dimensions do not match %d != %d"  % \
                                         (dataset.size, datasize))


### PR DESCRIPTION
When user selects spatial coordinates, they were ignored.

The current rationale, for a 3-dimensional dataset, is the following:

- 1 dataset selected as axis means the dataset is identified as channels. It must match the size of the stack 1D dimension
- 2 dataset selected as axes means the datasets are the spatial dimensions. They must match the corresponding dimensions of the data in size and order.
- 3 dataset selected as axes means the datasets are the dimensions of the data. They must match the corresponding dimensions of the data in size and order.