### PR TITLE
[HDF5] Hdf5 segfault handling

### DIFF
--- a/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -31,6 +31,7 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import os
 import posixpath
+import time
 import gc
 import re
 from operator import itemgetter
@@ -449,7 +450,7 @@ class H5FileProxy(H5NodeProxy):
             return H5NodeProxy(self.file, self.file[path], self)
 
     def raw_keys(self):
-        if isinstance(self.file, h5py.File):
+        if isinstance(self.file, h5py.File) and ((time.time() - os.stat(self.file.filename).st_mtime) > 3600):
             file_path = self.file.filename
             data_path = self.name
             return HDF5Utils.safe_hdf5_group_keys(file_path, data_path=data_path)

--- a/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -64,6 +64,7 @@ except ImportError:
                 raise
             _logger.info("Cannot open %s. Trying in SWMR mode" % filename)
             return h5py.File(filename, "r", libver='latest', swmr=True)
+from PyMca5.PyMcaIO import HDF5Utils
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
 safe_str = qt.safe_str
@@ -159,19 +160,18 @@ def h5py_sorting(object_list, sorting_list=None):
         _logger.warning("Probably all entries do not have the key %s" % sorting_key)
         return object_list
 
+
 def _get_number_list(txt):
     rexpr = '[/a-zA-Z:_-]'
     nbs= [float(w) for w in re.split(rexpr, txt) if w not in ['',' ']]
     return nbs
 
+
 class BrokenLink(object):
     pass
 
+
 class QRLock(qt.QMutex):
-
-    """
-    """
-
     def __init__(self):
         qt.QMutex.__init__(self, qt.QMutex.Recursive)
 
@@ -227,6 +227,7 @@ class RootItem(object):
         del self._children[idx]
         del self._identifiers[idx]
 
+
 class H5NodeProxy(object):
     def sortChildren(self, column, order):
         #print("sort children called with ", column, order)
@@ -236,6 +237,22 @@ class H5NodeProxy(object):
         else:
             self.__sorting_list = None
         self.__sorting_order = order
+
+    def raw_keys(self):
+        for node in self.children:
+            yield node.name
+
+    def raw_values(self):
+        node = self.getNode(self.name)
+        if hasattr(node, "values"):
+            return node.values()
+        else:
+            # spech5 does not implement values() prior to silx 0.6.0
+            for _, value in self.raw_items():
+                yield value
+
+    def raw_items(self):
+        return self.getNode(self.name).items()
 
     @property
     def children(self):
@@ -247,13 +264,8 @@ class H5NodeProxy(object):
             # freeze if navigating tree while data is processing
             if 1: #with self.file.plock:
                 try:
-                    items = list(self.getNode(self.name).items())
-                    if posixpath.dirname(self.name) == "/":
-                        # top level item
-                        doit = True
-                    else:
-                        doit = False
-                except:
+                    items = list(self.raw_items())
+                except Exception:
                     items = []
                     _logger.warning("Cannot obtain items list. Ignoring")
                 try:
@@ -270,17 +282,13 @@ class H5NodeProxy(object):
                                                                finalList[i][0])
                     self._children = [H5NodeProxy(self.file, i[1], self)
                                       for i in finalList]
-                except:
-                    #one cannot afford any error, so I revert to the old
+                except Exception:
+                    # one cannot afford any error, so I revert to the old
                     # method where values where used instead of items
                     if 1 or _logger.getEffectiveLevel() == logging.DEBUG:
                         raise
-                    else:
-                        # tmpList = list(self.getNode(self.name).values())
-                        # spech5 does not implement values() prior to silx 0.6.0
-                        tmpList = list(map(self.getNode(self.name).__getitem__,
-                                           self.getNode(self.name).keys()))
-                        finalList = tmpList
+                    tmpList = list(self.raw_values())
+                    finalList = tmpList
                     for i in range(len(finalList)):
                         finalList[i]._posixPath = posixpath.join(self.name,
                                                                items[i][0])
@@ -439,6 +447,22 @@ class H5FileProxy(H5NodeProxy):
             return self
         else:
             return H5NodeProxy(self.file, self.file[path], self)
