### PR TITLE
Suppress syntax warnings

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
- The PyMca X-Ray Fluorescence Toolkit is Copyright (C) 2004-2022 of the European Synchrotron Radiation Facility (ESRF).
+ The PyMca X-Ray Fluorescence Toolkit is Copyright (C) 2004-2023 of the European Synchrotron Radiation Facility (ESRF).
 
 Unless otherways stated in the relevant accompanying source code, the default license of these modules is MIT.
 

--- a/package/cxfreeze/cx_setup.py
+++ b/package/cxfreeze/cx_setup.py
@@ -543,7 +543,7 @@ if not sys.platform.startswith("win"):
 
 
 #  generation of the NSIS executable
-nsis = os.path.join("\Program Files (x86)", "NSIS", "makensis.exe")
+nsis = os.path.join(r"\Program Files (x86)", "NSIS", "makensis.exe")
 if sys.platform.startswith("win") and os.path.exists(nsis):
     # check if we can perform the packaging
     outFile = "nsisscript.nsi"

--- a/package/pyinstaller/PyMca.txt
+++ b/package/pyinstaller/PyMca.txt
@@ -3,7 +3,7 @@
 
  Copyright (C) 2004-2023 European Synchrotron Radiation Facility
 
- The PyMca X-ray Fluorescence Toolkit is developed at the ESRF by the Software group.
+ The PyMca X-ray Fluorescence Toolkit is developed at the ESRF.
 
  PyMca follows the very permissive MIT license. However, this frozen binary
 uses GPL-licensed code and therefore this binary follows the GPL license that follows.

--- a/package/pyinstaller/pyinstaller.spec
+++ b/package/pyinstaller/pyinstaller.spec
@@ -644,7 +644,7 @@ else:
     frozenDir = target
 
     #  generation of the NSIS executable
-    nsis = os.path.join("\Program Files (x86)", "NSIS", "makensis.exe")
+    nsis = os.path.join(r"\Program Files (x86)", "NSIS", "makensis.exe")
     if sys.platform.startswith("win") and os.path.exists(nsis):
         # check if we can perform the packaging
         outFile = os.path.join(SPECPATH, "nsisscript.nsi")


### PR DESCRIPTION
Triggered by Python 3.12