### PR TITLE
Swap arg places in nxClassNeedsInit error message

### DIFF
--- a/PyMca5/PyMcaIO/NexusUtils.py
+++ b/PyMca5/PyMcaIO/NexusUtils.py
@@ -241,7 +241,7 @@ def nxClassNeedsInit(parent, name, nxclass):
         _nxclass = nxClass(parent[name])
         if _nxclass != nxclass:
             raise RuntimeError('{} is an instance of {} instead of {}'
-                               .format(parent[name].name, nxclass, _nxclass))
+                               .format(parent[name].name, _nxclass, nxclass))
         return False
     else:
         parent.create_group(name)


### PR DESCRIPTION
When trying to save fit results in `/`, I got the following error:

```
RuntimeError: / is an instance of NXentry instead of NXroot
```

which felt odd to me (`/` is often `NXroot` and not `NXentry`).

A quick check in the code showed me that the NXclasses in the error message were indeed swapped. This PR fixes this.