### PR TITLE
Clean up locale_management in specfile

### DIFF
--- a/PyMca5/PyMcaIO/specfile/include/locale_management.h
+++ b/PyMca5/PyMcaIO/specfile/include/locale_management.h
@@ -24,23 +24,6 @@
 #define PyMca_LOCALE_MANAGEMENT_H
 
 #include <locale.h>
-#ifdef _GNU_SOURCE
-#  ifdef __GLIBC__
-#    include <features.h>
-#    if !((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ > 25)))
-#      /* strtod_l has been moved to stdlib.h since glibc 2.26 */
-#      include <xlocale.h>
-#    endif
-#  else
-#    include <xlocale.h>
-#  endif
-#else
-#  ifdef SPECFILE_POSIX
-#    ifndef LOCALE_NAME_MAX_LENGTH
-#           define LOCALE_NAME_MAX_LENGTH 85
-#    endif
-#  endif
-#endif
 
 double PyMcaAtof(const char*);
 

--- a/PyMca5/PyMcaIO/specfile/src/locale_management.c
+++ b/PyMca5/PyMcaIO/specfile/src/locale_management.c
@@ -29,7 +29,7 @@ double PyMcaAtof(const char * inputString)
     double result;
 	_locale_t newLocale = _create_locale(LC_NUMERIC, "C");
 	result = _atof_l(inputString, newLocale);
-	_freelocale(newLocale);
+	_free_locale(newLocale);
 	return result;
 #else
 	double result;

--- a/PyMca5/PyMcaIO/specfile/src/locale_management.c
+++ b/PyMca5/PyMcaIO/specfile/src/locale_management.c
@@ -20,6 +20,9 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
+
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <locale_management.h>
 
@@ -31,13 +34,11 @@ double PyMcaAtof(const char * inputString)
 	result = _atof_l(inputString, newLocale);
 	_free_locale(newLocale);
 	return result;
-#elif defined(__USE_GNU)
+#else
 	double result;
 	locale_t newLocale = newlocale(LC_NUMERIC_MASK, "C", NULL);
 	result = strtod_l(inputString, NULL, newLocale);
 	freelocale(newLocale);
 	return result;
-#else
-	return atof(inputString);
 #endif
 }

--- a/PyMca5/PyMcaIO/specfile/src/locale_management.c
+++ b/PyMca5/PyMcaIO/specfile/src/locale_management.c
@@ -31,7 +31,7 @@ double PyMcaAtof(const char * inputString)
 	result = _atof_l(inputString, newLocale);
 	_free_locale(newLocale);
 	return result;
-#elseif defined(__USE_GNU)
+#elif defined(__USE_GNU)
 	double result;
 	locale_t newLocale = newlocale(LC_NUMERIC_MASK, "C", NULL);
 	result = strtod_l(inputString, NULL, newLocale);

--- a/PyMca5/PyMcaIO/specfile/src/locale_management.c
+++ b/PyMca5/PyMcaIO/specfile/src/locale_management.c
@@ -31,13 +31,13 @@ double PyMcaAtof(const char * inputString)
 	result = _atof_l(inputString, newLocale);
 	_free_locale(newLocale);
 	return result;
-#else
+#elseif defined(__USE_GNU)
 	double result;
 	locale_t newLocale = newlocale(LC_NUMERIC_MASK, "C", NULL);
 	result = strtod_l(inputString, NULL, newLocale);
 	freelocale(newLocale);
 	return result;
-//#else
-//	return atof(inputString);
+#else
+	return atof(inputString);
 #endif
 }

--- a/PyMca5/PyMcaIO/specfile/src/locale_management.c
+++ b/PyMca5/PyMcaIO/specfile/src/locale_management.c
@@ -22,34 +22,22 @@
 # ############################################################################*/
 #include <stdlib.h>
 #include <locale_management.h>
-#include <string.h>
 
 double PyMcaAtof(const char * inputString)
 {
-#ifdef _GNU_SOURCE
+#if defined(_MSC_VER) && defined(_MSC_FULL_VER)
+    double result;
+	_locale_t newLocale = _create_locale(LC_NUMERIC, "C");
+	result = _atof_l(inputString, newLocale);
+	_freelocale(newLocale);
+	return result;
+#else
 	double result;
-	locale_t newLocale;
-	newLocale = newlocale(LC_NUMERIC_MASK, "C", NULL);
+	locale_t newLocale = newlocale(LC_NUMERIC_MASK, "C", NULL);
 	result = strtod_l(inputString, NULL, newLocale);
 	freelocale(newLocale);
 	return result;
-#endif
-#if defined(_MSC_VER) && defined(_MSC_FULL_VER)
-	_locale_t c_locale = _create_locale(LC_NUMERIC, "C");
-	return _atof_l(inputString, c_locale);
-#endif
-#ifdef SPECFILE_POSIX
-	char *currentLocaleBuffer;
-	char *restoredLocaleBuffer;
-	char localeBuffer[LOCALE_NAME_MAX_LENGTH + 1] = {'\0'};
-	double result;
-	currentLocaleBuffer = setlocale(LC_NUMERIC, NULL);
-	strcpy(localeBuffer, currentLocaleBuffer);
-	setlocale(LC_NUMERIC, "C\0");
-	result = atof(inputString);
-	restoredLocaleBuffer = setlocale(LC_NUMERIC, localeBuffer);
-	return(result);
-#else
-	return atof(inputString);
+//#else
+//	return atof(inputString);
 #endif
 }

--- a/setup.py
+++ b/setup.py
@@ -92,18 +92,6 @@ if PYMCA_DATA_DIR is None and PYMCA_DOC_DIR is None:
 
 USE_SMART_INSTALL_SCRIPTS = "--install-scripts" in sys.argv
 
-SPECFILE_USE_GNU_SOURCE = os.getenv("SPECFILE_USE_GNU_SOURCE")
-if SPECFILE_USE_GNU_SOURCE is None:
-    SPECFILE_USE_GNU_SOURCE = 0
-    if sys.platform.lower().startswith("linux"):
-        print("WARNING:")
-        print("A cleaner locale independent implementation")
-        print("may be achieved setting SPECFILE_USE_GNU_SOURCE to 1")
-        print("For instance running this script as:")
-        print("SPECFILE_USE_GNU_SOURCE=1 python setup.py build")
-else:
-    SPECFILE_USE_GNU_SOURCE = int(SPECFILE_USE_GNU_SOURCE)
-
 
 # check if cython is not to be used despite being present
 def use_cython():
@@ -256,14 +244,7 @@ def build_FastEdf(ext_modules):
 
 def build_specfile(ext_modules):
     if sys.platform == "win32":
-        specfile_define_macros = [('WIN32', None),
-                                  ('SPECFILE_POSIX', None)]
-    elif os.name.lower().startswith('posix'):
-        specfile_define_macros = [('SPECFILE_POSIX', None)]
-        # the best choice is to use _GNU_SOURCE if possible
-        # because that enables the use of strtod_l
-        if SPECFILE_USE_GNU_SOURCE:
-            specfile_define_macros = [('_GNU_SOURCE', 1)]
+        specfile_define_macros = [('WIN32', None),]
     else:
         specfile_define_macros = define_macros
 


### PR DESCRIPTION
Harmonize use of strtod_l. It should be available on all supported OSes.
Makes SPECFILE_USE_GNU_SOURCE obsolete.

fixes #859 