### PR TITLE
[XRF] Discrepancies between GUI and Batch results

### DIFF
--- a/src/PyMca5/PyMcaGui/physics/xrf/ConcentrationsWidget.py
+++ b/src/PyMca5/PyMcaGui/physics/xrf/ConcentrationsWidget.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -382,7 +382,7 @@ class ConcentrationsWidget(qt.QWidget):
                 self.fundamentalWidget.autoTimeCheckBox.setChecked(False)
                 self.fundamentalWidget.time.setEnabled(True)
             else:
-                self.fundamentalWidget.time.setText("%.6g" % self._liveTime)
+                self.fundamentalWidget.time.setText("%.8g" % self._liveTime)
                 self.fundamentalWidget.time.setEnabled(False)
                 if signal:
                     self._mySignal()
@@ -570,16 +570,16 @@ class ConcentrationsWidget(qt.QWidget):
             #self.referenceCombo.setCurrentText(QString("Auto"))
             self.referenceLine.setText(QString("Auto"))
 
-        self.fundamentalWidget.flux.setText("%.6g" % ddict['flux'])
-        self.fundamentalWidget.area.setText("%.6g" % ddict['area'])
-        self.fundamentalWidget.distance.setText("%.6g" % ddict['distance'])
+        self.fundamentalWidget.flux.setText("%.8g" % ddict['flux'])
+        self.fundamentalWidget.area.setText("%.8g" % ddict['area'])
+        self.fundamentalWidget.distance.setText("%.8g" % ddict['distance'])
         if ddict['time'] is not None:
-            self.fundamentalWidget.time.setText("%.6g" % ddict['time'])
+            self.fundamentalWidget.time.setText("%.8g" % ddict['time'])
         autotime = ddict.get("useautotime", False)
         if autotime:
             self.fundamentalWidget.autoTimeCheckBox.setChecked(True)
             if self._liveTime is not None:
-                self.fundamentalWidget.time.setText("%.6g" % self._liveTime)
+                self.fundamentalWidget.time.setText("%.8g" % self._liveTime)
         else:
             self.fundamentalWidget.autoTimeCheckBox.setChecked(False)
 

--- a/src/PyMca5/PyMcaGui/physics/xrf/EnergyTable.py
+++ b/src/PyMca5/PyMcaGui/physics/xrf/EnergyTable.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2024 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -424,7 +424,7 @@ class EnergyTable(QTable):
                 item.setChecked(False)
                 self.setText(r, 1+coloffset,"")
             if idx < len(self.weightList):
-                self.setText(r, 2+coloffset,"%g" % self.weightList[idx])
+                self.setText(r, 2+coloffset,"%.8g" % self.weightList[idx])
             else:
                 self.setText(r, 2+coloffset,"")
 

--- a/src/PyMca5/PyMcaGui/physics/xrf/FitParamForm.py
+++ b/src/PyMca5/PyMcaGui/physics/xrf/FitParamForm.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -181,6 +181,7 @@ class FitParamForm(qt.QWidget):
         self.stripIterLabel.setText(str("Strip Background Iterations"))
 
         self.iterSpin = Q3SpinBox(self.tabFit)
+        self.iterSpin.setMaxValue(1000)
         self.iterSpin.setMinValue(1)
 
         self.stripFilterLabel = qt.QLabel(self.tabFit)

--- a/src/PyMca5/PyMcaMath/fitting/Gefit.py
+++ b/src/PyMca5/PyMcaMath/fitting/Gefit.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2024 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -455,7 +455,7 @@ def RestreinedLeastSquaresFit(model0,parameters0,data0,maxiter,
                 chisq0 = chisq
                 flambda = flambda / 10.0
                 #print "iter = ",iter,"chisq = ", chisq
-            iiter = iiter -1
+        iiter = iiter - 1
     sigma0 = numpy.sqrt(abs(numpy.diag(inv(alpha0))))
     sigmapar = getsigmaparameters(fittedpar,sigma0,constrains)
     if not fulloutput:

--- a/src/PyMca5/PyMcaPhysics/xrf/ClassMcaTheory.py
+++ b/src/PyMca5/PyMcaPhysics/xrf/ClassMcaTheory.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2024 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2025 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF.
@@ -2212,6 +2212,8 @@ class McaTheory(object):
         self.sigmapar =fitresult[2]
         self.__niter  =fitresult[3]
         self.__lastdeltachi = fitresult[4]
+        if self.__niter >= self.MAXITER:
+            print("WARNING: Needed %d iterations" % self.__niter) 
 
         callStrategy = False
         if currentIteration is None:
@@ -2256,6 +2258,8 @@ class McaTheory(object):
                     self.sigmapar =fitresult[2]
                     self.__niter  =fitresult[3]
                     self.__lastdeltachi = fitresult[4]
+                    if self.__niter >= self.MAXITER:
+                        print("WARNING: Needed %d iterations" % self.__niter) 
             except Exception:
                 _logger.error( \
                     "Exception during strategy. Restoring configuration")

--- a/src/PyMca5/PyMcaPhysics/xrf/FisxHelper.py
+++ b/src/PyMca5/PyMcaPhysics/xrf/FisxHelper.py
@@ -476,7 +476,7 @@ def getMultilayerFluorescence(multilayerSample,
             _logger.info("Threading by energies")
             t0 = time.time()
             max_workers = min(os.cpu_count(), int(len(energyList)/2))
-            _logger.info("Number of workers = ", max_workers)
+            _logger.info("Number of workers = %d" % max_workers)
             pool = ThreadPoolExecutor(max_workers=max_workers)
             ele = [x.split()[0] for x in actualElementsList]
             family = [x.split()[1] for x in actualElementsList]


### PR DESCRIPTION
Some users have manually edited the cfg file without passing via the GUI.

The retained accuracy in the cfg file was higher than in the GUI, thus leading to equivalent but not identical results when comparing batch (full accuracy retained) and GUI (limited by %.6g text formatting)

The description is changed from %.6g (default for the format) to %.8g that is overkill but improves reproducibility.