### PR TITLE
H5py externallink fix

### DIFF
--- a/src/PyMca5/PyMcaGui/io/hdf5/NexusInfo.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/NexusInfo.py
@@ -129,10 +129,10 @@ def get_motor_positions(hdf5File, node):
     if not nxentry_name:
         return dict()
 
-    nxentry = node.file[nxentry_name] # nxentry = hdf5File[nxentry_name]
+    nxentry = node.file[nxentry_name]
     if not isinstance(nxentry, h5py.Group):
         return dict()
 
-    positions = getStartingPositionerValues(node.file, nxentry_name) # hdf5File
+    positions = getStartingPositionerValues(node.file, nxentry_name)
     column_names = "Name", "Value", "Units"
     return dict(zip(column_names, zip(*positions)))

--- a/src/PyMca5/PyMcaGui/io/hdf5/NexusInfo.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/NexusInfo.py
@@ -67,7 +67,6 @@ class NexusMotorInfoWidget(qt.QWidget):
     def setInfoDict(self, ddict):
         if "motors" in ddict:
             self._setInfoDict(ddict["motors"])
-            print('motors are here!')
         else:
             self._setInfoDict(ddict)
 

--- a/src/PyMca5/PyMcaGui/io/hdf5/NexusInfo.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/NexusInfo.py
@@ -29,6 +29,7 @@ __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
 
 import h5py
+import os
 
 from PyMca5.PyMcaGui import PyMcaQt as qt
 from PyMca5.PyMcaCore.NexusTools import getStartingPositionerValues
@@ -66,6 +67,7 @@ class NexusMotorInfoWidget(qt.QWidget):
     def setInfoDict(self, ddict):
         if "motors" in ddict:
             self._setInfoDict(ddict["motors"])
+            print('motors are here!')
         else:
             self._setInfoDict(ddict)
 
@@ -128,10 +130,10 @@ def get_motor_positions(hdf5File, node):
     if not nxentry_name:
         return dict()
 
-    nxentry = hdf5File[nxentry_name]
+    nxentry = node.file[nxentry_name] # nxentry = hdf5File[nxentry_name]
     if not isinstance(nxentry, h5py.Group):
         return dict()
 
-    positions = getStartingPositionerValues(hdf5File, nxentry_name)
+    positions = getStartingPositionerValues(node.file, nxentry_name) # hdf5File
     column_names = "Name", "Value", "Units"
     return dict(zip(column_names, zip(*positions)))

--- a/src/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -509,7 +509,6 @@ class QNexusWidget(qt.QWidget):
             phynxFile  = HDF5Widget.h5open(filename)
 
         info = self.getInfo(phynxFile, name)
-        # nxclass = phynxFile[name].attrs.get("NX_class")
         nxclass = phynxFile[name].file[phynxFile[name].name.split("/")[1]].attrs.get("NX_class")
         widget = NexusInfo.NexusInfoWidget(nxclass=nxclass)
         widget.notifyCloseEventToWidget(self)

--- a/src/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
+++ b/src/PyMca5/PyMcaGui/io/hdf5/QNexusWidget.py
@@ -509,7 +509,8 @@ class QNexusWidget(qt.QWidget):
             phynxFile  = HDF5Widget.h5open(filename)
 
         info = self.getInfo(phynxFile, name)
-        nxclass = phynxFile[name].attrs.get("NX_class")
+        # nxclass = phynxFile[name].attrs.get("NX_class")
+        nxclass = phynxFile[name].file[phynxFile[name].name.split("/")[1]].attrs.get("NX_class")
         widget = NexusInfo.NexusInfoWidget(nxclass=nxclass)
         widget.notifyCloseEventToWidget(self)
         title = os.path.basename(filename)


### PR DESCRIPTION
fixing "motors" when dataset is attached to external file. Also show motors when "show information" for a child (subgroups and datasets).