### PR TITLE
fix fwhm calculation

### DIFF
--- a/PyMca5/PyMcaMath/SpecArithmetic.py
+++ b/PyMca5/PyMcaMath/SpecArithmetic.py
@@ -102,10 +102,10 @@ def search_fwhm(xdata,ydata,peak=None,index=None):
         while ydata[idx] >= hm:
             idx = idx+1
 
-        x0 = xdata[idx]
-        x1 = xdata[idx+1]
-        y0 = ydata[idx]
-        y1 = ydata[idx+1]
+        x0 = xdata[idx-1]
+        x1 = xdata[idx]
+        y0 = ydata[idx-1]
+        y1 = ydata[idx]
 
         uhmx = (hm*(x1-x0) - (y0*x1)+(y1*x0)) / (y1-y0)
     except ZeroDivisionError:


### PR DESCRIPTION
when doing the simple spec arithmetic I encountered a bug in the math which is only obvious for data with a few (1-2) points at the slope (plateau-like instead of gauss-like functions).

for finding the x-coordinates of the FWHM a `while` loop is run for the lower and upper side of the peak maximum to find the index of the first data point that is smaller than the half-max value.

in the subsequent linear interpolation one should then use one data point below and above the half-max value.
This PR fixes this issue for the upper side of the peak.