### PR TITLE
[IO] Integrate beamline feedback

### DIFF
--- a/PyMca5/PyMcaCore/RedisTools.py
+++ b/PyMca5/PyMcaCore/RedisTools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2019-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2019-2021 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -71,7 +71,7 @@ def get_node_list(node, node_type=None, name=None, db_name=None, dimension=None,
     output_list = []
     # walk not waiting
     if node_type or name or db_name or dimension:
-        for node in iterator(wait=False, filter=filter):
+        for node in iterator(wait=False, include_filter=filter):
             if ignore_underscore and hasattr(node.name, "startswith") and node.name.startswith("_"):
                 continue
             if not _check_dimension(node, dimension):
@@ -87,7 +87,7 @@ def get_node_list(node, node_type=None, name=None, db_name=None, dimension=None,
             if unique and len(output_list):
                 break
     else:
-        for node in iterator(wait=False, filter=filter):
+        for node in iterator(wait=False, include_filter=filter):
             #print(node.name, node.db_name, node)
             if ignore_underscore and hasattr(node.name, "startswith") and node.name.startswith("_"):
                 continue

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -985,7 +985,16 @@ class QNexusWidget(qt.QWidget):
                     else:
                         actualDatasetPath = posixpath.join(entry,
                                                 cntSelection['cntlist'][yCnt])
-                    actualDataset = phynxFile[actualDatasetPath]
+                    try:
+                        actualDataset = phynxFile[actualDatasetPath]
+                    except KeyError:
+                        # filter x.1 and x.2 ESRF case
+                        if len(entryList) > 4:
+                            _logger.info("Ignoring %s in %s" % \
+                                         (actualDatasetPath, entry))
+                            continue
+                        else:
+                            raise
                     sel['scanselection'] = True
                     if hasattr(actualDataset, "shape"):
                         if len(actualDataset.shape) > 1:

--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2021 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.

--- a/PyMca5/PyMcaIO/BlissSpecFile.py
+++ b/PyMca5/PyMcaIO/BlissSpecFile.py
@@ -345,8 +345,13 @@ class BlissSpecScan(object):
         self._read_counters()
         counters = self._counters
         if len(counters):
-            key = list(counters.keys())[0]
-            return len(counters[key])
+            nlines = 0
+            keyList = list(counters.keys())
+            for key in keyList:
+                n = len(counters[key])
+                if n > nlines:
+                    nlines = n 
+            return nlines
         else:
             return 0
 

--- a/PyMca5/PyMcaIO/BlissSpecFile.py
+++ b/PyMca5/PyMcaIO/BlissSpecFile.py
@@ -3,7 +3,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020-2021 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.


### PR DESCRIPTION
- Correct deprecation warning concerning the use of filter as keyword
- Adjust the number of points to the maximum of points in a counter
- Handle selection covering different masters by not raising an exception if the number of selected scans is above four. The selection is simply ignored.