### PR TITLE
Rgb correlator apriori shape

### DIFF
--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -1325,11 +1325,10 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
                         "All Files (*)"]
         message = "Open ONE Batch result .dat file or SEVERAL EDF files"
         filelist = self.__getStackOfFiles(fileTypeList, message)
-        if not(len(filelist)):
-            return
-        filelist.sort()
-        self.sourceWidget.sourceSelector.lastInputDir = os.path.dirname(filelist[0])
-        PyMcaDirs.inputDir = os.path.dirname(filelist[0])
+        if filelist:
+            filelist.sort()
+            self.sourceWidget.sourceSelector.lastInputDir = os.path.dirname(filelist[0])
+            PyMcaDirs.inputDir = os.path.dirname(filelist[0])
         self.__correlator.append(PyMcaPostBatch.PyMcaPostBatch())
         for correlator in self.__correlator:
             if correlator.isHidden():
@@ -1337,7 +1336,8 @@ class PyMcaMain(PyMcaMdi.PyMcaMdi):
             correlator.raise_()
         self.__correlator[-1].sigRGBCorrelatorSignal.connect( \
                 self._deleteCorrelator)
-        correlator.addFileList(filelist)
+        if filelist:
+            correlator.addFileList(filelist)
 
     def __sumRules(self):
         if self.__correlator is None:

--- a/PyMca5/PyMcaGui/pymca/PyMcaPostBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaPostBatch.py
@@ -131,11 +131,11 @@ def main():
     w.layout().setContentsMargins(11, 11, 11, 11)
     if not filelist:
         filelist = w._getStackOfFiles()
-    if not filelist:
+    if filelist:
+        w.addFileList(filelist)
+    else:
         print("Usage:")
         print("python PyMcaPostBatch.py PyMCA_BATCH_RESULT_DOT_DAT_FILE")
-        sys.exit(app.quit())
-    w.addFileList(filelist)
     if transpose:
         w.transposeImages()
     w.show()

--- a/PyMca5/PyMcaGui/pymca/PyMcaPostBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaPostBatch.py
@@ -101,12 +101,13 @@ def main():
     import getopt
     options = ''
     longoptions = ["nativefiledialogs=", "transpose=", "fileindex=",
-                   "logging=", "debug="]
+                   "logging=", "debug=", "shape="]
     opts, args = getopt.getopt(
                     sys.argv[1:],
                     options,
                     longoptions)
     transpose = False
+    image_shape = None
     for opt, arg in opts:
         if opt in '--nativefiledialogs':
             if int(arg):
@@ -119,11 +120,14 @@ def main():
         elif opt in '--fileindex':
             if int(arg):
                 transpose = True
+        elif opt in '--shape':
+            image_shape = tuple(int(n) for n in arg.split(','))
+            print(image_shape)
 
     logging.basicConfig(level=getLoggingLevel(opts))
 
     filelist = args
-    w = PyMcaPostBatch()
+    w = PyMcaPostBatch(image_shape=image_shape)
     w.layout().setContentsMargins(11, 11, 11, 11)
     if not filelist:
         filelist = w._getStackOfFiles()

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
@@ -49,7 +49,7 @@ class RGBCorrelator(qt.QWidget):
 
     sigRGBCorrelatorSignal = qt.pyqtSignal(object)
     
-    def __init__(self, parent = None, graph = None, bgrx = True):
+    def __init__(self, parent = None, graph = None, bgrx = True, image_shape=None):
         qt.QWidget.__init__(self, parent)
         self.setWindowTitle("PyMca RGB Correlator")
         self.setWindowIcon(qt.QIcon(qt.QPixmap(RGBCorrelatorGraph.IconDict['gioconda16'])))
@@ -58,7 +58,7 @@ class RGBCorrelator(qt.QWidget):
         self.mainLayout.setSpacing(6)
         self.splitter   = qt.QSplitter(self)
         self.splitter.setOrientation(qt.Qt.Horizontal)
