### PR TITLE
fix anchors in MCA-HOWTO.html

### DIFF
--- a/PyMca5/PyMcaData/HTML/MCA-HOWTO.html
+++ b/PyMca5/PyMcaData/HTML/MCA-HOWTO.html
@@ -10,7 +10,7 @@ marginwidth=10 marginheight=10  topmargin=10 leftmargin=10>
 <a HREF=#Advanced>HOWTO - Advanced fit&nbsp;</a><br>
 <br>
 <br>
-<H3><a NAME=#Energy>Display MCA spectra in energy instead of channels&nbsp;</a></H3><br>
+<H3><a NAME=Energy>Display MCA spectra in energy instead of channels&nbsp;</a></H3><br>
 <br>
 At the calibration combo box below the Mca graphics window, select Internal.
 If the spectra in the graphics window have an energy calibration associated
@@ -27,7 +27,7 @@ Other options will be present in case the user has previously decided to
 perform an energy calibration. Selecting any of these non default options
 will plot all the spectra with the same selected energy calibration.&nbsp;<br>
 <br>
-<H3><a NAME=#Calibration>Calibrate MCA spectra&nbsp;</a></H3><br>
+<H3><a NAME=Calibration>Calibrate MCA spectra&nbsp;</a></H3><br>
 Select the spectrum to calibrate by clicking on its legend.&nbsp;<br>
 Click on calibrate.&nbsp;<br>
 If you want to enter a calibration by hand or to copy a calibration from
@@ -44,7 +44,7 @@ Once you have finished click OK to validate the calibration or Cancel to
 disregard it. Back to the main application, select the appropriate option
 in the calibration combo box.&nbsp;<br>
 <br>
-<H3><a NAME=#Roi>Define a ROI&nbsp;</a></H3><br>
+<H3><a NAME=Roi>Define a ROI&nbsp;</a></H3><br>
 A table of Regions of Interest (ROIs) may be seen below the MCA graph.
 A default ROI named ICR is always present.&nbsp;<br>
 The Raw counts contains the total counts between the markers.&nbsp;<br>
@@ -54,13 +54,13 @@ to the spectrum point at the ending of the ROI. To define a new ROI just
 click the "ADD ROI" button and move the blue markers (click and move) to
 the appropriate position(s).&nbsp;<br>
 <br>
-<H3><a NAME=#Fit>Fit MCA Spectra&nbsp;</a></H3><br>
+<H3><a NAME=Fit>Fit MCA Spectra&nbsp;</a></H3><br>
 Select the spectrum to be fitted by clicking on its legend.&nbsp;<br>
 Select the region to be fitted by zooming with the mouse.&nbsp;<br>
 Click on the Fit Icon. Select "Simple" or "Advanced" depending on the type
 of fit to be performed.&nbsp;<br>
 <br>
-<H3><a NAME=#Simple>Simple Fit&nbsp;</a></H3><br>
+<H3><a NAME=Simple>Simple Fit&nbsp;</a></H3><br>
 PyMca automatically searches for peaks in the spectrum, divides the spectrum
 in several regions depending on the separation among peaks and on the FWHM
 specified in the configuration and presents all the results in a table.&nbsp;<br>
@@ -75,7 +75,7 @@ order to get the actual areas.&nbsp;<br>
 If you are interested on peak FWHM in energy, the fit has to be made with
 the calibration set to an option different from None.&nbsp;<br>
 <br>
-<H3><a NAME=#Advanced>Advanced Fit&nbsp;</a></H3><br>
+<H3><a NAME=Advanced>Advanced Fit&nbsp;</a></H3><br>
 This is PyMca main reason of being. The initial goal of PyMca was to supply
 an interactive tool to set up the configuration file of a program for batch
 fitting of multiple spectra.&nbsp;<br>


### PR DESCRIPTION
On Fedora Workstation (both on 36 with PyMca-5.6.7-6.fc36.x86_64 and on 34 with PyMca-5.5.0-7.fc34.x86_64) the text links in the window:
PyMca -- Help -- MCA HOWTOs
do not jump to the anchors below.