### PR TITLE
Modify imports to make the code PyInstaller friendly

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include LICENSE.LGPL
 include changelog.txt
 include qtconffile
 include cx_setup.py
+include PyMca.txt
 include py2app_setup.py
 include PlatypusScript
 include nsisscript.nsi.in

--- a/PyMca5/PyMcaGui/io/QEdfFileWidget.py
+++ b/PyMca5/PyMcaGui/io/QEdfFileWidget.py
@@ -33,7 +33,7 @@ import numpy
 import logging
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PlotWidget
+from PyMca5.PyMcaGui.plotting import PlotWidget
 
 
 if not hasattr(qt, 'QString'):
@@ -44,11 +44,11 @@ else:
     QStringList = qt.QStringList
 QTVERSION = qt.qVersion()
 QT4=True
-from PyMca5.PyMcaGui import QPyMcaMatplotlibSave
+from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave
 MATPLOTLIB = True
-from PyMca5.PyMcaGui import IconDict
-from PyMca5.PyMcaGui import ColormapDialog
-from PyMca5.PyMcaGui import PyMcaPrintPreview
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
+from PyMca5.PyMcaGui.plotting import ColormapDialog
+from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview
 from PyMca5.PyMcaIO import ArraySave
 from PyMca5 import PyMcaDirs
 from . import SpecFileDataInfo

--- a/PyMca5/PyMcaGui/io/QSourceSelector.py
+++ b/PyMca5/PyMcaGui/io/QSourceSelector.py
@@ -34,7 +34,7 @@ _logger = logging.getLogger(__name__)
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
 QTVERSION = qt.qVersion()
-from PyMca5.PyMcaGui import PyMca_Icons as icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons as icons
 from PyMca5.PyMcaIO import spswrap as sps
 from PyMca5 import PyMcaDirs
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs

--- a/PyMca5/PyMcaGui/io/QSpsWidget.py
+++ b/PyMca5/PyMcaGui/io/QSpsWidget.py
@@ -31,9 +31,9 @@ import logging
 from PyMca5.PyMcaIO import spswrap as sps
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaGui.io import SpecFileCntTable
-from PyMca5.PyMcaGui import MaskImageWidget
+from PyMca5.PyMcaGui.plotting import MaskImageWidget
 QTVERSION = qt.qVersion()
-from PyMca5.PyMcaGui import PyMca_Icons as icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons as icons
 
 _logger = logging.getLogger(__name__)
 

--- a/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetTable.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5DatasetTable.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,13 +23,13 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import CloseEventNotifyingWidget
-from PyMca5.PyMcaGui import NumpyArrayTableWidget
+from PyMca5.PyMcaGui.misc import CloseEventNotifyingWidget
+from PyMca5.PyMcaGui.misc import NumpyArrayTableWidget
 
 class HDF5DatasetTable(CloseEventNotifyingWidget.CloseEventNotifyingWidget):
     def __init__(self, parent=None):

--- a/PyMca5/PyMcaGui/io/hdf5/Hdf5NodeView.py
+++ b/PyMca5/PyMcaGui/io/hdf5/Hdf5NodeView.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ import os
 
 import PyMca5
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import CloseEventNotifyingWidget
+from PyMca5.PyMcaGui.misc import CloseEventNotifyingWidget
 
 from PyMca5.PyMcaGui.PluginsToolButton import PluginsToolButton
 

--- a/PyMca5/PyMcaGui/math/FFTAlignmentWindow.py
+++ b/PyMca5/PyMcaGui/math/FFTAlignmentWindow.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,15 +24,15 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import ExternalImagesWindow
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.pymca import ExternalImagesWindow
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 
 class ParametersWidget(qt.QWidget):
     parametersWidgetSignal = qt.pyqtSignal(object)

--- a/PyMca5/PyMcaGui/math/PCAWindow.py
+++ b/PyMca5/PyMcaGui/math/PCAWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,19 +23,19 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import MaskImageWidget
-from PyMca5.PyMcaGui import ScanWindow
+from PyMca5.PyMcaGui.plotting import MaskImageWidget
+from PyMca5.PyMcaGui.pymca import ScanWindow
 from PyMca5.PyMcaMath.mva import PCAModule
-from PyMca5.PyMcaGui import ScatterPlotCorrelatorWidget
+from PyMca5.PyMcaGui.plotting import ScatterPlotCorrelatorWidget
 
 if hasattr(qt, "QString"):
     QString = qt.QString

--- a/PyMca5/PyMcaGui/math/SGWindow.py
+++ b/PyMca5/PyMcaGui/math/SGWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,9 +29,9 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import ScanWindow
+from PyMca5.PyMcaGui.pymca import ScanWindow
 from PyMca5.PyMcaMath import SGModule
 
 

--- a/PyMca5/PyMcaGui/math/SIFTAlignmentWindow.py
+++ b/PyMca5/PyMcaGui/math/SIFTAlignmentWindow.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2019 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,15 +24,15 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import os
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import ExternalImagesWindow
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.plotting import ExternalImagesWindow
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 import pyopencl
 import silx.opencl
 from silx.image import sift

--- a/PyMca5/PyMcaGui/math/SNIPWindow.py
+++ b/PyMca5/PyMcaGui/math/SNIPWindow.py
@@ -29,10 +29,10 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import MaskImageWidget
-from PyMca5.PyMcaGui import ScanWindow
+from PyMca5.PyMcaGui.plotting import MaskImageWidget
+from PyMca5.PyMcaGui.pymca import ScanWindow
 from PyMca5.PyMcaMath import SNIPModule
 #TODO: Add this functionality using SilxGLWindow
 OBJECT3D = False