-        self.controller = RGBCorrelatorWidget.RGBCorrelatorWidget(self.splitter)
+        self.controller = RGBCorrelatorWidget.RGBCorrelatorWidget(self.splitter, image_shape=image_shape)
         self._y1AxisInverted = False
         self._imageBuffer = None
         self._matplotlibSaveImage = None

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -700,7 +700,6 @@ class RGBCorrelatorWidget(qt.QWidget):
         self.addImageSlot(ddict)
 
     def _imageResizeSlot(self):
-        if self.__imageLength is None: return
         dialog = ImageShapeDialog(self, shape = self.__imageShape)
         dialog.setModal(True)
         ret = dialog.exec_()
@@ -721,11 +720,10 @@ class RGBCorrelatorWidget(qt.QWidget):
 
 
     def setImageShape(self, shape):
-        if self.__imageLength is None: return
-        length = 1
-        for value in shape:
-            length *= value
-        if length != self.__imageLength:
+        length = numpy.prod(shape, dtype=int)
+        if self.__imageLength is None:
+            self.__imageLength = length
+        elif length != self.__imageLength:
             raise ValueError("New length %d different of old length %d" % \
                     (length, self.__imageLength))
         self.__imageShape = shape
@@ -1459,13 +1457,19 @@ class ImageShapeDialog(qt.QDialog):
         self.okButton.clicked.connect(self.accept)
 
     def _rowsChanged(self):
+        if not self._size:
+            return
         nrows, ncolumns = self.getImageShape()
-        if (nrows * ncolumns) != self._size:
+        size = nrows * ncolumns
+        if size and size != self._size:
             self.columns.setText("%g" % (self._size/float(nrows)))
 
     def _columnsChanged(self):
+        if not self._size:
+            return
         nrows, ncolumns = self.getImageShape()
-        if (nrows * ncolumns) != self._size:
+        size = nrows * ncolumns
+        if size and size != self._size:
             self.rows.setText("%g" % (self._size/float(ncolumns)))
 
     def getImageShape(self):

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -160,7 +160,7 @@ class RGBCorrelatorWidget(qt.QWidget):
 
     sigRGBCorrelatorWidgetSignal = qt.pyqtSignal(object)
 
-    def __init__(self, parent = None, bgrx = False, replace = False):
+    def __init__(self, parent = None, bgrx = False, replace = False, image_shape=None):
         qt.QWidget.__init__(self, parent)
         self.replaceOption = replace
         self.setWindowTitle("RGBCorrelatorWidget")
@@ -279,7 +279,14 @@ class RGBCorrelatorWidget(qt.QWidget):
             self.bgrx = "RGBX"
         self._imageList = []
         self._imageDict = {}
-        self.__imageLength = None
+        if image_shape:
+            self.__imageLength = numpy.prod(image_shape, dtype=int)
+            self.__imageShape = tuple(image_shape)
+        else:
+            self.__imageLength = None
+            self.__imageShape = None
+        self.__imageLengthOriginal = self.__imageLength
+        self.__imageShapeOriginal = self.__imageShape
         self.__redLabel = None
         self.__greenLabel = None
         self.__blueLabel = None
@@ -763,8 +770,8 @@ class RGBCorrelatorWidget(qt.QWidget):
         self._tableSlot({'r':[],'g':[],'b':[]})
         self._imageList = []
         self._imageDict = {}
-        self.__imageLength = None
-        self.__imageShape = None
+        self.__imageLength = self.__imageLengthOriginal
+        self.__imageShape = self.__imageShapeOriginal
         self.__redLabel    = None
         self.__greenLabel  = None
         self.__blueLabel   = None


### PR DESCRIPTION
Closes #729 

Add image shape to `pymcapostbatch` CLI:

```python
pymcapostbatch --shape=68,101 filename.h5::1.1/measurement
```

In addition the RGB correlator window is opened when no images are specified. Useful in case you want to specify the shape (with the "reshape" button) before loading images when launching the RGB correlator from the main GUI.