### PR TITLE
[IO] Read last MCA data when trailing space present

### DIFF
--- a/PyMca5/PyMcaIO/specfile/src/sfmca.c
+++ b/PyMca5/PyMcaIO/specfile/src/sfmca.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2000-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2000-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -289,6 +289,11 @@ SfGetMca( SpecFile *sf, long index, long number, double **retdata, int *error )
        val = my_atof(strval);
        data[vals] = val;
        vals++;
+     } else if (i>0) {
+         strval[i] = '\0';
+         val = PyMcaAtof(strval);
+         data[vals] = val;
+         vals++;
      }
 
     *retdata = data;


### PR DESCRIPTION
If there is a space before line-feed, the last data is not read.
```
#S 1 mythen_save Point:0 Scan:1 Datafile:/temp.dat
#T 5 (Seconds)
#@MCA %25C
#@CTIME 5
#I 0.000000
@A 253 253 253 279 284 286 
```