### PR TITLE
[IO] RTX Map. Ignore sum spectrum in processed maps.

### DIFF
--- a/PyMca5/PyMcaIO/RTXMap.py
+++ b/PyMca5/PyMcaIO/RTXMap.py
@@ -3,7 +3,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -84,6 +84,11 @@ class RTXMap(DataObject.DataObject):
         motorNames = sf.allmotors()
         # assuming dictionaries are ordered
         if len(motorNames):
+            # test if last scan also contains motors
+            # processed files contain an additional sum spectrum
+            if len(sf[-1].allmotorpos()) == 0:
+                _logger.info("Last scan does not contain motors. Ignoring it")
+            nScans -= 1
             positioners = {}
             for mne in motorNames:
                 positioners[mne] = numpy.zeros((nScans,),


### PR DESCRIPTION
Identify the sum spectrum because it has no motor positions while the other scans have them.

```
error opening an rtx file
 
Traceback (most recent call last):
File "PyMcaMain", line 1439, in __roiImaging
File "PyMca5\PyMcaGui\pymca\QStackWidget.py", line 630, in loadStack
stack = self.stackSelector.getStack()
File "PyMca5\PyMcaGui\pymca\StackSelector.py", line 181, in getStack
stack = RTXMap.RTXMap(filelist[0])
File "PyMca5\PyMcaIO\RTXMap.py", line 105, in __init__
positioners[mne][i] = motorPos[mneIdx]
IndexError: list index out of range
```