### PR TITLE
[PyMcaBatch] Force default to cfg for the fit configuration file.

### DIFF
--- a/PyMca5/PyMcaGui/io/ConfigurationFileDialogs.py
+++ b/PyMca5/PyMcaGui/io/ConfigurationFileDialogs.py
@@ -1,8 +1,8 @@
 #/*##########################################################################
-# Copyright (C) 2019 European Synchrotron Radiation Facility
+# Copyright (C) 2019-2023 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
-# the ESRF by the Software group.
+# the ESRF.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
+++ b/PyMca5/PyMcaGui/pymca/PyMcaBatch.py
@@ -1142,7 +1142,7 @@ class McaBatchGUI(qt.QWidget):
             self.inputDir =  os.getcwd()
         wdir = self.inputDir
         wfilter = self.inputFilter
-        filetypes = "McaFiles (*.mca)\nEdfFiles (*.edf)\n"
+        filetypes = "McaFiles (*.mca)\nEdfFiles (*.edf)\nCSV (*.csv *.CSV)\n"
         if HDF5SUPPORT:
             filetypes += "HDF5 (*.nxs *.h5 *.hdf *.hdf5)\n"
         filetypes += "SpecFiles (*.spec)\nSpecFiles (*.dat)\nAll files (*)"
@@ -1169,7 +1169,8 @@ class McaBatchGUI(qt.QWidget):
         fileList = ConfigurationFileDialogs.getFitConfigurationFilePath(self,
                                                 currentdir=wdir,
                                                 mode="OPEN",
-                                                single=True)
+                                                single=True,
+                                                currentfilter="Fit configuration files (*.cfg)")
 
         if fileList:
             self.setConfigFile(fileList[0])


### PR DESCRIPTION
If all `All files` was selected for the input file list, the fit configuration was also defaulting to `All files`

Add CSV to the list of predefined filters