### PR TITLE
Adapt tests to python 3.11

### DIFF
--- a/PyMca5/PyMcaGui/misc/testutils.py
+++ b/PyMca5/PyMcaGui/misc/testutils.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "22/07/2022"
 
 
 import gc
@@ -202,9 +202,13 @@ class TestCaseQt(unittest.TestCase):
 
     def _currentTestSucceeded(self):
         if hasattr(self, '_outcome'):
-            # For Python >= 3.4
-            result = self.defaultTestResult()  # these 2 methods have no side effects
-            self._feedErrorsToResult(result, self._outcome.errors)
+            if hasattr(self, '_feedErrorsToResult'):
+                # For Python 3.4 -3.10
+                result = self.defaultTestResult()  # these 2 methods have no side effects
+                self._feedErrorsToResult(result, self._outcome.errors)
+            else:
+                # Python 3.11+
+                result = self._outcome.result
         else:
             # For Python < 3.4
             result = getattr(self, '_outcomeForDoCleanups', self._resultForDoCleanups)

--- a/setup.py
+++ b/setup.py
@@ -459,7 +459,10 @@ build_specfit(ext_modules)
 build_sps(ext_modules)
 build_PyMcaIOHelper(ext_modules)
 
-build__cython_kmeans(ext_modules)
+if sys.version_info < (3, 11):
+    build__cython_kmeans(ext_modules)
+else:
+    print("Internal K-means not yet supported for this version of python")
 
 build_PyMcaSciPy(ext_modules)
 build_plotting_ctools(ext_modules)


### PR DESCRIPTION
Follows:

https://stackoverflow.com/questions/4414234/getting-pythons-unittest-results-in-a-teardown-method

closes #889 