+
+    def raw_keys(self):
+        if isinstance(self.file, h5py.File):
+            file_path = self.file.filename
+            data_path = self.name
+            return HDF5Utils.safe_hdf5_group_keys(file_path, data_path=data_path)
+        else:
+            return super().raw_keys()
+
+    def raw_values(self):
+        for _, value in self.raw_items():
+            yield value
+
+    def raw_items(self):
+        for data_path in self.raw_keys():
+            yield data_path, self.getNode(data_path)
 
 
 class FileModel(qt.QAbstractItemModel):

--- a/PyMca5/PyMcaIO/HDF5Utils.py
+++ b/PyMca5/PyMcaIO/HDF5Utils.py
@@ -1,0 +1,48 @@
+import os
+import h5py
+from queue import Empty
+import multiprocessing
+
+
+def get_hdf5_group_keys(file_path, data_path=None):
+    """Note: segmentation faults seem to be caused only when iterating the HDF5 root.
+    """
+    os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+    with h5py.File(file_path, mode="r") as group:
+        if data_path:
+            group = group[data_path]
+        else:
+            group = group["/"]  # to preserve the order
+        return list(group.keys())
+
+
+def safe_hdf5_group_keys(file_path, data_path=None):
+    return run_in_subprocess(
+        get_hdf5_group_keys, file_path, data_path=data_path, default=list()
+    )
+
+
+def run_in_subprocess(target, *args, context=None, default=None, **kwargs):
+    ctx = multiprocessing.get_context(context)
+    queue = ctx.Queue(maxsize=1)
+    p = ctx.Process(
+        target=subprocess_main,
+        args=(queue, target) + args,
+        kwargs=kwargs,
+    )
+    p.start()
+    try:
+        p.join()
+        try:
+            return queue.get(block=False)
+        except Empty:
+            return default
+    finally:
+        try:
+            p.kill()
+        except AttributeError:
+            p.terminate()
+
+
+def subprocess_main(queue, method, *args, **kwargs):
+    queue.put(method(*args, **kwargs))

--- a/PyMca5/tests/HDF5UtilsTest.py
+++ b/PyMca5/tests/HDF5UtilsTest.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+import tempfile
+import unittest
+import h5py
+
+from PyMca5.PyMcaIO import HDF5Utils
+
+
+def _cause_segfault(*args, **kwargs):
+    import ctypes
+
+    i = ctypes.c_char(b"a")
+    j = ctypes.pointer(i)
+    c = 0
+    while True:
+        j[c] = b"a"
+        c += 1
+
+
+def _safe_cause_segfault(*args, **kwargs):
+    return HDF5Utils.run_in_subprocess(_cause_segfault, *args, **kwargs)
+
+
+class testHDF5Utils(unittest.TestCase):
+    def setUp(self):
+        self.path = tempfile.mkdtemp(prefix="pymca")
+
+    def tearDown(self):
+        shutil.rmtree(self.path)
+
+    def testHdf5GroupKeys(self):
+        filename = os.path.join(self.path, "test.h5")
+        with h5py.File(filename, "w", track_order=True) as f:
+            for i in range(5):
+                f[str(i)] = i
+
+        names = list(map(str, range(5)))
+        self.assertEqual(HDF5Utils.get_hdf5_group_keys(filename), names)
+        self.assertEqual(HDF5Utils.safe_hdf5_group_keys(filename), names)
+
+    def testSegFault(self):
+        self.assertEqual(_safe_cause_segfault(default=123), 123)
+
+
+def getSuite(auto=True):
+    testSuite = unittest.TestSuite()
+    if auto:
+        testSuite.addTest(unittest.TestLoader().loadTestsFromTestCase(testHDF5Utils))
+    else:
+        # use a predefined order
+        testSuite.addTest(testHDF5Utils("testHdf5GroupKeys"))
+        testSuite.addTest(testHDF5Utils("testSegFault"))
+    return testSuite
+
+
+def test(auto=False):
+    unittest.TextTestRunner(verbosity=2).run(getSuite(auto=auto))
+
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
Iterating the HDF5 root (for example `h5file["/"].keys()`) can cause segfaults. Execute these calls in a subprocess.