--- a/PyMca5/PyMcaGui/math/StripBackgroundWidget.py
+++ b/PyMca5/PyMcaGui/math/StripBackgroundWidget.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,14 +23,14 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PlotWindow
+from PyMca5.PyMcaGui.plotting import PlotWindow
 from PyMca5.PyMcaMath.fitting import SpecfitFuns
 
 

--- a/PyMca5/PyMcaGui/math/fitting/RateLawWindow.py
+++ b/PyMca5/PyMcaGui/math/fitting/RateLawWindow.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -34,9 +34,9 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import PlotWindow
+from PyMca5.PyMcaGui.plotting import PlotWindow
 from PyMca5.PyMcaMath.fitting import RateLaw
 
 class RateLawWindow(qt.QMainWindow):

--- a/PyMca5/PyMcaGui/math/fitting/SimpleFitBatchGui.py
+++ b/PyMca5/PyMcaGui/math/fitting/SimpleFitBatchGui.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,16 +24,16 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import os
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting import IconDict
 from PyMca5 import PyMcaDirs
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 PyMcaDirs.nativeFileDialogs = False
 QTVERSION = qt.qVersion()
 HDF5SUPPORT = True

--- a/PyMca5/PyMcaGui/math/fitting/SimpleFitConfigurationGui.py
+++ b/PyMca5/PyMcaGui/math/fitting/SimpleFitConfigurationGui.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2019 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -46,7 +46,7 @@ except ImportError:
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaIO import ConfigDict
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
-from PyMca5.PyMcaGui import PyMca_Icons as Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons as Icons
 from PyMca5 import PyMcaDirs
 if h5py is not None:
     from PyMca5.PyMcaGui.io.hdf5 import HDF5Widget

--- a/PyMca5/PyMcaGui/math/fitting/SpecfitGui.py
+++ b/PyMca5/PyMcaGui/math/fitting/SpecfitGui.py
@@ -34,7 +34,7 @@ import logging
 from PyMca5.PyMcaCore import EventHandler
 from PyMca5.PyMcaMath.fitting import Specfit
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 
 QTVERSION = qt.qVersion()
 from . import FitConfigGui

--- a/PyMca5/PyMcaGui/physics/xas/XASFourierTransformParameters.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASFourierTransformParameters.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,13 +26,13 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/physics/xas/XASNormalizationParameters.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASNormalizationParameters.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -34,9 +34,9 @@ import os
 import sys
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
-from PyMca5.PyMcaGui import XASNormalizationWindow
-from PyMca5.PyMca import XASNormalization
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
+from PyMca5.PyMcaGui.physics.xas import XASNormalizationWindow
+from PyMca5.PyMcaPhysics.xas import XASNormalization
 IconDict = PyMca_Icons.IconDict
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASNormalizationWindow.py
@@ -35,12 +35,12 @@ import numpy
 import traceback
 import copy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from PyMca5.PyMcaGraph.backends.MatplotlibBackend \
      import MatplotlibBackend as backend
