### PR TITLE
[HDF5] HDF5Widget disable automatic scrolling

### DIFF
--- a/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -711,6 +711,8 @@ class HDF5Widget(FileView):
     def __init__(self, model, parent=None):
         FileView.__init__(self, model, parent)
         self.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
+        self.setAutoScroll(False)
+
         self._adjust()
         if 0:
             self.activated[qt.QModelIndex].connect(self.itemActivated)


### PR DESCRIPTION
Avoids the problem reported in https://bugreports.qt.io/browse/QTBUG-5115

Without this modification, when selecting the description, the horizontal bar shifts and the first column is hidden.