### PR TITLE
Correct HTML report generation

### DIFF
--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1847,7 +1847,7 @@ class McaBatchWindow(qt.QWidget):
             except:
                 _logger.warning("ERROR on REPORT %s", sys.exc_info())
                 _logger.warning("%s", sys.exc_info()[1])
-                _logger.warning("filename = %s key =%s ", (filename, key))
+                _logger.warning("filename = %s key =%s " , filename, key)
                 _logger.warning("If your batch is stopped, please report this")
                 _logger.warning("error sending the above mentioned file and the")
                 _logger.warning("associated fit configuration file.")

--- a/PyMca5/PyMcaPhysics/xrf/ConcentrationsTool.py
+++ b/PyMca5/PyMcaPhysics/xrf/ConcentrationsTool.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -67,12 +67,16 @@ class ConcentrationsConversion(object):
             text += "<br>"
             labels = ['Element', 'Group', 'Fit Area', 'Sigma Area']
             if mmolarflag:
-                labels += 'mM concentration'
+                labels += ['mM concentration']
             else:
-                labels += 'Mass fraction'
+                labels += ['Mass fraction']
 
             #the table
             if 'layerlist' in result:
+                # somehow the new McaAdvancedFitBatch sends an empty string
+                # instead of an empty list like the McaAdvancedFitWindow
+                if result['layerlist'] == "":
+                    result['layerlist'] = []
                 if type(result['layerlist']) != type([]):
                     result['layerlist'] = [result['layerlist']]
                 for label in result['layerlist']:
@@ -155,6 +159,8 @@ class ConcentrationsConversion(object):
             else:
                 labels += ['Mass_fraction']
             if 'layerlist' in result:
+                if result['layerlist'] == "":
+                    result['layerlist'] = []
                 if type(result['layerlist']) != type([]):
                     result['layerlist'] = [result['layerlist']]
                 for label in result['layerlist']:


### PR DESCRIPTION
Error generating HTML report with concentrations selected reported at mailing list

https://sourceforge.net/p/pymca/mailman/message/37410891/

```
WARNING:__main__:ERROR on REPORT (<class 'KeyError'>, KeyError('',), <traceback object at 0x0000027FAC6F8A08>)
WARNING:__main__:''
--- Logging error ---
Traceback (most recent call last):
  File "build\tmp\PyMcaBatch.py", line 1847, in onMca
  File "build\tmp\PyMcaBatch.py", line 1935, in __htmlReport
  File "C:\Program Files\PyMca 5.6.7\PyMca5\PyMcaGui\physics\xrf\QtMcaAdvancedFitReport.py", line 119, in writeReport
    text = self.getText()
  File "C:\Program Files\PyMca 5.6.7\PyMca5\PyMcaGui\physics\xrf\QtMcaAdvancedFitReport.py", line 168, in getText
    text+=self.getConcentrations()
  File "C:\Program Files\PyMca 5.6.7\PyMca5\PyMcaGui\physics\xrf\QtMcaAdvancedFitReport.py", line 662, in getConcentrations
    self.concentrations)
  File "C:\Program Files\PyMca 5.6.7\PyMca5\PyMcaPhysics\xrf\ConcentrationsTool.py", line 115, in getConcentrationsAsHtml
    if result[layer]['mass fraction'][group] < 0.0:
KeyError: ''

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 994, in emit
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 840, in format
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 577, in format
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 338, in getMessage
TypeError: not enough arguments for format string
Call stack:
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\initscripts\__startup__.py", line 14, in run
  File "C:\Program Files\Python36\lib\site-packages\cx_Freeze\initscripts\Console.py", line 26, in run
  File "build\tmp\PyMcaBatch.py", line 2228, in <module>
  File "build\tmp\PyMcaBatch.py", line 2220, in main
  File "build\tmp\PyMcaBatch.py", line 1759, in customEvent
  File "build\tmp\PyMcaBatch.py", line 1854, in onMca
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 1320, in warning
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 1444, in _log
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 1454, in handle
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 1516, in callHandlers
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 865, in handle
  File "C:\Program Files\Python36\lib\logging\__init__.py", line 1000, in emit
Message: 'filename = %s key =%s '
Arguments: (('18031920.mca', '1.1.00001.1'),)
WARNING:__main__:If your batch is stopped, please report this
WARNING:__main__:error sending the above mentioned file and the
WARNING:__main__:associated fit configuration file.
WARNING:__main__:ERROR on REPORT (<class 'KeyError'>, KeyError('',), <traceback object at 0x0000027FABF3AF48>)
WARNING:__main__:''
```