-from PyMca5.PyMcaGui import PlotWindow
-from PyMca5.PyMcaPhysics import XASNormalization
+from PyMca5.PyMcaGui.plotting import PlotWindow
+from PyMca5.PyMcaPhysics.xas import XASNormalization
 
 POLYNOM_OPTIONS = ['Modif. Victoreen',
                    'Victoreen',

--- a/PyMca5/PyMcaGui/physics/xas/XASParameters.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASParameters.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,19 +26,19 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import XASNormalizationParameters
-from PyMca5.PyMcaGui import XASPostEdgeParameters
-from PyMca5.PyMcaGui import XASFourierTransformParameters
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.physics.xas import XASNormalizationParameters
+from PyMca5.PyMcaGui.physics.xas import XASPostEdgeParameters
+from PyMca5.PyMcaGui.physics.xas import XASFourierTransformParameters
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaIO import ConfigDict
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/physics/xas/XASPostEdgeParameters.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASPostEdgeParameters.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,13 +26,13 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/physics/xas/XASSelfattenuationWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASSelfattenuationWindow.py
@@ -3,10 +3,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,13 +27,13 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaPhysics.xrf import Elements
 from PyMca5.PyMcaGui.physics.xrf import MatrixImage
 from PyMca5.PyMcaGui.physics.xrf import MaterialEditor

--- a/PyMca5/PyMcaGui/physics/xas/XASWindow.py
+++ b/PyMca5/PyMcaGui/physics/xas/XASWindow.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -36,12 +36,12 @@ import numpy
 import traceback
 import copy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import PlotWindow
-from PyMca5.PyMcaGui import XASParameters
+from PyMca5.PyMcaGui.plotting import PlotWindow
+from PyMca5.PyMcaGui.physics.xas import XASParameters
 
-from PyMca5.PyMca import XASClass
+from PyMca5.PyMcaPhysics.xas import XASClass
 import logging
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/physics/xrf/EnergyTable.py
+++ b/PyMca5/PyMcaGui/physics/xrf/EnergyTable.py
@@ -36,8 +36,8 @@ import numpy
 import logging
 from . import QXTube
 from PyMca5.PyMcaCore import PyMcaDirs
-from PyMca5.PyMcaGui import PyMca_Icons as Icons
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.plotting import PyMca_Icons as Icons
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 qt = QXTube.qt
 
 QTVERSION = qt.qVersion()

--- a/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FastXRFLinearFitWindow.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,10 +32,10 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from PyMca5.PyMcaGui import PyMcaFileDialogs
-from PyMca5.PyMcaGui import ConfigurationFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import ConfigurationFileDialogs
 try:
     import h5py
     hasH5py = True

--- a/PyMca5/PyMcaGui/physics/xrf/FitParam.py
+++ b/PyMca5/PyMcaGui/physics/xrf/FitParam.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "E. Papillon & V. Armando Sole - ESRF Software Group"
+__author__ = "E. Papillon & V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -37,7 +37,7 @@ from PyMca5.PyMcaGui import PyMcaQt as qt
 QTVERSION = qt.qVersion()
 
 from PyMca5.PyMcaIO import ConfigDict
-from PyMca5.PyMcaGui import PyMca_Icons as Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons as Icons
 import os.path
 import copy
 from PyMca5.PyMcaPhysics import Elements
@@ -59,7 +59,7 @@ except ImportError:
     # no XRFMC support
     pass
 from PyMca5.PyMcaGui.math import StripBackgroundWidget
-from PyMca5.PyMcaGui import PlotWindow
+from PyMca5.PyMcaGui.plotting import PlotWindow
 from PyMca5.PyMcaGui.physics.xrf import StrategyHandler
 import numpy
 

--- a/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -48,7 +48,7 @@ else:
 
 QTVERSION = qt.qVersion()
 
-from PyMca5.PyMcaGui import QPyMcaMatplotlibSave1D
+from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave1D
 MATPLOTLIB = True
 #force understanding of utf-8 encoding
 #otherways it cannot generate svg output
@@ -67,19 +67,19 @@ from . import McaAdvancedTable
 from . import QtMcaAdvancedFitReport
 from . import ConcentrationsWidget
 from PyMca5.PyMcaPhysics.xrf import ConcentrationsTool
-from PyMca5.PyMcaGui import PlotWindow
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PlotWindow
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from . import McaCalWidget
 from . import PeakIdentifier
-from PyMca5.PyMcaGui import SubprocessLogWidget
+from PyMca5.PyMcaGui.misc import SubprocessLogWidget
 from . import ElementsInfo
 Elements = ElementsInfo.Elements
 #import McaROIWidget
-from PyMca5.PyMcaGui import PyMcaPrintPreview
+from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview
 from PyMca5.PyMcaCore import PyMcaDirs
 from PyMca5.PyMcaIO import ConfigDict
-from PyMca5.PyMcaGui import CalculationThread
+from PyMca5.PyMcaGui.misc import CalculationThread
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaAdvancedFit.py
@@ -62,18 +62,18 @@ from PyMca5.PyMcaPhysics.xrf import ClassMcaTheory
 FISX = ClassMcaTheory.FISX
 if FISX:
     FisxHelper = ClassMcaTheory.FisxHelper
-from . import FitParam
-from . import McaAdvancedTable
-from . import QtMcaAdvancedFitReport
-from . import ConcentrationsWidget
+from PyMca5.PyMcaGui.physics.xrf import FitParam
+from PyMca5.PyMcaGui.physics.xrf import McaAdvancedTable
+from PyMca5.PyMcaGui.physics.xrf import QtMcaAdvancedFitReport
+from PyMca5.PyMcaGui.physics.xrf import ConcentrationsWidget
 from PyMca5.PyMcaPhysics.xrf import ConcentrationsTool
 from PyMca5.PyMcaGui.plotting import PlotWindow
 from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
-from . import McaCalWidget
-from . import PeakIdentifier
+from PyMca5.PyMcaGui.physics.xrf import McaCalWidget
+from PyMca5.PyMcaGui.physics.xrf import PeakIdentifier
 from PyMca5.PyMcaGui.misc import SubprocessLogWidget
-from . import ElementsInfo
+from PyMca5.PyMcaGui.physics.xrf import ElementsInfo
 Elements = ElementsInfo.Elements
 #import McaROIWidget
 from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview

--- a/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
@@ -38,7 +38,7 @@ import copy
 import logging
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui.PlotWidget import PlotWidget
+from PyMca5.PyMcaGui.plotting.PlotWidget import PlotWidget
 
 if hasattr(qt, "QString"):
     QString = qt.QString
@@ -48,7 +48,7 @@ QTVERSION = qt.qVersion()
 from PyMca5.PyMcaMath.fitting import Gefit
 from PyMca5.PyMcaMath.fitting import Specfit
 from PyMca5.PyMcaMath.fitting import SpecfitFuns
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from . import PeakTableWidget
 if 0:

--- a/PyMca5/PyMcaGui/physics/xrf/PeakIdentifier.py
+++ b/PyMca5/PyMcaGui/physics/xrf/PeakIdentifier.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -34,7 +34,7 @@ import sys
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaPhysics import Elements
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 QTVERSION = qt.qVersion()
 

--- a/PyMca5/PyMcaGui/physics/xrf/QXTube.py
+++ b/PyMca5/PyMcaGui/physics/xrf/QXTube.py
@@ -31,8 +31,8 @@ __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import logging
-from PyMca5.PyMcaPhysics import Elements
-from PyMca5.PyMcaPhysics import XRayTubeEbel
+from PyMca5.PyMcaPhysics.xrf import Elements
+from PyMca5.PyMcaPhysics.xrf import XRayTubeEbel
 import numpy
 from PyMca5.PyMcaGui.plotting.PlotWindow import PlotWindow
 from PyMca5.PyMcaGui import PyMcaQt as qt

--- a/PyMca5/PyMcaGui/physics/xrf/StrategyHandler.py
+++ b/PyMca5/PyMcaGui/physics/xrf/StrategyHandler.py
@@ -34,9 +34,9 @@ import sys
 import copy
 import logging
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaPhysics import Elements
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 from PyMca5.PyMcaIO import ConfigDict
 from .MaterialEditor import MaterialComboBox
 

--- a/PyMca5/PyMcaGui/physics/xrf/TransmissionTableEditor.py
+++ b/PyMca5/PyMcaGui/physics/xrf/TransmissionTableEditor.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ import numpy
 import traceback
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaCore import PyMcaDirs
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaIO import specfilewrapper as specfile
 from PyMca5.PyMcaIO import ArraySave
 

--- a/PyMca5/PyMcaGui/physics/xrf/XRFMCPyMca.py
+++ b/PyMca5/PyMcaGui/physics/xrf/XRFMCPyMca.py
@@ -37,7 +37,7 @@ import traceback
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5 import PyMcaDirs as xrfmc_dirs
 from PyMca5.PyMcaIO import ConfigDict
-from PyMca5.PyMcaGui import SubprocessLogWidget
+from PyMca5.PyMcaGui.misc import SubprocessLogWidget
 from PyMca5.PyMcaPhysics.xrf.XRFMC import XRFMCHelper
 
 QTVERSION = qt.qVersion()

--- a/PyMca5/PyMcaGui/plotting/MaskImageTools.py
+++ b/PyMca5/PyMcaGui/plotting/MaskImageTools.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -253,7 +253,7 @@ def applyMaskToImage(pixmap, mask=None, colors=None, copy=True):
 
 if __name__ == "__main__":
     from PyMca5.PyMcaGui import PyMcaQt as qt
-    from PyMca5.PyMcaGui import PlotWidget
+    from PyMca5.PyMcaGui.plotting import PlotWidget
     app = qt.QApplication([])
     w = PlotWidget.PlotWidget()
     data = numpy.arange(10000.).reshape(100, 100)

--- a/PyMca5/PyMcaGui/pymca/EdfFileSimpleViewer.py
+++ b/PyMca5/PyMcaGui/pymca/EdfFileSimpleViewer.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2019 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -34,9 +34,10 @@ from PyMca5.PyMcaGui import PyMcaQt as qt
 QTVERSION = qt.qVersion()
 _logger = logging.getLogger(__name__)
 
-from PyMca5.PyMcaGui import QSourceSelector
+from PyMca5.PyMcaGui.io import QSourceSelector
 from PyMca5.PyMcaGui.pymca import QDataSource
-from PyMca5.PyMcaGui import QEdfFileWidget
+from PyMca5.PyMcaGui.io import QEdfFileWidget
+
 class EdfFileSimpleViewer(qt.QWidget):
     def __init__(self, parent=None):
         qt.QWidget.__init__(self, parent)

--- a/PyMca5/PyMcaGui/pymca/ExternalImagesStackPluginBase.py
+++ b/PyMca5/PyMcaGui/pymca/ExternalImagesStackPluginBase.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2019 European Synchrotron Radiation Facility
+# Copyright (c) 2019-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,14 +36,14 @@ import logging
 from PyMca5 import StackPluginBase
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaIO import EDFStack
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 try:
     import h5py
 except ImportError:
     HAS_H5PY = False
 else:
     HAS_H5PY = True
-    from PyMca5.PyMca import HDF5Widget
+    from PyMca5.PyMcaGui.io.hdf5 import HDF5Widget
     from PyMca5.PyMcaIO import NexusUtils
 
 _logger = logging.getLogger(__name__)

--- a/PyMca5/PyMcaGui/pymca/ExternalImagesWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ExternalImagesWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2018 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -38,7 +38,7 @@ if hasattr(qt, "QString"):
 else:
     QString = str
 from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
-from PyMca5.PyMcaGui import MaskImageWidget
+from PyMca5.PyMcaGui.plotting import MaskImageWidget
 from PyMca5.PyMcaIO import EdfFile
 EDF = True
 

--- a/PyMca5/PyMcaGui/pymca/LegacyPyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/LegacyPyMcaBatch.py
@@ -51,7 +51,7 @@ from PyMca5.PyMcaGui.physics.xrf import QtMcaAdvancedFitReport
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaCore import EdfFileLayer
 from PyMca5.PyMcaCore import SpecFileLayer
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaGui.pymca import McaCustomEvent
 from PyMca5.PyMcaGui.pymca import EdfFileSimpleViewer
 from PyMca5.PyMcaCore import HtmlIndex

--- a/PyMca5/PyMcaGui/pymca/Mca2Edf.py
+++ b/PyMca5/PyMcaGui/pymca/Mca2Edf.py
@@ -37,7 +37,7 @@ from PyMca5.PyMcaGui import PyMcaQt as qt
 QTVERSION = qt.qVersion()
 if QTVERSION >= '4.0.0':
     qt.Qt.WDestructiveClose = "TO BE DONE"
-from PyMca5.PyMcaGui.PyMca_Icons import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaGui.pymca import McaCustomEvent
 from PyMca5.PyMcaIO import EdfFile
 from PyMca5.PyMcaCore import SpecFileLayer

--- a/PyMca5/PyMcaGui/pymca/Mca2Edf.py
+++ b/PyMca5/PyMcaGui/pymca/Mca2Edf.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2018 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -37,7 +37,7 @@ from PyMca5.PyMcaGui import PyMcaQt as qt
 QTVERSION = qt.qVersion()
 if QTVERSION >= '4.0.0':
     qt.Qt.WDestructiveClose = "TO BE DONE"
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.PyMca_Icons import IconDict
 from PyMca5.PyMcaGui.pymca import McaCustomEvent
 from PyMca5.PyMcaIO import EdfFile
 from PyMca5.PyMcaCore import SpecFileLayer

--- a/PyMca5/PyMcaGui/pymca/McaWindow.py
+++ b/PyMca5/PyMcaGui/pymca/McaWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -46,7 +46,7 @@ if __name__ == "__main__":
 import copy
 
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from .ScanWindow import ScanWindow
 from . import McaCalibrationControlGUI
 from PyMca5.PyMcaIO import ConfigDict
@@ -56,10 +56,10 @@ from PyMca5.PyMcaCore import DataObject
 from . import McaSimpleFit
 from PyMca5.PyMcaMath.fitting import Specfit
 from PyMca5.PyMcaMath.fitting import SpecfitFuns
-from PyMca5.PyMcaGui import PyMcaPrintPreview
+from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview
 from PyMca5 import PyMcaDirs
 
-from PyMca5.PyMcaGui import QPyMcaMatplotlibSave1D
+from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave1D
 MATPLOTLIB = True
 
 # force understanding of utf-8 encoding

--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -60,7 +60,7 @@ from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaGui.io import ConfigurationFileDialogs
 from PyMca5.PyMcaCore import EdfFileLayer
 from PyMca5.PyMcaCore import SpecFileLayer
-from PyMca5.PyMcaGui.PyMca_icons import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaGui.pymca import McaCustomEvent
 from PyMca5.PyMcaGui.pymca import EdfFileSimpleViewer
 from PyMca5.PyMcaCore import HtmlIndex

--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -60,7 +60,7 @@ from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaGui.io import ConfigurationFileDialogs
 from PyMca5.PyMcaCore import EdfFileLayer
 from PyMca5.PyMcaCore import SpecFileLayer
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.PyMca_icons import IconDict
 from PyMca5.PyMcaGui.pymca import McaCustomEvent
 from PyMca5.PyMcaGui.pymca import EdfFileSimpleViewer
 from PyMca5.PyMcaCore import HtmlIndex

--- a/PyMca5/PyMcaGui/pymca/PyMcaImageWindow.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaImageWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -34,7 +34,7 @@ from . import RGBImageCalculator
 qt = RGBImageCalculator.qt
 QTVERSION = qt.qVersion()
 from . import RGBCorrelator
-from PyMca5.PyMcaGui import FrameBrowser
+from PyMca5.PyMcaGui.misc import FrameBrowser
 USE_BROWSER = True
 
 _logger = logging.getLogger(__name__)
@@ -438,7 +438,7 @@ if __name__ == "__main__":
     else:PYMCA = False
 
     if PYMCA:
-        from PyMca5.PyMcaGui import PyMcaMain
+        from PyMca5.PyMcaGui.pymca import PyMcaMain
         w = PyMcaMain.PyMcaMain()
         w.show()
     else:

--- a/PyMca5/PyMcaGui/pymca/PyMcaMain.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMain.py
@@ -279,8 +279,8 @@ OBJECT3D = isSilxGLAvailable
 _logger.info("SilxGL availability: %s", isSilxGLAvailable)
 
 from PyMca5.PyMcaGui.pymca import QDispatcher
-from PyMca5.PyMcaGui import ElementsInfo
-from PyMca5.PyMcaGui import PeakIdentifier
+from PyMca5.PyMcaGui.physics.xrf import ElementsInfo
+from PyMca5.PyMcaGui.physics.xrf import PeakIdentifier
 from PyMca5.PyMcaGui.pymca import PyMcaBatch
 ###########import Fit2Spec
 from PyMca5.PyMcaGui.pymca import Mca2Edf
@@ -291,8 +291,8 @@ try:
 except:
     STACK = False
 from PyMca5.PyMcaGui.pymca import PyMcaPostBatch
-from PyMca5.PyMcaGui import RGBCorrelator
-from PyMca5.PyMcaGui import MaterialEditor
+from PyMca5.PyMcaGui.pymca import RGBCorrelator
+from PyMca5.PyMcaGui.physics.xrf import MaterialEditor
 
 from PyMca5.PyMcaIO import ConfigDict
 from PyMca5 import PyMcaDirs

--- a/PyMca5/PyMcaGui/pymca/PyMcaMdi.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaMdi.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -37,7 +37,7 @@ else:
 
 QTVERSION = qt.qVersion()
 
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 IconDict0 = PyMca_Icons.IconDict0
 from .PyMca_help  import HelpDict

--- a/PyMca5/PyMcaGui/pymca/PyMcaPostBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaPostBatch.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,8 +45,8 @@ if __name__ == "__main__":
 
 from PyMca5 import PyMcaDirs
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMcaFileDialogs
-from PyMca5.PyMcaGui import RGBCorrelator
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
+from PyMca5.PyMcaGui.pymca import RGBCorrelator
 if hasattr(qt, "QString"):
     QString = qt.QString
     QStringList = qt.QStringList

--- a/PyMca5/PyMcaGui/pymca/QPyMcaMatplotlibSave.py
+++ b/PyMca5/PyMcaGui/pymca/QPyMcaMatplotlibSave.py
@@ -37,7 +37,7 @@ import logging
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaCore import PyMcaMatplotlibSave
-from PyMca5.PyMcaGui.plotting.PyMca_icons import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview
 from PyMca5 import PyMcaDirs
 

--- a/PyMca5/PyMcaGui/pymca/QPyMcaMatplotlibSave.py
+++ b/PyMca5/PyMcaGui/pymca/QPyMcaMatplotlibSave.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2019 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,8 +24,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-from __future__ import absolute_import
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -38,8 +37,8 @@ import logging
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaCore import PyMcaMatplotlibSave
-from PyMca5.PyMcaGui import IconDict
-from PyMca5.PyMcaGui import PyMcaPrintPreview
+from PyMca5.PyMcaGui.plotting.PyMca_icons import IconDict
+from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview
 from PyMca5 import PyMcaDirs
 
 from matplotlib import cm

--- a/PyMca5/PyMcaGui/pymca/QPyMcaMatplotlibSave1D.py
+++ b/PyMca5/PyMcaGui/pymca/QPyMcaMatplotlibSave1D.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -34,7 +34,7 @@ import numpy
 import logging
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 
 from matplotlib import __version__ as matplotlib_version

--- a/PyMca5/PyMcaGui/pymca/QStackWidget.py
+++ b/PyMca5/PyMcaGui/pymca/QStackWidget.py
@@ -89,18 +89,18 @@ try:
 except:
     pass
 
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaCore import DataObject
 from PyMca5.PyMcaGui.pymca import McaWindow
 from PyMca5.PyMcaCore import StackBase
 from PyMca5.PyMcaCore import McaStackExport
-from PyMca5.PyMcaGui import CloseEventNotifyingWidget
-from PyMca5.PyMcaGui import MaskImageWidget
+from PyMca5.PyMcaGui.misc import CloseEventNotifyingWidget
+from PyMca5.PyMcaGui.plotting import MaskImageWidget
 convertToRowAndColumn = MaskImageWidget.convertToRowAndColumn
 
 from PyMca5.PyMcaGui.pymca import RGBCorrelator
 from PyMca5.PyMcaGui.pymca.RGBCorrelatorWidget import ImageShapeDialog
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_icons import IconDict
 from PyMca5.PyMcaGui.pymca import StackSelector
 from PyMca5 import PyMcaDirs
 from PyMca5.PyMcaIO import ArraySave

--- a/PyMca5/PyMcaGui/pymca/QStackWidget.py
+++ b/PyMca5/PyMcaGui/pymca/QStackWidget.py
@@ -100,7 +100,7 @@ convertToRowAndColumn = MaskImageWidget.convertToRowAndColumn
 
 from PyMca5.PyMcaGui.pymca import RGBCorrelator
 from PyMca5.PyMcaGui.pymca.RGBCorrelatorWidget import ImageShapeDialog
-from PyMca5.PyMcaGui.plotting.PyMca_icons import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaGui.pymca import StackSelector
 from PyMca5 import PyMcaDirs
 from PyMca5.PyMcaIO import ArraySave

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 #/*##########################################################################
-# Copyright (C) 2004-2020 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -37,11 +37,11 @@ if hasattr(qt, 'QString'):
     QString = qt.QString
 else:
     QString = str
-from PyMca5.PyMcaGui import RGBCorrelatorGraph
-from PyMca5.PyMcaGui import QPyMcaMatplotlibSave
+from PyMca5.PyMcaGui.pymca import RGBCorrelatorGraph
+from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave
 USE_MASK_WIDGET = False
 if USE_MASK_WIDGET:
-    from PyMca5.PyMcaGui import MaskImageWidget
+    from PyMca5.PyMcaGui.plotting import MaskImageWidget
     
 MATPLOTLIB = True
 

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelator.py
@@ -37,7 +37,7 @@ if hasattr(qt, 'QString'):
     QString = qt.QString
 else:
     QString = str
-from PyMca5.PyMcaGui.pymca import RGBCorrelatorGraph
+from PyMca5.PyMcaGui.plotting import RGBCorrelatorGraph
 from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave
 USE_MASK_WIDGET = False
 if USE_MASK_WIDGET:

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorSlider.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorSlider.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,12 +23,12 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import logging
-from PyMca5.PyMcaGui import DoubleSlider
+from PyMca5.PyMcaGui.misc import DoubleSlider
 qt = DoubleSlider.qt
 
 QTVERSION = qt.qVersion()

--- a/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
+++ b/PyMca5/PyMcaGui/pymca/RGBCorrelatorWidget.py
@@ -38,14 +38,14 @@ from . import RGBCorrelatorSlider
 from . import RGBCorrelatorTable
 from PyMca5.PyMcaGui.pymca import RGBImageCalculator
 from PyMca5 import spslut
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaIO import ArraySave
 from PyMca5 import PyMcaDirs
 from PyMca5.PyMcaCore import EdfFileDataSource
 from PyMca5.PyMcaGui.pymca import ExternalImagesWindow
 from PyMca5.PyMcaIO import TiffIO
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
-from PyMca5.PyMcaGui import ScatterPlotCorrelatorWidget
+from PyMca5.PyMcaGui.plotting import ScatterPlotCorrelatorWidget
 
 DataReader = EdfFileDataSource.EdfFileDataSource
 USE_STRING = False
@@ -60,9 +60,9 @@ else:
 
 QTVERSION = qt.qVersion()
 try:
-    from PyMca5.PyMcaGui import NNMADialog
+    from PyMca5.PyMcaGui.math import NNMADialog
     NNMA = NNMADialog.NNMA
-    from PyMca5.PyMcaGui import PCADialog
+    from PyMca5.PyMcaGui.math import PCADialog
     PCA = PCADialog.PCA
 except:
     NNMA = False
@@ -94,7 +94,7 @@ except ImportError:
 else:
     def isHdf5(filename):
         return h5py.is_hdf5(filename)
-    from PyMca5.PyMca import HDF5Widget
+    from PyMca5.PyMcaGui.io.hdf5 import HDF5Widget
     from PyMca5.PyMcaIO import NexusUtils
 
 

--- a/PyMca5/PyMcaGui/pymca/ScanWindow.py
+++ b/PyMca5/PyMcaGui/pymca/ScanWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,7 @@
 #############################################################################*/
 """This module defines a :class:`ScanWindow` inheriting a 
 :class:`PlotWindow` with additional tools and actions."""
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -49,11 +49,11 @@ from . import ScanFit
 from PyMca5.PyMcaMath import SimpleMath
 from PyMca5.PyMcaCore import DataObject
 import copy
-from PyMca5.PyMcaGui import PyMcaPrintPreview
+from PyMca5.PyMcaGui.plotting import PyMcaPrintPreview
 from PyMca5.PyMcaCore import PyMcaDirs
-from . import ScanWindowInfoWidget
+from PyMca5.PyMcaGui.pymca import ScanWindowInfoWidget
 #implement the plugins interface
-from PyMca5.PyMcaGui import QPyMcaMatplotlibSave1D
+from PyMca5.PyMcaGui.pymca import QPyMcaMatplotlibSave1D
 MATPLOTLIB = True
 #force understanding of utf-8 encoding
 #otherways it cannot generate svg output

--- a/PyMca5/PyMcaGui/pymca/SilxScatterWindow.py
+++ b/PyMca5/PyMcaGui/pymca/SilxScatterWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2019-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2019-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -323,7 +323,7 @@ if __name__ == "__main__":
         PYMCA = False
 
     if PYMCA:
-        from PyMca5.PyMcaGui import PyMcaMain
+        from PyMca5.PyMcaGui.pymca import PyMcaMain
         w = PyMcaMain.PyMcaMain()
         w.show()
     else:

--- a/PyMca5/PyMcaGui/pymca/StackBrowser.py
+++ b/PyMca5/PyMcaGui/pymca/StackBrowser.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,15 +23,15 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 import logging
-from PyMca5.PyMcaGui import MaskImageWidget
-from PyMca5.PyMcaGui import FrameBrowser
+from PyMca5.PyMcaGui.plotting import MaskImageWidget
+from PyMca5.PyMcaGui.misc import FrameBrowser
 from PyMca5.PyMcaCore import DataObject
 qt = MaskImageWidget.qt
 IconDict = MaskImageWidget.IconDict

--- a/PyMca5/PyMcaGui/pymca/StackROIBatchWindow.py
+++ b/PyMca5/PyMcaGui/pymca/StackROIBatchWindow.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,14 +26,14 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaGui.io import ConfigurationFileDialogs

--- a/PyMca5/PyMcaGui/pymca/StackROIWindow.py
+++ b/PyMca5/PyMcaGui/pymca/StackROIWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2014 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,17 +23,17 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import ExternalImagesWindow
+from PyMca5.PyMcaGui.pymca import ExternalImagesWindow
 MaskImageWidget = ExternalImagesWindow.MaskImageWidget
 from PyMca5.PyMcaMath.PyMcaSciPy.signal import median
 medfilt2d = median.medfilt2d
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 
 class MedianParameters(qt.QWidget):
     def __init__(self, parent=None):

--- a/PyMca5/PyMcaGui/pymca/StackSimpleFitWindow.py
+++ b/PyMca5/PyMcaGui/pymca/StackSimpleFitWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2015 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -33,11 +33,11 @@ import traceback
 import time
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5 import PyMcaDirs
-from PyMca5.PyMcaGui import SimpleFitGui
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.math.fitting import SimpleFitGui
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5.PyMcaMath.fitting import StackSimpleFit
 from PyMca5.PyMcaIO import ArraySave
-from PyMca5.PyMcaGui import CalculationThread
+from PyMca5.PyMcaGui.misc import CalculationThread
 safe_str = qt.safe_str
 
 class OutputParameters(qt.QWidget):

--- a/PyMca5/PyMcaGui/pymca/StackXASBatchWindow.py
+++ b/PyMca5/PyMcaGui/pymca/StackXASBatchWindow.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,14 +26,14 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V. Armando Sole - ESRF Data Analysis"
+__author__ = "V. Armando Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import numpy
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaGui import PyMca_Icons
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import PyMca_Icons
 IconDict = PyMca_Icons.IconDict
 from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 

--- a/PyMca5/PyMcaGui/pymca/SumRulesTool.py
+++ b/PyMca5/PyMcaGui/pymca/SumRulesTool.py
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (C) 2004-2019 T. Rueter, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "Tonn Rueter - ESRF Data Analysis"
+__author__ = "Tonn Rueter - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -37,15 +37,15 @@ from os.path import join as osPathJoin
 import numpy
 from PyMca5.PyMcaMath.fitting.SpecfitFuns import upstep, downstep
 
-from PyMca5.PyMca import PyMcaQt as qt
-from PyMca5.PyMca import PlotWindow as DataDisplay
-from PyMca5.PyMca import Elements
-from PyMca5.PyMca import ConfigDict
+from PyMca5.PyMcaGui import PyMcaQt as qt
+from PyMca5.PyMcaGui.plotting import PlotWindow as DataDisplay
+from PyMca5.PyMcaPhysics.xrf import Elements
+from PyMca5.PyMcaIO import ConfigDict
 
-from PyMca5.PyMca import PyMcaDataDir, PyMcaDirs
-from PyMca5.PyMca import QSpecFileWidget
-from PyMca5.PyMca import SpecFileDataSource
-from PyMca5.PyMcaGui import IconDict
+from PyMca5 import PyMcaDataDir, PyMcaDirs
+from PyMca5.PyMcaGui.io import QSpecFileWidget
+from PyMca5.PyMcaCore import SpecFileDataSource
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 
 if hasattr(qt, "QString"):
     QString = qt.QString
@@ -266,7 +266,10 @@ class LineEditDisplay(qt.QLineEdit):
         self.setMaximumWidth(120)
         self.controller = controller
         if isinstance(self.controller, qt.QComboBox):
-            self.controller.currentIndexChanged['QString'].connect(self.setText)
+            if hasattr(self.controller, "textActivated"):
+                self.controller.textActivated['QString'].connect(self.setText)
+            else:
+                self.controller.currentIndexChanged['QString'].connect(self.setText)
         elif isinstance(self.controller, qt.QDoubleSpinBox):
             # Update must be triggered otherwise
             #self.controller.valueChanged['QString'].connect(self.setText)
@@ -432,7 +435,10 @@ class SumRulesWindow(qt.QMainWindow):
                 self.elementEConfCB = qt.QComboBox()
                 self.elementEConfCB.setMinimumWidth(100)
                 self.elementEConfCB.addItems(['']+self.electronConfs)
-                self.elementEConfCB.currentIndexChanged['QString'].connect(self.setElectronConf)
+                if hasattr(self.elementEConfCB, "textActivated"):
+                    self.elementEConfCB.textActivated['QString'].connect(self.setElectronConf)
+                else:           
+                    self.elementEConfCB.currentIndexChanged['QString'].connect(self.setElectronConf)
                 elementEConfLayout = qt.QHBoxLayout()
                 elementEConfLayout.setContentsMargins(0,0,0,0)
                 elementEConfLayout.addWidget(qt.QLabel('Electron configuration'))
@@ -445,7 +451,10 @@ class SumRulesWindow(qt.QMainWindow):
                 self.elementCB = qt.QComboBox()
                 self.elementCB.setMinimumWidth(100)
                 self.elementCB.addItems([''])
-                self.elementCB.currentIndexChanged['QString'].connect(self.getElementInfo)
+                if hasattr(self.elementCB, "textActivated"):
+                    self.elementCB.textActivated['QString'].connect(self.getElementInfo)
+                else:
+                    self.elementCB.currentIndexChanged['QString'].connect(self.getElementInfo)
                 elementLayout = qt.QHBoxLayout()
                 elementLayout.setContentsMargins(0,0,0,0)
                 elementLayout.addWidget(qt.QLabel('Element'))

--- a/PyMca5/PyMcaGui/pymca/XMCDWindow.py
+++ b/PyMca5/PyMcaGui/pymca/XMCDWindow.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "Tonn Rueter - ESRF Data Analysis"
+__author__ = "Tonn Rueter - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -31,9 +31,9 @@ import numpy, copy
 import logging
 import sys
 from os.path import splitext, basename, dirname, exists, join as pathjoin
-from PyMca5.PyMcaGui import IconDict
+from PyMca5.PyMcaGui.plotting.PyMca_Icons import IconDict
 from PyMca5 import PyMcaDirs
-from PyMca5.PyMcaGui import PyMcaFileDialogs
+from PyMca5.PyMcaGui.io import PyMcaFileDialogs
 from PyMca5.PyMcaIO import ConfigDict
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaIO import specfilewrapper as specfile

--- a/PyMca5/PyMcaPhysics/xrf/ClassMcaTheory.py
+++ b/PyMca5/PyMcaPhysics/xrf/ClassMcaTheory.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -2940,7 +2940,7 @@ def test(inputfile=None,scankey=None,pkm=None,
 
     if plotflag:
         from PyMca5.PyMcaGui import PyMcaQt as qt
-        from PyMca5.PyMcaGui import ScanWindow
+        from PyMca5.PyMcaGui.pymca import ScanWindow
         app = qt.QApplication(sys.argv)
         graph = ScanWindow.ScanWindow()
         xw = numpy.ravel(mcafit.xdata)

--- a/package/pyinstaller/pyinstaller.spec
+++ b/package/pyinstaller/pyinstaller.spec
@@ -183,52 +183,56 @@ special_modules = [os.path.dirname(PyMca5.__file__),
                    os.path.dirname(fisx.__file__),
                    os.path.dirname(h5py.__file__),
                    #os.path.dirname(numpy.__file__),
-                   os.path.dirname(matplotlib.__file__),
                    #os.path.dirname(ctypes.__file__),
                    os.path.dirname(hdf5plugin.__file__),
                    ]
 
-# recent versions of matplotlib need packaging, PIL and pyparsing
-try:
-    import packaging
-    special_modules.append(os.path.dirname(packaging.__file__))
-except:
-    pass
-try:
-    import PIL
-    special_modules.append(os.path.dirname(PIL.__file__))
-except:
-    pass
-try:
-    import pyparsing
-    special_modules.append(os.path.dirname(pyparsing.__file__))
-except:
-    pass
-try:
-    import dateutil
-    special_modules.append(os.path.dirname(dateutil.__file__))
-except:
-    pass
-try:
-    import mpl_toolkits.mplot3d.axes3d as axes3d
-    special_modules.append(os.path.dirname(os.path.dirname(axes3d.__file__)))
-except:
-    pass
-try:
-    import six
-    special_modules.append(six.__file__)
-except:
-    pass
-try:
-    import cycler
-    special_modules.append(cycler.__file__)
-except:
-    pass
-try:
-    import uuid
-    special_modules.append(uuid.__file__)
-except:
-    pass
+# this block  can be needed for matplotlib
+MATPLOTLIB_FROM_PYINSTALLER = True
+if not MATPLOTLIB_FROM_PYINSTALLER:
+    special_modules.append(os.path.dirname(matplotlib.__file__))
+
+    # recent versions of matplotlib need packaging, PIL and pyparsing
+    try:
+        import packaging
+        special_modules.append(os.path.dirname(packaging.__file__))
+    except:
+        pass
+    try:
+        import PIL
+        special_modules.append(os.path.dirname(PIL.__file__))
+    except:
+        pass
+    try:
+        import pyparsing
+        special_modules.append(os.path.dirname(pyparsing.__file__))
+    except:
+        pass
+    try:
+        import dateutil
+        special_modules.append(os.path.dirname(dateutil.__file__))
+    except:
+        pass
+    try:
+        import mpl_toolkits.mplot3d.axes3d as axes3d
+        special_modules.append(os.path.dirname(os.path.dirname(axes3d.__file__)))
+    except:
+        pass
+    try:
+        import six
+        special_modules.append(six.__file__)
+    except:
+        pass
+    try:
+        import cycler
+        special_modules.append(cycler.__file__)
+    except:
+        pass
+    try:
+        import uuid
+        special_modules.append(uuid.__file__)
+    except:
+        pass
 
 excludes = []
 
@@ -450,7 +454,7 @@ if sys.platform.startswith("win") and os.path.exists(nsis):
 
     # cleanup intermediate files
     for dname in ["build", "dist", "__pycache__"]:
-        ddir = os.path.join(SPECPATH, "dname")
+        ddir = os.path.join(SPECPATH, dname)
         if os.path.exists(ddir):
             shutil.rmtree(ddir)
 


### PR DESCRIPTION
PyMcaPostBatch.exe was not working if matplotlib was taken from the PyInstaller hook.

By using complete imports it works.