### PR TITLE
Verify risk of overwriting input file when choosing output directory

### DIFF
--- a/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -124,6 +124,14 @@ class QNexusWidget(qt.QWidget):
         self._BUTTONS = buttons
         self.build()
 
+    def sizeHint(self):
+        originalHint = qt.QWidget.sizeHint(self)
+        if isinstance(self.parent(), qt.QDialog):
+            return qt.QSize(2 * originalHint.width(),
+                            originalHint.height())
+        else:
+            return qt.QSize(originalHint.width(),
+                            originalHint.height())
     def build(self):
         self.mainLayout = qt.QVBoxLayout(self)
         self.mainLayout.setContentsMargins(5, 5, 5, 0)

--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -1098,6 +1098,22 @@ class McaBatchGUI(qt.QWidget):
                 else:
                     self.raise_()
                 return False
+        if len(self.fileList) == 1:
+            if HDF5SUPPORT:
+                try:
+                    if h5py.is_hdf5(self.fileList[0]):
+                        if os.path.dirname(os.path.abspath(self.fileList[0])) == \
+                           os.path.abspath(outputdir):
+                            msg = "Please specify a different output directory.\n"
+                            msg += "Risk of overwritting input file."
+                            qt.QMessageBox.critical(self,"ERROR", msg)
+                            if QTVERSION < '4.0.0':
+                                self.raiseW()
+                            else:
+                                self.raise_()
+                            return False
+                except:
+                    _logger.warning("Cannot verify suitability of output directory")
         return True
 
     def __getFileType(self,inputfile):

--- a/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
+++ b/PyMca5/PyMcaPhysics/xrf/McaAdvancedFitBatch.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -330,8 +330,13 @@ class McaAdvancedFitBatch(object):
                         # if (len(self._filelist) == 1) && (self.mcaStep > 1)
                         # it should attempt to avoid loading  many times
                         # the stack into memory in case of multiple processes
+                        if len(self._filelist) == 1:
+                            scanlist = self.selection.get("entry", None)
+                        else:
+                            scanlist = None
                         return HDF5Stack1D.HDF5Stack1D(self._filelist,
-                                                       self.selection)
+                                                       self.selection,
+                                                       scanlist=scanlist)
                     except:
                         raise
 


### PR DESCRIPTION
The risk appears when there is only one HDF5 file to fit and the output directory is the directory containing that file.

closes #800 
completes PR #802 