### PR TITLE
use one single function to sort HDF5 items

### DIFF
--- a/src/PyMca5/PyMcaCore/NexusDataSource.py
+++ b/src/PyMca5/PyMcaCore/NexusDataSource.py
@@ -51,6 +51,7 @@ if sys.version_info >= (3,):
 
 from . import DataObject
 from . import NexusTools
+from PyMca5.PyMcaIO.HDF5Utils import extract_numbers_from_string
 
 SOURCE_TYPE = "HDF5"
 
@@ -119,7 +120,7 @@ def h5py_sorting(object_list):
             return [x[1] for x in sorted_list]
 
         if sorting_key == 'name':
-            sorting_list = [(_get_number_list(o.name),o)
+            sorting_list = [(extract_numbers_from_string(o.name),o)
                            for o in object_list]
             sorting_list.sort()
             return [x[1] for x in sorting_list]
@@ -131,10 +132,6 @@ def h5py_sorting(object_list):
         _logger.warning("Probably all entries do not have the key %s", sorting_key)
         return object_list
 
-def _get_number_list(txt):
-    rexpr = '[/a-zA-Z:-]'
-    nbs= [float(w) for w in re.split(rexpr, txt) if w not in ['',' ']]
-    return nbs
 
 def get_family_pattern(filelist):
     name1 = filelist[0]

--- a/src/PyMca5/PyMcaCore/NexusDataSource.py
+++ b/src/PyMca5/PyMcaCore/NexusDataSource.py
@@ -40,9 +40,7 @@ except Exception:
     # but do not crash just because of it
     pass
 import h5py
-from operator import itemgetter
 import re
-import posixpath
 import logging
 phynx = h5py
 
@@ -51,7 +49,6 @@ if sys.version_info >= (3,):
 
 from . import DataObject
 from . import NexusTools
-from PyMca5.PyMcaIO.HDF5Utils import extract_numbers_from_string
 
 SOURCE_TYPE = "HDF5"
 
@@ -86,51 +83,6 @@ def h5open(filename):
                     _logger.info("Cannot open %s using silx" % filename)
             # give back the original error
             return h5py.File(filename, "r")
-
-#sorting method
-def h5py_sorting(object_list):
-    sorting_list = ['start_time', 'end_time', 'name']
-    n = len(object_list)
-    if n < 2:
-        return object_list
-
-    # This implementation only sorts entries
-    if posixpath.dirname(object_list[0].name) != "/":
-        return object_list
-
-    names = list(object_list[0].keys())
-
-    sorting_key = None
-    for key in sorting_list:
-        if key in names:
-            sorting_key = key
-            break
-
-    if sorting_key is None:
-        if 'name' in sorting_list:
-            sorting_key = 'name'
-        else:
-            return object_list
-
-    try:
-        if sorting_key != 'name':
-            sorting_list = [(o[sorting_key][()], o)
-                           for o in object_list]
-            sorted_list = sorted(sorting_list, key=itemgetter(0))
-            return [x[1] for x in sorted_list]
-
-        if sorting_key == 'name':
-            sorting_list = [(extract_numbers_from_string(o.name),o)
-                           for o in object_list]
-            sorting_list.sort()
-            return [x[1] for x in sorting_list]
-    except Exception:
-        #The only way to reach this point is to have different
-        #structures among the different entries. In that case
-        #defaults to the unfiltered case
-        _logger.warning("Default ordering")
-        _logger.warning("Probably all entries do not have the key %s", sorting_key)
-        return object_list
 
 
 def get_family_pattern(filelist):

--- a/src/PyMca5/PyMcaCore/NexusTools.py
+++ b/src/PyMca5/PyMcaCore/NexusTools.py
@@ -53,6 +53,8 @@ except Exception:
     def is_group(something):
         return False
 
+from PyMca5.PyMcaIO.HDF5Utils import extract_numbers_from_string
+
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -119,7 +121,7 @@ def h5py_sorting(object_list):
             return [x[1] for x in sorted_list]
 
         if sorting_key == 'name':
-            sorting_list = [(_get_number_list(o[1].name),o)
+            sorting_list = [(extract_numbers_from_string(o[1].name),o)
                            for o in object_list]
             sorting_list.sort()
             return [x[1] for x in sorting_list]
@@ -131,10 +133,6 @@ def h5py_sorting(object_list):
                         "Probably all entries do not have the key %s", sorting_key)
         return object_list
 
-def _get_number_list(txt):
-    rexpr = '[/a-zA-Z:-]'
-    nbs= [float(w) for w in re.split(rexpr, txt) if w not in ['',' ']]
-    return nbs
 
 def getEntryName(path, h5file=None):
     """

--- a/src/PyMca5/PyMcaCore/NexusTools.py
+++ b/src/PyMca5/PyMcaCore/NexusTools.py
@@ -32,8 +32,6 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import os
-from operator import itemgetter
-import re
 import posixpath
 try:
     # try to import hdf5plugin
@@ -53,7 +51,7 @@ except Exception:
     def is_group(something):
         return False
 
-from PyMca5.PyMcaIO.HDF5Utils import extract_numbers_from_string
+from PyMca5.PyMcaIO.HDF5Utils import sort_h5items
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -75,63 +73,6 @@ def isDataset(item):
         return True
     else:
         return False
-
-#sorting method
-def h5py_sorting(object_list):
-    sorting_list = ['start_time', 'end_time', 'name']
-    n = len(object_list)
-    if n < 2:
-        return object_list
-
-    # we have received items, not values
-    # perform a first sort based on received names
-    # this solves a problem with Eiger data where all the
-    # external data have the same posixName. Without this sorting
-    # they arrive "unsorted"
-    object_list.sort()
-    try:
-        posixNames = [item[1].name for item in object_list]
-    except AttributeError:
-        # Typical of broken external links
-        _logger.debug("HDF5Widget: Cannot get posixNames")
-        return object_list
-
-    # This implementation only sorts entries
-    if posixpath.dirname(posixNames[0]) != "/":
-        return object_list
-
-    sorting_key = None
-    if hasattr(object_list[0][1], "items"):
-        for key in sorting_list:
-            if key in [x[0] for x in object_list[0][1].items()]:
-                sorting_key = key
-                break
-
-    if sorting_key is None:
-        if 'name' in sorting_list:
-            sorting_key = 'name'
-        else:
-            return object_list
-
-    try:
-        if sorting_key != 'name':
-            sorting_list = [(o[1][sorting_key][()], o)
-                           for o in object_list]
-            sorted_list = sorted(sorting_list, key=itemgetter(0))
-            return [x[1] for x in sorted_list]
-
-        if sorting_key == 'name':
-            sorting_list = [(extract_numbers_from_string(o[1].name),o)
-                           for o in object_list]
-            sorting_list.sort()
-            return [x[1] for x in sorting_list]
-    except Exception:
-        #The only way to reach this point is to have different
-        #structures among the different entries. In that case
-        #defaults to the unfiltered case
-        _logger.warning("Default ordering. "
-                        "Probably all entries do not have the key %s", sorting_key)
-        return object_list
 
 
 def getEntryName(path, h5file=None):
@@ -460,7 +401,7 @@ def getNXClassGroups(h5file, path, classes, single=False):
     groups = []
     items_list = list(h5file[path].items())
     if ("NXentry" in classes) or (b"NXentry" in classes):
-        items_list = h5py_sorting(items_list)
+        items_list = sort_h5items(items_list)
 
     for key, group in items_list:
         if not isGroup(group):

--- a/src/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -31,10 +31,7 @@ __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 import sys
 import os
 import posixpath
-import time
 import gc
-import re
-from operator import itemgetter
 import logging
 _logger = logging.getLogger(__name__)
 
@@ -67,7 +64,7 @@ except ImportError:
             return h5py.File(filename, "r", libver='latest', swmr=True)
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
-from PyMca5.PyMcaIO.HDF5Utils import extract_numbers_from_string
+from PyMca5.PyMcaIO.HDF5Utils import sort_h5items
 
 safe_str = qt.safe_str
 
@@ -78,89 +75,6 @@ else:
         return x
 
 QVERSION = qt.qVersion()
-
-
-#sorting method
-def h5py_sorting(object_list, sorting_list=None):
-    if sorting_list is None:
-        sorting_list = ['start_time', 'end_time', 'name']
-    n = len(object_list)
-    if n < 2:
-        return object_list
-
-    # we have received items, not values
-    # perform a first sort based on received names
-    # this solves a problem with Eiger data where all the
-    # external data have the same posixName. Without this sorting
-    # they arrive "unsorted"
-    object_list.sort()
-    try:
-        posixNames = [item[1].name for item in object_list]
-    except AttributeError:
-        # Typical of broken external links
-        _logger.debug("HDF5Widget: Cannot get posixNames")
-        return object_list
-
-    # This implementation only sorts entries
-    if posixpath.dirname(posixNames[0]) != "/":
-        return object_list
-
-    sorting_key = None
-    if hasattr(object_list[0][1], "items"):
-        for key in sorting_list:
-            if key in [x[0] for x in object_list[0][1].items()]:
-                sorting_key = key
-                break
-
-    if sorting_key is None:
-        if 'name' in sorting_list:
-            sorting_key = 'name'
-        else:
-            return object_list
-
-    try:
-        if sorting_key == 'title':
-            def getTitle(x):
-                try:
-                    title = x["title"][()]
-                except Exception:
-                    # allow the title to be missing
-                    title = ""
-                if hasattr(title, "dtype"):
-                    if hasattr(title, "__len__"):
-                        if len(title) == 1:
-                            title = title[0]
-                if hasattr(title, "decode"):
-                    title = title.decode("utf-8")
-                return title
-            # sort first by the traditional keys in order to be sorted
-            # by title and respecting actquisition order for equal title
-            try:
-                ordered_list = h5py_sorting(object_list)
-            except Exception:
-                ordered_list = object_list
-            sorting_list = [(getTitle(o[1]), o) for o in ordered_list]
-            sorted_list = sorted(sorting_list, key=itemgetter(0))
-            return [x[1] for x in sorted_list]
-
-        if sorting_key != 'name':
-            sorting_list = [(o[1][sorting_key][()], o)
-                           for o in object_list]
-            sorted_list = sorted(sorting_list, key=itemgetter(0))
-            return [x[1] for x in sorted_list]
-
-        if sorting_key == 'name':
-            sorting_list = [(extract_numbers_from_string(o[1].name),o)
-                           for o in object_list]
-            sorting_list.sort()
-            return [x[1] for x in sorting_list]
-    except Exception:
-        #The only way to reach this point is to have different
-        #structures among the different entries. In that case
-        #defaults to the unfiltered case
-        _logger.warning("WARNING: Default ordering")
-        _logger.warning("Probably all entries do not have the key %s" % sorting_key)
-        return object_list
 
 
 class BrokenLink(object):
@@ -271,7 +185,7 @@ class H5NodeProxy(object):
                     items = list(self.getNode(self.name).items())
                 try:
                     # better handling of external links
-                    finalList = h5py_sorting(items, sorting_list=self.__sorting_list)
+                    finalList = sort_h5items(items, sorting_list=self.__sorting_list)
                     for i in range(len(finalList)):
                         # avoid an error at silx level with the linechecking "if finalList[i][1] and "
                         finalListIsTrue = True

--- a/src/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/HDF5Widget.py
@@ -67,6 +67,8 @@ except ImportError:
             return h5py.File(filename, "r", libver='latest', swmr=True)
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
+from PyMca5.PyMcaIO.HDF5Utils import extract_numbers_from_string
+
 safe_str = qt.safe_str
 
 if hasattr(qt, 'QStringList'):
@@ -148,7 +150,7 @@ def h5py_sorting(object_list, sorting_list=None):
             return [x[1] for x in sorted_list]
 
         if sorting_key == 'name':
-            sorting_list = [(_get_number_list(o[1].name),o)
+            sorting_list = [(extract_numbers_from_string(o[1].name),o)
                            for o in object_list]
             sorting_list.sort()
             return [x[1] for x in sorting_list]
@@ -159,12 +161,6 @@ def h5py_sorting(object_list, sorting_list=None):
         _logger.warning("WARNING: Default ordering")
         _logger.warning("Probably all entries do not have the key %s" % sorting_key)
         return object_list
-
-
-def _get_number_list(txt):
-    rexpr = '[/a-zA-Z:_-]'
-    nbs= [float(w) for w in re.split(rexpr, txt) if w not in ['',' ']]
-    return nbs
 
 
 class BrokenLink(object):

--- a/src/PyMca5/PyMcaIO/HDF5Utils.py
+++ b/src/PyMca5/PyMcaIO/HDF5Utils.py
@@ -1,8 +1,14 @@
 import os
 import re
 import h5py
+import logging
+import posixpath
 from queue import Empty
 import multiprocessing
+from operator import itemgetter
+
+
+_logger = logging.getLogger(__name__)
 
 
 def get_hdf5_group_keys(file_path, data_path=None):
@@ -49,8 +55,102 @@ def subprocess_main(queue, method, *args, **kwargs):
     queue.put(method(*args, **kwargs))
 
 
-def extract_numbers_from_string(txt):
-    return [int(w) for w in _NON_NUMERIC_CHARS.split(txt) if w]
+def sort_h5items(h5_items, sorting_list=None):
+    """
+    :param h5_items: list of key and HDF5 item pairs
+    :param sorting_list: list of HDF5 datasets names to sort on
+    :returns: list of key and HDF5 item pairs
+    """
+    n = len(h5_items)
+    if n < 2:
+        return h5_items
 
+    if sorting_list is None:
+        sorting_list = ['start_time', 'end_time']
+
+    # we have received items, not values
+    # perform a first sort based on received names
+    # this solves a problem with Eiger data where all the
+    # external data have the same posixName. Without this sorting
+    # they arrive "unsorted"
+    h5_items.sort()
+    try:
+        posixNames = [h5_item.name for _, h5_item in h5_items]
+    except AttributeError as ex:
+        # Typical of broken external links
+        _logger.debug(f"Cannot get posixNames: {ex}")
+        return h5_items
+
+    # This implementation only sorts entries
+    if posixpath.dirname(posixNames[0]) != "/":
+        return h5_items
+
+    sorting_key = None
+    first_h5_item = h5_items[0][1]
+    if hasattr(first_h5_item, "items"):
+        names = [k for k, _ in first_h5_item.items()]
+        for name in sorting_list:
+            if name in names:
+                sorting_key = name
+                break
+
+    if sorting_key:
+        try:
+            if sorting_key == 'title':
+                list_to_sort = [(_extract_h5title(item[1]), item) for item in h5_items]
+            else:
+                list_to_sort = [(item[1][sorting_key][()], item) for item in h5_items]
+        except Exception as ex:
+            list_to_sort = []
+            _logger.warning("WARNING: Sorting by '%s' failed (%s)", sorting_key, ex)
+
+        if _list_of_tuples_has_unique_first_item(list_to_sort):
+            sorted_list = sorted(list_to_sort, key=itemgetter(0))
+            return [item for _, item in sorted_list]
+
+        sorting_list = [key for key in sorting_list if key != sorting_key]
+        if sorting_list:
+            return sort_h5items(h5_items, sorting_list=sorting_list)
+
+    try:
+        list_to_sort = [(_extract_sort_key_from_name(item[1].name), item) for item in h5_items]
+    except Exception as ex:
+        list_to_sort = []
+        _logger.warning("WARNING: Sorting by name failed ('%s')", sorting_key, ex)
+
+    if _list_of_tuples_has_unique_first_item(list_to_sort):
+        sorted_list = sorted(list_to_sort, key=itemgetter(0))
+        return [item for _, item in sorted_list]
+
+    return h5_items
+
+
+def _list_of_tuples_has_unique_first_item(list_of_tuples):
+    if not list_of_tuples:
+        return False
+    first_items = [tpl[0] for tpl in list_of_tuples]
+    return len(set(first_items)) == len(first_items)
+
+
+def _extract_h5title(h5item):
+    try:
+        title = h5item["title"][()]
+    except Exception:
+        # allow the title to be missing
+        title = ""
+    if hasattr(title, "dtype"):
+        if hasattr(title, "__len__"):
+            if len(title) == 1:
+                title = title[0]
+    if hasattr(title, "decode"):
+        title = title.decode("utf-8")
+    return title
+
+
+def _extract_sort_key_from_name(name):
+    key = tuple(int(w) for w in _NON_NUMERIC_CHARS.split(name) if w)
+    if key:
+        return key
+    return name
 
 _NON_NUMERIC_CHARS = re.compile('[^0-9]')

--- a/src/PyMca5/PyMcaIO/HDF5Utils.py
+++ b/src/PyMca5/PyMcaIO/HDF5Utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import h5py
 from queue import Empty
 import multiprocessing
@@ -46,3 +47,9 @@ def run_in_subprocess(target, *args, context=None, default=None, **kwargs):
 
 def subprocess_main(queue, method, *args, **kwargs):
     queue.put(method(*args, **kwargs))
+
+
+def extract_numbers_from_string(txt):
+    rexpr = '[/a-zA-Z:_-]'
+    nbs= [float(w) for w in re.split(rexpr, txt) if w not in ['',' ']]
+    return nbs

--- a/src/PyMca5/PyMcaIO/HDF5Utils.py
+++ b/src/PyMca5/PyMcaIO/HDF5Utils.py
@@ -50,6 +50,7 @@ def subprocess_main(queue, method, *args, **kwargs):
 
 
 def extract_numbers_from_string(txt):
-    rexpr = '[/a-zA-Z:_-]'
-    nbs= [float(w) for w in re.split(rexpr, txt) if w not in ['',' ']]
-    return nbs
+    return [int(w) for w in _NON_NUMERIC_CHARS.split(txt) if w]
+
+
+_NON_NUMERIC_CHARS = re.compile('[^0-9]')

--- a/src/PyMca5/tests/HDF5UtilsTest.py
+++ b/src/PyMca5/tests/HDF5UtilsTest.py
@@ -1,7 +1,9 @@
 import os
+import time
 import shutil
 import tempfile
 import unittest
+import datetime
 import h5py
 
 from PyMca5.PyMcaIO import HDF5Utils
@@ -41,6 +43,96 @@ class testHDF5Utils(unittest.TestCase):
 
     def testSegFault(self):
         self.assertEqual(_safe_cause_segfault(default=123), 123)
+
+    def testHdf5GroupSortByName(self):
+        filename = os.path.join(self.path, "test.h5")
+
+        with h5py.File(filename, "w", track_order=True) as f:
+            _ = f.create_group("c")
+            _ = f.create_group("b")
+            _ = f.create_group("a")
+
+        with h5py.File(filename, "r") as f:
+            h5_items = list(f.items())
+            keys = [key for key, _ in HDF5Utils.sort_h5items(h5_items)]
+        assert keys == ["a", "b", "c"]
+
+    def testHdf5GroupSortByNameWithNumbers(self):
+        filename = os.path.join(self.path, "test.h5")
+
+        expected = []
+        with h5py.File(filename, "w", track_order=True) as f:
+            for i in list(range(1, 11))[::-1]:
+                key = f"1.{i}"
+                _ = f.create_group(key)
+                expected.insert(0, key)
+
+        with h5py.File(filename, "r") as f:
+            h5_items = list(f.items())
+            keys = [key for key, _ in HDF5Utils.sort_h5items(h5_items)]
+        assert keys == expected
+
+    def testHdf5GroupSortByStartTime(self):
+        filename = os.path.join(self.path, "test.h5")
+        expected = []
+        with h5py.File(filename, "w", track_order=True) as f:
+            for i in list(range(1, 11))[::-1]:
+                key = f"1.{i}"
+                grp = f.create_group(key)
+                grp["start_time"] = datetime.datetime.now().astimezone().isoformat()
+                expected.append(key)
+                time.sleep(0.1)  # make sure the start_time is unique
+
+        with h5py.File(filename, "r") as f:
+            h5_items = list(f.items())
+            keys = [key for key, _ in HDF5Utils.sort_h5items(h5_items)]
+        assert keys == expected
+
+    def testHdf5GroupSortByIdenticalStartTime(self):
+        filename = os.path.join(self.path, "test.h5")
+        expected = []
+        with h5py.File(filename, "w", track_order=True) as f:
+            start_time = datetime.datetime.now().astimezone().isoformat()
+            for i in list(range(1, 11))[::-1]:
+                key = f"1.{i}"
+                grp = f.create_group(key)
+                grp["start_time"] = start_time
+                expected.insert(0, key)
+
+        with h5py.File(filename, "r") as f:
+            h5_items = list(f.items())
+            keys = [key for key, _ in HDF5Utils.sort_h5items(h5_items)]
+        assert keys == expected
+
+    def testHdf5GroupSortByTitle(self):
+        filename = os.path.join(self.path, "test.h5")
+        expected = []
+        with h5py.File(filename, "w", track_order=True) as f:
+            for i in range(1, 11)[::-1]:
+                key = f"1.{11 - i}"
+                grp = f.create_group(key)
+                grp["title"] = chr(i + 65)
+                expected.insert(0, key)
+
+        with h5py.File(filename, "r") as f:
+            h5_items = list(f.items())
+            keys = [key for key, _ in HDF5Utils.sort_h5items(h5_items, ["title"])]
+        assert keys == expected
+
+    def testHdf5GroupSortByIdenticalTitle(self):
+        filename = os.path.join(self.path, "test.h5")
+        expected = []
+        with h5py.File(filename, "w", track_order=True) as f:
+            for i in range(1, 11)[::-1]:
+                key = f"1.{i}"
+                grp = f.create_group(key)
+                grp["title"] = "same title"
+                expected.insert(0, key)
+
+        with h5py.File(filename, "r") as f:
+            h5_items = list(f.items())
+            keys = [key for key, _ in HDF5Utils.sort_h5items(h5_items, ["title"])]
+        assert keys == expected
 
 
 def getSuite(auto=True):


### PR DESCRIPTION
- Move and refactor the three copies of `h5py_sorting` to a single `PyMca5.PyMcaIO.HDF5Utils.sort_h5items` function
- Improve sorting by name by splitting on all non-numeric characters (if any)
- When sorting by title, start_time, etc. has duplicate values, fall back to sorting by name