### PR TITLE
fix: protect `HDF5Widget.emitSignal()` when mouse was not pressed yet

### DIFF
--- a/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -827,10 +827,7 @@ class HDF5Widget(FileView):
         ddict['dtype'] = item.dtype
         ddict['shape'] = item.shape
         ddict['color'] = item.color
-        mouse = None
-        if hasattr(self, '_lastMouse'):
-            mouse = self._lastMouse * 1
-        ddict['mouse'] = mouse
+        ddict['mouse'] = getattr(self, '_lastMouse', 'left') * 1
         self.sigHDF5WidgetSignal.emit(ddict)
 
     def getSelectedEntries(self):

--- a/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -827,7 +827,10 @@ class HDF5Widget(FileView):
         ddict['dtype'] = item.dtype
         ddict['shape'] = item.shape
         ddict['color'] = item.color
-        ddict['mouse'] = self._lastMouse * 1
+        mouse = None
+        if hasattr(self, '_lastMouse'):
+            mouse = self._lastMouse * 1
+        ddict['mouse'] = mouse
         self.sigHDF5WidgetSignal.emit(ddict)
 
     def getSelectedEntries(self):


### PR DESCRIPTION
`_lastMouse` attribute does not exist if the mouse was never pressed in the widget lifetime. This causes troubles e.g. when one sets current index (`setCurrentIndex()`) which leads to `emitSignal()`.
Protect `emitSignal()` against non existing `_lastMouse` attribute.