### PR TITLE
Handle ID18 MCA calibration under Python 3

### DIFF
--- a/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
@@ -808,7 +808,7 @@ class McaCalWidget(qt.QDialog):
         """
         if order == "TOF":
             return self.calculateTOF(usedpeaks)
-        if order in ["ID18", " ID14"]:
+        if order in ["ID18", "ID14"]:
             order = 2
         if len(usedpeaks) == 1:
             if (usedpeaks[0][0] - 0.0) > 1.0E-20:

--- a/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
@@ -1128,7 +1128,7 @@ class CalibrationParameters(qt.QWidget):
             self.CLabel.setText("Vr:")
             self.CText.setReadOnly(0)
             self.CFixed.show()
-        elif qstring in ["ID14", "ID18":
+        elif qstring in ["ID14", "ID18"]:
             self.caldict[self.currentcal]['order'] = 'ID14'
             self.CLabel.setText("C:")
             self.CText.setReadOnly(1)

--- a/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
@@ -429,7 +429,7 @@ class McaCalWidget(qt.QDialog):
             self.current  = current
             order = dict['caldict'][current]['order']
             self.caldict[current]['order'] = order
-            if order == "ID18":
+            if order in ["ID18", "ID14"]:
                 result = self.timeCalibratorCalibration()
                 if result is None:
                     return
@@ -1026,7 +1026,7 @@ class CalibrationParameters(qt.QWidget):
                                        options=['1st','2nd'])
             else:
                 self.orderbox = SimpleComboBox(parw,
-                                       options=['1st','2nd','TOF', 'ID18'])
+                                       options=['1st','2nd','TOF', 'ID14'])
         layout.addWidget(lab)
         layout.addWidget(self.orderbox)
         lab= qt.QLabel("A:", parw)
@@ -1128,8 +1128,8 @@ class CalibrationParameters(qt.QWidget):
             self.CLabel.setText("Vr:")
             self.CText.setReadOnly(0)
             self.CFixed.show()
-        elif qstring == "ID18":
-            self.caldict[self.currentcal]['order'] = 'ID18'
+        elif qstring in ["ID14", "ID18":
+            self.caldict[self.currentcal]['order'] = 'ID14'
             self.CLabel.setText("C:")
             self.CText.setReadOnly(1)
             if QTVERSION > '4.0.0':

--- a/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
+++ b/PyMca5/PyMcaGui/physics/xrf/McaCalWidget.py
@@ -808,6 +808,8 @@ class McaCalWidget(qt.QDialog):
         """
         if order == "TOF":
             return self.calculateTOF(usedpeaks)
+        if order in ["ID18", " ID14"]:
+            order = 2
         if len(usedpeaks) == 1:
             if (usedpeaks[0][0] - 0.0) > 1.0E-20:
                 return [0.0, usedpeaks[0][1]/usedpeaks[0][0], 0.0]

--- a/PyMca5/PyMcaGui/pymca/McaWindow.py
+++ b/PyMca5/PyMcaGui/pymca/McaWindow.py
@@ -1031,7 +1031,7 @@ class McaWindow(ScanWindow):
                                                 legend=legend,
                                                 info=curveinfo,
                                                 own=True)
-                            if calibrationOrder == 'ID18':
+                            if calibrationOrder in ["ID14", "ID18"]:
                                 self.setGraphXLabel('Time')
                             else:
                                 self.setGraphXLabel('Energy')
@@ -1076,7 +1076,7 @@ class McaWindow(ScanWindow):
                                               legend=legend,
                                               info=curveinfo,
                                               own=True)
-                            if calibrationOrder == 'ID18':
+                            if calibrationOrder in ["ID14", "ID18"]:
                                 self.setGraphXLabel('Time')
                             else:
                                 self.setGraphXLabel('Energy')

--- a/PyMca5/PyMcaGui/pymca/SilxMcaWindow.py
+++ b/PyMca5/PyMcaGui/pymca/SilxMcaWindow.py
@@ -1022,7 +1022,7 @@ class McaWindow(ScanWindow.ScanWindow):
                                               legend=legend,
                                               info=curveinfo,
                                               own=True)
-                            if calibrationOrder == 'ID18':
+                            if calibrationOrder in ["ID14", "ID18"]:
                                 self.setGraphXLabel('Time')
                             else:
                                 self.setGraphXLabel('Energy')
@@ -1066,7 +1066,7 @@ class McaWindow(ScanWindow.ScanWindow):
                                               legend=legend,
                                               info=curveinfo,
                                               own=True)
-                            if calibrationOrder == 'ID18':
+                            if calibrationOrder in ["ID14", "ID18"]:
                                 self.setGraphXLabel('Time')
                             else:
                                 self.setGraphXLabel('Energy')


### PR DESCRIPTION
There was a comparison between string and integer triggering an error when moving from ID18 to ID14.