### PR TITLE
Fix rounding within OmnicMap's getPositionFromIndexAndInfo

### DIFF
--- a/PyMca5/PyMcaIO/OmnicMap.py
+++ b/PyMca5/PyMcaIO/OmnicMap.py
@@ -309,7 +309,7 @@ class OmnicMap(DataObject.DataObject):
         x1, y1 = ddict['Last map location']
         deltaX = ddict['Mapping stage X step size']
         deltaY = ddict['Mapping stage Y step size']
-        nX = int(1 + ((x1 - x0) / deltaX))
+        nX = int(round(1 + ((x1 - x0) / deltaX)))
         x = x0 + (index % nX) * deltaX
         y = y0 + int(index / nX) * deltaY
         return x, y


### PR DESCRIPTION
This PR aims to fix an intermittent issue in reading positions from maps.

@clsandt sent me a map where:
- deltaX = 49.97058868408203
- x0 = -815.0
- x1 = 884.0

The number of jumps (intervals) in X is ((x1 - x0) / deltaX) which is 33.9999996946446, which means that the number of measurements nX is 33.9999996946446 + 1.

The old code wrongly rounded this down. This is what the consequences look like:
![before](https://user-images.githubusercontent.com/552182/191759385-8845af6e-d0aa-4b1a-a3eb-7e05531e4ffe.png)

The new code rounds before converting to int so it is more robust to numeric inaccuracies. I think the change is self-explanatory. After the change (also as Omnic's software shows it):

![after](https://user-images.githubusercontent.com/552182/191759640-58833959-b938-416d-b017-298ae50bbc34.png)
