### PR TITLE
[IO] Correct MacOS issues

### DIFF
--- a/PyMca5/PyMcaIO/HDF5Stack1D.py
+++ b/PyMca5/PyMcaIO/HDF5Stack1D.py
@@ -94,6 +94,8 @@ class HDF5Stack1D(DataObject.DataObject):
         # built the selection in terms of HDF terms
         # for the time being
         xSelectionList = selection.get('x', None)
+        if xSelectionList == []:
+            xSelectionList = None
         if xSelectionList is not None:
             if type(xSelectionList) != type([]):
                 xSelectionList = [xSelectionList]

--- a/PyMca5/PyMcaIO/specfilewrapper.py
+++ b/PyMca5/PyMcaIO/specfilewrapper.py
@@ -75,7 +75,10 @@ else:
         return var[0]
 
 def Specfile(filename):
-    f = open(filename, 'r', errors="ignore")
+    if sys.version_info < (3, 0):
+        f = open(filename)
+    else:
+        f = open(filename, 'r', errors="ignore")
     line0  = f.readline()
     if filename.upper().endswith('DTA'):
         #TwinMic single column file

--- a/PyMca5/PyMcaIO/specfilewrapper.py
+++ b/PyMca5/PyMcaIO/specfilewrapper.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -75,7 +75,7 @@ else:
         return var[0]
 
 def Specfile(filename):
-    f = open(filename)
+    f = open(filename, 'r', errors="ignore")
     line0  = f.readline()
     if filename.upper().endswith('DTA'):
         #TwinMic single column file

--- a/PyMca5/PyMcaIO/specfilewrapper.py
+++ b/PyMca5/PyMcaIO/specfilewrapper.py
@@ -75,15 +75,15 @@ else:
         return var[0]
 
 def Specfile(filename):
-    f = open(filename)
+    f = open(filename, "rb")
     line0  = f.readline()
     if filename.upper().endswith('DTA'):
         #TwinMic single column file
         line = line0 * 1
-        line = line.replace('\r','')
-        line = line.replace('\n','')
-        line = line.replace('\t',' ')
-        s = line.split(' ')
+        line = line.replace(b'\r', b'')
+        line = line.replace(b'\n', b'')
+        line = line.replace(b'\t', b' ')
+        s = line.split(b' ')
         if len(s) == 2:
             if len(s[-1]) == 0:
                 try:
@@ -102,18 +102,18 @@ def Specfile(filename):
     line = line0
     while(len(line)):
         if len(line) > 1:
-            if line[0:2] == '#S':
-                if ('#SIGNALTYPE' in line) or \
-                   ('#SPECTRUM' in line):
-                    line = ""
+            if line[0:2] == b'#S':
+                if (b'#SIGNALTYPE' in line) or \
+                   (b'#SPECTRUM' in line):
+                    line = b""
                 break
-            elif line[0] not in ['#', ' ', '\r']:
-                line = ""
+            elif line[0] not in [b'#', b' ', b'\r']:
+                line = b""
                 break
         try:
             line = f.readline()
         except:
-            line = ""
+            line = b""
             break
     f.close()
     # end of specfile identification
@@ -129,13 +129,13 @@ def Specfile(filename):
     else:
         _logger.debug("this does not look as a specfile")
         if len(line0) > 7:
-            if line0.startswith('$SPEC_ID') or\
-               line0.startswith('$DATE_MEA') or\
-               line0.startswith('$MEAS_TIM') or\
-               line0.startswith('$Core_ID') or\
-               line0.startswith('$Section_ID'):
+            if line0.startswith(b'$SPEC_ID') or\
+               line0.startswith(b'$DATE_MEA') or\
+               line0.startswith(b'$MEAS_TIM') or\
+               line0.startswith(b'$Core_ID') or\
+               line0.startswith(b'$Section_ID'):
                 qxas = True
-        if (not qxas) and line0.startswith('<<'):
+        if (not qxas) and line0.startswith(b'<<'):
                 amptek = True
         if (not qxas) and (not amptek) and Fit2DChiFileParser.isFit2DChiFile(filename):
             return Fit2DChiFileParser.Fit2DChiFileParser(filename)

--- a/PyMca5/PyMcaIO/specfilewrapper.py
+++ b/PyMca5/PyMcaIO/specfilewrapper.py
@@ -75,15 +75,15 @@ else:
         return var[0]
 
 def Specfile(filename):
-    f = open(filename, "rb")
+    f = open(filename)
     line0  = f.readline()
     if filename.upper().endswith('DTA'):
         #TwinMic single column file
         line = line0 * 1
-        line = line.replace(b'\r', b'')
-        line = line.replace(b'\n', b'')
-        line = line.replace(b'\t', b' ')
-        s = line.split(b' ')
+        line = line.replace('\r','')
+        line = line.replace('\n','')
+        line = line.replace('\t',' ')
+        s = line.split(' ')
         if len(s) == 2:
             if len(s[-1]) == 0:
                 try:
@@ -102,18 +102,18 @@ def Specfile(filename):
     line = line0
     while(len(line)):
         if len(line) > 1:
-            if line[0:2] == b'#S':
-                if (b'#SIGNALTYPE' in line) or \
-                   (b'#SPECTRUM' in line):
-                    line = b""
+            if line[0:2] == '#S':
+                if ('#SIGNALTYPE' in line) or \
+                   ('#SPECTRUM' in line):
+                    line = ""
                 break
-            elif line[0] not in [b'#', b' ', b'\r']:
-                line = b""
+            elif line[0] not in ['#', ' ', '\r']:
+                line = ""
                 break
         try:
             line = f.readline()
         except:
-            line = b""
+            line = ""
             break
     f.close()
     # end of specfile identification
@@ -129,13 +129,13 @@ def Specfile(filename):
     else:
         _logger.debug("this does not look as a specfile")
         if len(line0) > 7:
-            if line0.startswith(b'$SPEC_ID') or\
-               line0.startswith(b'$DATE_MEA') or\
-               line0.startswith(b'$MEAS_TIM') or\
-               line0.startswith(b'$Core_ID') or\
-               line0.startswith(b'$Section_ID'):
+            if line0.startswith('$SPEC_ID') or\
+               line0.startswith('$DATE_MEA') or\
+               line0.startswith('$MEAS_TIM') or\
+               line0.startswith('$Core_ID') or\
+               line0.startswith('$Section_ID'):
                 qxas = True
-        if (not qxas) and line0.startswith(b'<<'):
+        if (not qxas) and line0.startswith('<<'):
                 amptek = True
         if (not qxas) and (not amptek) and Fit2DChiFileParser.isFit2DChiFile(filename):
             return Fit2DChiFileParser.Fit2DChiFileParser(filename)


### PR DESCRIPTION
Perform file type identification using byte strings to avoid decoding errors.

close #655 