### PR TITLE
[IO] Minimal support of bcf files

### DIFF
--- a/PyMca5/PyMcaCore/McaStackExport.py
+++ b/PyMca5/PyMcaCore/McaStackExport.py
@@ -2,10 +2,10 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020-2022 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-__author__ = "V.A. Sole - ESRF Data Analysis"
+__author__ = "V.A. Sole - ESRF"
 __contact__ = "sole@esrf.fr"
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
@@ -265,7 +265,11 @@ def exportStack(stack, h5object, path, channels=None, calibration=None):
                                   dtype=numpy.float32)
                 dim0[:] = yScale[0] + yScale[1] * numpy.arange(len(dim0))
                 dim1[:] = xScale[0] + xScale[1] * numpy.arange(len(dim1))
-                map_[dim2_name] = h5py.SoftLink(h5g["channels"].name)
+                if "channels" in h5g:
+                    map_[dim2_name] = h5py.SoftLink(h5g["channels"].name)
+                else:
+                    map_[dim2_name] = numpy.arange(data.shape[-1],
+                                                   dtype=numpy.float32)
                 dim2 = map_[dim2_name]
                 dim0.attrs["long_name"] = dim0_long_name
                 dim1.attrs["long_name"] = dim1_long_name

--- a/PyMca5/PyMcaCore/StackBase.py
+++ b/PyMca5/PyMcaCore/StackBase.py
@@ -34,7 +34,7 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 Base class to handle stacks.
 
 """
-from . import DataObject
+from PyMca5.PyMcaCore import DataObject
 import numpy
 import time
 import os
@@ -208,7 +208,8 @@ class StackBase(object):
            ("DataObject.DataObject" in ("%s" % type(stack))) or\
            ("QStack" in ("%s" % type(stack))) or\
            ("Map" in ("%s" % type(stack)))or\
-           ("Stack" in ("%s" % type(stack))):
+           ("Stack" in ("%s" % type(stack))) or\
+           (hasattr(stack, "data") and hasattr(stack, "info")):
             self._stack = stack
             self._stack.info['SourceName'] = stack.info.get('SourceName',
                                                             "Data of unknown origin")

--- a/PyMca5/PyMcaGui/pymca/StackSelector.py
+++ b/PyMca5/PyMcaGui/pymca/StackSelector.py
@@ -52,6 +52,7 @@ from PyMca5.PyMcaIO import OmdaqLmf
 from PyMca5.PyMcaIO import JcampOpusStack
 from PyMca5.PyMcaIO import FsmMap
 from PyMca5.PyMcaIO import LabSpec6TxtMap
+from PyMca5.PyMcaIO import BrukerBCF
 from .QStack import QStack, QSpecFileStack
 try:
     from PyMca5.PyMcaGui.pymca import QHDF5Stack1D
@@ -202,16 +203,24 @@ class StackSelector(object):
                 # columns would be accepted as a Renishaw Map
                 # by other hand, I do not know how to handle
                 # that case as a stack.
+                _logger.info("RenishawMap")
                 stack = RenishawMap.RenishawMap(filelist[0])
                 omnicfile = True
             elif OmdaqLmf.isOmdaqLmf(filelist[0]):
+                _logger.info("OmdaqLmf")
                 stack = OmdaqLmf.OmdaqLmf(filelist[0])
                 omnicfile = True
             elif FsmMap.isFsmFile(filelist[0]):
+                _logger.info("FsmMap")
                 stack = FsmMap.FsmMap(filelist[0])
                 omnicfile = True
             elif JcampOpusStack.isJcampOpusStackFile(filelist[0]):
+                _logger.info("JcampOpusStack")
                 stack = JcampOpusStack.JcampOpusStack(filelist[0])
+                omnicfile = True
+            elif BrukerBCF.isBrukerBCFFile(filelist[0]):
+                _logger.info("Bruker bcf")
+                stack = BrukerBCF.BrukerBCF(filelist[0])
                 omnicfile = True
             else:
                 stack = QSpecFileStack()
@@ -397,6 +406,9 @@ class StackSelector(object):
         if not HDF5:
             idx = fileTypeList.index("HDF5 Files (*.nxs *.hdf *.hdf5 *.h5)")
             del fileTypeList[idx]
+        if BrukerBCF.HAS_BCF_SUPPORT:
+            idx = fileTypeList.index("RTX Files (*.rtx *.RTX)")
+            fileTypeList.insert(idx+1, "BCF Files (*.bcf *.BCF)")
         message = "Open ONE indexed stack or SEVERAL files"
         return self._getFileList(fileTypeList, message=message,
                                  getfilter=getfilter)

--- a/PyMca5/PyMcaIO/BrukerBCF.py
+++ b/PyMca5/PyMcaIO/BrukerBCF.py
@@ -101,9 +101,11 @@ class BrukerBCF(DataObject):
         root = root.find("./ClassInstance[@Type='TRTSpectrumDatabase']")
         xScale, yScale = get_scales(root)
         self.info["xScale"] = xScale
-        self.info["xScale"][1] = xScale[1] * self._sampling
+        if xScale:
+            self.info["xScale"][1] = xScale[1] * self._sampling
         self.info["yScale"] = yScale
-        self.info["yScale"][1] = yScale[1] * self._sampling
+        if yScale:
+            self.info["yScale"][1] = yScale[1] * self._sampling
         self.info["McaCalib"] = get_calibration(root)
 
 def get_scales(root):

--- a/PyMca5/PyMcaIO/BrukerBCF.py
+++ b/PyMca5/PyMcaIO/BrukerBCF.py
@@ -145,6 +145,4 @@ if __name__ == "__main__":
     stack = BrukerBCF(filename)
     print(stack.data)
     print(stack.info)
-    
-    
 

--- a/PyMca5/PyMcaIO/BrukerBCF.py
+++ b/PyMca5/PyMcaIO/BrukerBCF.py
@@ -1,0 +1,135 @@
+#/*##########################################################################
+#
+# The PyMca X-Ray Fluorescence Toolkit
+#
+# Copyright (c) 2022 European Synchrotron Radiation Facility
+#
+# This file is part of the PyMca X-ray Fluorescence Toolkit developed at
+# the ESRF.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+__author__ = "V.A. Sole - ESRF"
+__contact__ = "sole@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "26/10/2022"
+
+import sys
+import os
+import struct
+import numpy
+import logging
+
+_logger = logging.getLogger(__name__)
+
+try:
+    from bcflight import bruker
+    _logger.info("Bruker BCF file supported")
+    HAS_BCF_SUPPORT = True
+except:
+    _logger.info("Bruker BCF file support not available")
+    HAS_BCF_SUPPORT = False
+
+try:
+    from PyMca5.PyMcaCore.Dataobject import DataObject
+except ImportError:
+    _logger.info("Using built-in container")
+    class DataObject:
+        def __init__(self):
+            self.info = {}
+            self.data = numpy.array([])
+
+SOURCE_TYPE = "EdfFileStack"
+
+class BrukerBCF(DataObject):
+    def __init__(self, filename):
+        if not isBrukerBCFFile(filename):
+            raise IOError("Filename %s does not seem to be a Bruker bcf file")
+        DataObject.__init__(self)
+        reader = bruker.BCF_reader(filename)
+        # TODO: I should allow downsampling here
+        self.data = reader.parse_hypermap(downsample=1, lazy=False)
+        print(type(self.data))
+        self.sourceName = filename
+        self.info = {}
+        self.info["SourceType"] = SOURCE_TYPE
+        self.info["SourceName"] = self.sourceName
+        shape = self.data.shape
+        for i in range(len(shape)):
+            key = 'Dim_%d' % (i + 1,)
+            self.info[key] = shape[i]
+        self.info["NumberOfFiles"] = 1
+        self.info["McaIndex"] = -1
+        self.info["McaCalib"] = [0.0, 1.0, 0.0]
+        self.info["Channel0"] = 0.0
+        return
+
+        # header information
+        header_file = reader.get_file('EDSDatabase/HeaderData')
+        header_byte_str = header_file.get_as_BytesIO_string().getvalue()
+        hd_bt_str = bruker.fix_dec_patterns.sub(b'\\1.\\2', header_byte_str)
+        xml_str = hd_bt_str
+        root = ET.fromstring(xml_str)
+        root = root.find("./ClassInstance[@Type='TRTSpectrumDatabase']")
+
+
+def isBrukerBCFFile(filename):
+    _logger.info("BrukerBCF.isBrukerBCFFile called %s" % filename)
+    result = False
+    try:
+        owner = False
+        if not hasattr(filename, "seek"):
+            fid = open(filename, mode='rb')
+            owner = True
+        else:
+            fid =filename
+        fid.seek(0)
+        eight_chars = fid.read(8)
+        if hasattr(eight_chars, "decode"):
+            if eight_chars == b"AAMVHFSS":
+                if owner:
+                    fid.close()
+                _logger.info("It is a Bruker bcf file")
+                result = True
+        else:
+            if eight_chars == "AAMVHFSS":
+                if owner:
+                    fid.close()
+                _logger.info("It is a Bruker bcf file")
+                result = True
+    except:
+        if owner:
+            fid.close()
+    if result:
+        _logger.info("It is a Bruker bcf file")
+    else:
+        _logger.info("Not a Bruker bcf file")
+    return result
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        filename = sys.argv[1]
+    else:
+        print("Usage: ")
+        print("python BrukerBCF.py filename")
+        sys.exit(0)
+    print("is Bruker BCF File?", isBrukerBCF(filename))
+


### PR DESCRIPTION
This PR allows reading of bcf files, including energy calibration into the ROI Imaging Tool.

In case the map does not fit into memory, an automatic down sampling takes place.

For the time being, the data might need to be exported to HDF5 for full functionality.

The live_time of each pixel still has to be read.