### PR TITLE
[XRF] XRF fit improvements

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/StrategyHandler.py
+++ b/PyMca5/PyMcaGui/physics/xrf/StrategyHandler.py
@@ -185,7 +185,7 @@ class SingleLayerStrategyWidget(qt.QWidget):
         label = qt.QLabel("Number of matrix iterations to perfom:")
         self._nIterations = qt.QSpinBox(self)
         self._nIterations.setMinimum(1)
-        self._nIterations.setMaximum(5)
+        self._nIterations.setMaximum(100)
         self._nIterations.setValue(3)
         self.mainLayout.addWidget(label, 0, 0)
         self.mainLayout.addWidget(qt.HorizontalSpacer(self), 1, 0)

--- a/PyMca5/PyMcaPhysics/xrf/ClassMcaTheory.py
+++ b/PyMca5/PyMcaPhysics/xrf/ClassMcaTheory.py
@@ -440,7 +440,7 @@ class McaTheory(object):
             div.sort()
             #print "before = ",len(newpeaksnames)
             div = Elements._filterPeaks(div, ethreshold = deltaonepeak,
-                                            ithreshold = 0.0005,
+                                            ithreshold = 0.00005,
                                             #ithreshold = ithreshold,
                                             nthreshold = None,
                                             keeptotalrate=True)


### PR DESCRIPTION
- Do not limit the number of matrix iterations to 5.
- Allow lower intensity peaks.